### PR TITLE
Big modification of the global structure.

### DIFF
--- a/makefile
+++ b/makefile
@@ -41,7 +41,7 @@ SRC = 		./src/core/core.cpp \
 		./src/ir/push.cpp \
 		./src/snapshotEngine/snapshotEngine.cpp \
 		./src/solverEngine/solverEngine.cpp \
-		./src/solverEngine/utils.cpp \
+		./src/solverEngine/smt2lib_utils.cpp \
 		./src/symbolicEngine/symbolicElement.cpp \
 		./src/symbolicEngine/symbolicEngine.cpp \
 		./src/taintEngine/taintEngine.cpp \

--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -9,17 +9,36 @@ VOID Image(IMG img, VOID *v)
   RTN unlockRTN = RTN_FindByName(img, KnobStartAnalysis.Value().c_str());
   RTN taintParamsRTN = RTN_FindByName(img, "check"); /* TODO: generique */
 
+
   if (RTN_Valid(unlockRTN)){
     RTN_Open(unlockRTN);
-    RTN_InsertCall(unlockRTN, IPOINT_BEFORE, (AFUNPTR)unlockAnalysis, IARG_END);
-    RTN_InsertCall(unlockRTN, IPOINT_AFTER, (AFUNPTR)lockAnalysis, IARG_END);
+    RTN_InsertCall(unlockRTN,
+                   IPOINT_BEFORE,
+                   (AFUNPTR)unlockAnalysis,
+                   IARG_PTR,
+                   &_analysisStatus,
+                   IARG_END);
+
+    RTN_InsertCall(unlockRTN,
+                   IPOINT_AFTER,
+                   (AFUNPTR)lockAnalysis,
+                   IARG_PTR,
+                   &_analysisStatus,
+                   IARG_END);
+
     RTN_Close(unlockRTN);
   }
 
   if (RTN_Valid(taintParamsRTN)){
     RTN_Open(taintParamsRTN);
-    RTN_InsertCall(taintParamsRTN, IPOINT_BEFORE, (AFUNPTR)taintParams, IARG_CONTEXT, IARG_END);
+    RTN_InsertCall(taintParamsRTN,
+                   IPOINT_BEFORE,
+                   (AFUNPTR)taintParams,
+                   IARG_CONTEXT,
+                   IARG_PTR,
+                   taintEngine,
+                   IARG_END);
     RTN_Close(taintParamsRTN);
-  } 
+  }
 }
 

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -1,108 +1,108 @@
 
 #include "pin.H"
-#include "Triton.h"
 
-
+#include "registers.h"
+#include "utils.h"
 
 UINT64 translatePinRegToID(REG reg)
 {
   switch(reg){
-    case REG_RAX:  
-    case REG_EAX:  
-    case REG_AX:   
-    case REG_AH:   
-    case REG_AL:  
-         return ID_RAX;  
+    case REG_RAX:
+    case REG_EAX:
+    case REG_AX:
+    case REG_AH:
+    case REG_AL:
+         return ID_RAX;
 
-    case REG_RBX:  
-    case REG_EBX:  
-    case REG_BX:   
-    case REG_BH:   
-    case REG_BL:   
-         return ID_RBX;  
+    case REG_RBX:
+    case REG_EBX:
+    case REG_BX:
+    case REG_BH:
+    case REG_BL:
+         return ID_RBX;
 
-    case REG_RCX:  
-    case REG_ECX:  
-    case REG_CX:   
-    case REG_CH:   
-    case REG_CL:   
-         return ID_RCX;  
+    case REG_RCX:
+    case REG_ECX:
+    case REG_CX:
+    case REG_CH:
+    case REG_CL:
+         return ID_RCX;
 
-    case REG_RDX:  
-    case REG_EDX:  
-    case REG_DX:   
-    case REG_DH:   
-    case REG_DL:   
-         return ID_RDX;  
+    case REG_RDX:
+    case REG_EDX:
+    case REG_DX:
+    case REG_DH:
+    case REG_DL:
+         return ID_RDX;
 
-    case REG_RDI:  
-    case REG_EDI:  
-    case REG_DI:   
-    case REG_DIL:  
-         return ID_RDI;  
+    case REG_RDI:
+    case REG_EDI:
+    case REG_DI:
+    case REG_DIL:
+         return ID_RDI;
 
-    case REG_RSI:  
-    case REG_ESI:  
-    case REG_SI:   
-    case REG_SIL:  
-         return ID_RSI;  
+    case REG_RSI:
+    case REG_ESI:
+    case REG_SI:
+    case REG_SIL:
+         return ID_RSI;
 
-    case REG_RBP:  
-    case REG_EBP:  
-    case REG_BP:   
+    case REG_RBP:
+    case REG_EBP:
+    case REG_BP:
          return ID_RBP;
 
-    case REG_RSP:  
-    case REG_ESP:  
-    case REG_SP:   
+    case REG_RSP:
+    case REG_ESP:
+    case REG_SP:
          return ID_RSP;
 
-    case REG_R8:  
-    case REG_R8D:  
-    case REG_R8W:  
-    case REG_R8B:   
+    case REG_R8:
+    case REG_R8D:
+    case REG_R8W:
+    case REG_R8B:
          return ID_R8;
 
-    case REG_R9:  
-    case REG_R9D:  
-    case REG_R9W:  
-    case REG_R9B:   
+    case REG_R9:
+    case REG_R9D:
+    case REG_R9W:
+    case REG_R9B:
          return ID_R9;
 
-    case REG_R10:  
-    case REG_R10D:  
-    case REG_R10W:  
-    case REG_R10B:   
+    case REG_R10:
+    case REG_R10D:
+    case REG_R10W:
+    case REG_R10B:
          return ID_R10;
 
-    case REG_R11:  
-    case REG_R11D:  
-    case REG_R11W:  
-    case REG_R11B:   
+    case REG_R11:
+    case REG_R11D:
+    case REG_R11W:
+    case REG_R11B:
          return ID_R11;
 
-    case REG_R12:  
-    case REG_R12D:  
-    case REG_R12W:  
-    case REG_R12B:   
+    case REG_R12:
+    case REG_R12D:
+    case REG_R12W:
+    case REG_R12B:
          return ID_R12;
 
-    case REG_R13:  
-    case REG_R13D:  
-    case REG_R13W:  
-    case REG_R13B:   
+    case REG_R13:
+    case REG_R13D:
+    case REG_R13W:
+    case REG_R13B:
          return ID_R13;
 
-    case REG_R14:  
-    case REG_R14D:  
-    case REG_R14W:  
-    case REG_R14B:   
+    case REG_R14:
+    case REG_R14D:
+    case REG_R14W:
+    case REG_R14B:
          return ID_R14;
 
-    case REG_R15:  
-    case REG_R15D:  
-    case REG_R15W:  
-    case REG_R15B:   
+    case REG_R15:
+    case REG_R15D:
+    case REG_R15W:
+    case REG_R15B:
          return ID_R15;
 
     default:
@@ -114,102 +114,102 @@ UINT64 translatePinRegToID(REG reg)
 REG getHighReg(REG reg)
 {
   switch(reg){
-    case REG_RAX:  
-    case REG_EAX:  
-    case REG_AX:   
-    case REG_AH:   
-    case REG_AL:  
+    case REG_RAX:
+    case REG_EAX:
+    case REG_AX:
+    case REG_AH:
+    case REG_AL:
          return REG_RAX;
 
-    case REG_RBX:  
-    case REG_EBX:  
-    case REG_BX:   
-    case REG_BH:   
-    case REG_BL:   
+    case REG_RBX:
+    case REG_EBX:
+    case REG_BX:
+    case REG_BH:
+    case REG_BL:
          return REG_RBX;
 
-    case REG_RCX:  
-    case REG_ECX:  
-    case REG_CX:   
-    case REG_CH:   
-    case REG_CL:   
+    case REG_RCX:
+    case REG_ECX:
+    case REG_CX:
+    case REG_CH:
+    case REG_CL:
          return REG_RCX;
 
-    case REG_RDX:  
-    case REG_EDX:  
-    case REG_DX:   
-    case REG_DH:   
-    case REG_DL:   
+    case REG_RDX:
+    case REG_EDX:
+    case REG_DX:
+    case REG_DH:
+    case REG_DL:
          return REG_RDX;
 
-    case REG_RDI:  
-    case REG_EDI:  
-    case REG_DI:   
-    case REG_DIL:  
+    case REG_RDI:
+    case REG_EDI:
+    case REG_DI:
+    case REG_DIL:
          return REG_RDI;
 
-    case REG_RSI:  
-    case REG_ESI:  
-    case REG_SI:   
-    case REG_SIL:  
+    case REG_RSI:
+    case REG_ESI:
+    case REG_SI:
+    case REG_SIL:
          return REG_RSI;
 
-    case REG_RBP:  
-    case REG_EBP:  
-    case REG_BP:   
+    case REG_RBP:
+    case REG_EBP:
+    case REG_BP:
          return REG_RBP;
 
-    case REG_RSP:  
-    case REG_ESP:  
-    case REG_SP:   
+    case REG_RSP:
+    case REG_ESP:
+    case REG_SP:
          return REG_RSP;
 
-    case REG_R8:  
-    case REG_R8D:  
-    case REG_R8W:  
-    case REG_R8B:   
+    case REG_R8:
+    case REG_R8D:
+    case REG_R8W:
+    case REG_R8B:
          return REG_R8;
 
-    case REG_R9:  
-    case REG_R9D:  
-    case REG_R9W:  
-    case REG_R9B:   
+    case REG_R9:
+    case REG_R9D:
+    case REG_R9W:
+    case REG_R9B:
          return REG_R9;
 
-    case REG_R10:  
-    case REG_R10D:  
-    case REG_R10W:  
-    case REG_R10B:   
+    case REG_R10:
+    case REG_R10D:
+    case REG_R10W:
+    case REG_R10B:
          return REG_R10;
 
-    case REG_R11:  
-    case REG_R11D:  
-    case REG_R11W:  
-    case REG_R11B:   
+    case REG_R11:
+    case REG_R11D:
+    case REG_R11W:
+    case REG_R11B:
          return REG_R11;
 
-    case REG_R12:  
-    case REG_R12D:  
-    case REG_R12W:  
-    case REG_R12B:   
+    case REG_R12:
+    case REG_R12D:
+    case REG_R12W:
+    case REG_R12B:
          return REG_R12;
 
-    case REG_R13:  
-    case REG_R13D:  
-    case REG_R13W:  
-    case REG_R13B:   
+    case REG_R13:
+    case REG_R13D:
+    case REG_R13W:
+    case REG_R13B:
          return REG_R13;
 
-    case REG_R14:  
-    case REG_R14D:  
-    case REG_R14W:  
-    case REG_R14B:   
+    case REG_R14:
+    case REG_R14D:
+    case REG_R14W:
+    case REG_R14B:
          return REG_R14;
 
-    case REG_R15:  
-    case REG_R15D:  
-    case REG_R15W:  
-    case REG_R15B:   
+    case REG_R15:
+    case REG_R15D:
+    case REG_R15W:
+    case REG_R15B:
          return REG_R15;
 
     default:
@@ -218,21 +218,21 @@ REG getHighReg(REG reg)
 }
 
 
-VOID unlockAnalysis(void)
+VOID unlockAnalysis(UINT32 *analysisStatus)
 {
-  _analysisStatus = UNLOCKED;
+  *analysisStatus = UNLOCKED;
   std::cout << "[Start analysis]" << std::endl;
 }
 
 
-VOID lockAnalysis(void)
+VOID lockAnalysis(UINT32 *analysisStatus)
 {
-  _analysisStatus = LOCKED;
+  *analysisStatus = LOCKED;
   std::cout << "[Stop analysis]" << std::endl;
 }
 
 
-VOID taintParams(CONTEXT *ctx)
+VOID taintParams(CONTEXT *ctx, TaintEngine *taintEngine)
 {
   UINT64  i;
   ADDRINT rdi = PIN_GetContextReg(ctx, REG_RDI);

--- a/src/includes/SnapshotEngine.h
+++ b/src/includes/SnapshotEngine.h
@@ -2,12 +2,14 @@
 #ifndef   __SNAPSHOTENGINE_H__
 #define   __SNAPSHOTENGINE_H__
 
+#include <list>
+
 #include "pin.H"
 
 
 class SnapshotEngine{
- 
-  private: 
+
+  private:
     /* I/O memory monitoring for snapshot */
     /* item1: memory address              */
     /* item2: byte                        */

--- a/src/includes/SolverEngine.h
+++ b/src/includes/SolverEngine.h
@@ -2,16 +2,14 @@
 #ifndef   __SOLVERENGINE_H__
 #define   __SOLVERENGINE_H__
 
+#include <cstdlib>
+#include <stdint.h>
+#include <string>
+
 #include <z3++.h>
 
-#include "pin.H"
-#include "Triton.h"
+#include "registers.h"
 #include "SymbolicEngine.h"
-
-/* decl */
-std::string     smt2lib_bv(UINT64 value, UINT64 size);
-std::string     smt2lib_declare(UINT64 idSymVar, UINT64 BitVecSize);
-std::string     smt2lib_extract(UINT64 regSize);
 
 
 class SolverEngine
@@ -23,8 +21,8 @@ class SolverEngine
     z3::context         *ctx;
 
   public:
-    VOID                solveFromID(UINT64 id);
-    VOID                displayModel();
+    void                solveFromID(uint64_t id);
+    void                displayModel();
     z3::model           getModel();
     std::string         getFormula();
 

--- a/src/includes/SymbolicEngine.h
+++ b/src/includes/SymbolicEngine.h
@@ -2,8 +2,13 @@
 #ifndef   __SYMBOLICENGINE_H__
 #define   __SYMBOLICENGINE_H__
 
-#include "pin.H"
+#include <list>
+#include <sstream>
+#include <stdint.h>
+#include <string>
+#include <utility>
 
+#include "smt2lib_utils.h"
 
 
 /* Symbolic element */
@@ -13,16 +18,16 @@ class symbolicElement {
     std::stringstream   *source;
     std::stringstream   *destination;
     std::stringstream   *expression;
-    UINT64              id;
+    uint64_t              id;
 
 
   public:
-    UINT32        isTainted;
+    uint32_t      isTainted;
     std::string   getExpression();
     std::string   getSource();
-    UINT64        getID();
+    uint64_t      getID();
 
-    symbolicElement(std::stringstream &dst, std::stringstream &src, UINT64 id);
+    symbolicElement(std::stringstream &dst, std::stringstream &src, uint64_t id);
     ~symbolicElement();
 
 };
@@ -33,24 +38,24 @@ class SymbolicEngine {
   private:
 
     /* symbolic expression ID */
-    UINT64 uniqueID;
+    uint64_t uniqueID;
 
     /* Number of symbolic variables used */
-    UINT64 numberOfSymVar;
+    uint64_t numberOfSymVar;
 
-    /* 
-     * Addresses <-> symbolic expression 
+    /*
+     * Addresses <-> symbolic expression
      * item1: memory address
      * item2: reference ID
      */
-    std::list< std::pair<UINT64, UINT64> > memoryReference;
+    std::list< std::pair<uint64_t, uint64_t> > memoryReference;
 
     /*
      * Addresses <-> Z3 Symbolic Variable
      * item1: memory address
      * item2: symbolic variable ID
      */
-    std::list< std::pair<UINT64, UINT64> > symVarMemoryReference;
+    std::list< std::pair<uint64_t, uint64_t> > symVarMemoryReference;
 
     /* List of variables decl in smt2lib */
     std::list<std::string> smt2libVarDeclList;
@@ -62,16 +67,16 @@ class SymbolicEngine {
   public:
 
     /* Symbolic trace */
-    UINT64 symbolicReg[25];
+    uint64_t symbolicReg[25];
 
-    INT32               isMemoryReference(UINT64 addr);
-    UINT64              getUniqueID();
-    UINT64              getUniqueSymVarID();
-    VOID                addMemoryReference(UINT64 mem, UINT64 id);
-    VOID                addSmt2LibVarDecl(UINT64 symVarID, UINT64 readSize);
-    VOID                addSymVarMemoryReference(UINT64 mem, UINT64 symVarID);
-    VOID                setSymbolicReg(UINT64 reg, UINT64 referenceID);
-    symbolicElement     *getElementFromId(UINT64 id);
+    int32_t               isMemoryReference(uint64_t addr);
+    uint64_t              getUniqueID();
+    uint64_t              getUniqueSymVarID();
+    void                addMemoryReference(uint64_t mem, uint64_t id);
+    void                addSmt2LibVarDecl(uint64_t symVarID, uint64_t readSize);
+    void                addSymVarMemoryReference(uint64_t mem, uint64_t symVarID);
+    void                setSymbolicReg(uint64_t reg, uint64_t referenceID);
+    symbolicElement     *getElementFromId(uint64_t id);
     std::string         getSmt2LibVarsDecl();
     symbolicElement     *newSymbolicElement(std::stringstream &src);
 

--- a/src/includes/TaintEngine.h
+++ b/src/includes/TaintEngine.h
@@ -2,8 +2,12 @@
 #ifndef   __TAINTENGINE_H__
 #define   __TAINTENGINE_H__
 
-#include "pin.H"
-#include "Triton.h"
+#include <list>
+#include <sstream>
+#include <stdint.h>
+
+
+#define TAINTED       1
 
 
 class TaintEngine {
@@ -11,23 +15,23 @@ class TaintEngine {
   private:
 
     /* Tainted addresses */
-    std::list<UINT64> taintedAddresses;
+    std::list<uint64_t> taintedAddresses;
 
     /* Tainted registers */
-    UINT64 taintedReg[16]; 
+    uint64_t taintedReg[16];
 
 
   public:
     TaintEngine();
     ~TaintEngine();
 
-    UINT64    getRegStatus(UINT64 regID);
-    VOID      addAddress(UINT64 addr);
-    VOID      removeAddress(UINT64 addr);
-    VOID      taintReg(UINT64 regID);
-    VOID      untaintReg(UINT64 regID);
-    bool      isMemoryTainted(UINT64 addr);
-    bool      isRegTainted(UINT64 regID);
+    uint64_t   getRegStatus(uint64_t regID);
+    void       addAddress(uint64_t addr);
+    void       removeAddress(uint64_t addr);
+    void       taintReg(uint64_t regID);
+    void       untaintReg(uint64_t regID);
+    bool       isMemoryTainted(uint64_t addr);
+    bool       isRegTainted(uint64_t regID);
 
 };
 

--- a/src/includes/Triton.h
+++ b/src/includes/Triton.h
@@ -21,36 +21,8 @@
 #include "SolverEngine.h"
 #include "SymbolicEngine.h"
 #include "TaintEngine.h"
-
-#define LOCKED        1
-#define UNLOCKED      !LOCKED
-#define TAINTED       1
-
-#define ID_RAX        0
-#define ID_RBX        1
-#define ID_RCX        2
-#define ID_RDX        3
-#define ID_RDI        4
-#define ID_RSI        5
-#define ID_RBP        6
-#define ID_RSP        7
-#define ID_R8         8
-#define ID_R9         9
-#define ID_R10        10
-#define ID_R11        11
-#define ID_R12        12
-#define ID_R13        13
-#define ID_R14        14
-#define ID_R15        15
-#define ID_CF         16
-#define ID_PF         17
-#define ID_AF         18
-#define ID_ZF         19
-#define ID_SF         20
-#define ID_TF         21
-#define ID_IF         22
-#define ID_DF         23
-#define ID_OF         24
+#include "registers.h"
+#include "utils.h"
 
 
 /* Extern decl */
@@ -64,18 +36,14 @@ extern boost::format            outputInstruction;
 
 
 /* decl */
-REG             getHighReg(REG reg);
-UINT64          derefMem(UINT64 mem, UINT64 readSize);
-UINT64          translatePinRegToID(REG reg);
-VOID            Image(IMG img, VOID *v);
 VOID            Instruction(INS ins, VOID *v);
+VOID            Image(IMG img, VOID *v);
 VOID            addRegImm(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, REG reg1, UINT64 imm);
 VOID            addRegReg(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, REG reg1, REG reg2);
 VOID            branchs(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, UINT32 opcode);
 VOID            cmpMemImm(std::string insDis, ADDRINT insAddr, UINT64 imm, UINT64 mem, UINT32 readSize);
 VOID            cmpRegImm(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, REG reg1, UINT64 imm);
 VOID            cmpRegReg(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, REG reg1, REG reg2);
-VOID            lockAnalysis(void);
 VOID            movMemImm(std::string insDis, ADDRINT insAddr, UINT64 imm, UINT64 mem, UINT32 writeSize, INT32 opcode);
 VOID            movMemReg(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, REG reg1, UINT64 mem, UINT32 writeSize, INT32 opcode);
 VOID            movRegImm(std::string insDis, ADDRINT insAddr, REG reg1, UINT64 imm, INT32 opcode);
@@ -85,8 +53,6 @@ VOID            notImplemented(std::string insDis, ADDRINT insAddr);
 VOID            popReg(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, REG reg1, UINT64 mem, UINT32 readSize);
 VOID            pushImm(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, UINT64 imm, UINT64 mem, UINT32 writeSize);
 VOID            pushReg(std::string insDis, ADDRINT insAddr, CONTEXT *ctx, REG reg1, UINT64 mem, UINT32 writeSize);
-VOID            taintParams(CONTEXT *ctx);
-VOID            unlockAnalysis(void);
 
 
 VOID displayTrace(ADDRINT addr, const std::string &insDis, const std::string &expr, UINT64 isTainted);

--- a/src/includes/registers.h
+++ b/src/includes/registers.h
@@ -1,0 +1,30 @@
+#ifndef  __REGISTERS_H__
+#define  __REGISTERS_H__
+
+#define ID_RAX        0
+#define ID_RBX        1
+#define ID_RCX        2
+#define ID_RDX        3
+#define ID_RDI        4
+#define ID_RSI        5
+#define ID_RBP        6
+#define ID_RSP        7
+#define ID_R8         8
+#define ID_R9         9
+#define ID_R10        10
+#define ID_R11        11
+#define ID_R12        12
+#define ID_R13        13
+#define ID_R14        14
+#define ID_R15        15
+#define ID_CF         16
+#define ID_PF         17
+#define ID_AF         18
+#define ID_ZF         19
+#define ID_SF         20
+#define ID_TF         21
+#define ID_IF         22
+#define ID_DF         23
+#define ID_OF         24
+
+#endif /* __REGISTERS_H__ */

--- a/src/includes/smt2lib_utils.h
+++ b/src/includes/smt2lib_utils.h
@@ -1,0 +1,14 @@
+
+#ifndef  __SMT2LIB_UTILS__
+#define  __SMT2LIB_UTILS__
+
+#include <sstream>
+#include <stdint.h>
+#include <string>
+
+std::string     smt2lib_bv(uint64_t value, uint64_t size);
+std::string     smt2lib_declare(uint64_t idSymVar, uint64_t BitVecSize);
+std::string     smt2lib_extract(uint64_t regSize);
+
+#endif  /* !__SMTLIB2_UTILS__ */
+

--- a/src/includes/utils.h
+++ b/src/includes/utils.h
@@ -1,0 +1,22 @@
+
+#ifndef __UTILS_H__
+#define __UTILS_H__
+
+#include <iostream>
+
+#include "pin.H"
+
+#include "TaintEngine.h"
+
+#define LOCKED        1
+#define UNLOCKED      !LOCKED
+
+
+UINT64 translatePinRegToID(REG reg);
+REG getHighReg(REG reg);
+VOID unlockAnalysis(UINT32 *analysisStatus);
+VOID lockAnalysis(UINT32 *analysisStatus);
+VOID taintParams(CONTEXT *ctx, TaintEngine *taintEngine);
+UINT64 derefMem(UINT64 mem, UINT64 readSize);
+
+#endif /* !__UTILS_H__ */

--- a/src/snapshotEngine/snapshotEngine.cpp
+++ b/src/snapshotEngine/snapshotEngine.cpp
@@ -1,8 +1,5 @@
 
-
-#include "pin.H"
-#include "Triton.h"
-
+#include "SnapshotEngine.h"
 
 
 SnapshotEngine::SnapshotEngine()

--- a/src/solverEngine/smt2lib_utils.cpp
+++ b/src/solverEngine/smt2lib_utils.cpp
@@ -1,9 +1,8 @@
 
-#include "pin.H"
-#include "Triton.h"
+#include "smt2lib_utils.h"
 
 
-std::string smt2lib_bv(UINT64 value, UINT64 size)
+std::string smt2lib_bv(uint64_t value, uint64_t size)
 {
   std::stringstream stream;
 
@@ -21,12 +20,12 @@ std::string smt2lib_bv(UINT64 value, UINT64 size)
       stream << "(_ bv" << std::dec << value << " 64)";
       break;
   }
-  
+
   return stream.str();
 }
 
 
-std::string smt2lib_extract(UINT64 regSize)
+std::string smt2lib_extract(uint64_t regSize)
 {
   std::stringstream stream;
 
@@ -44,12 +43,12 @@ std::string smt2lib_extract(UINT64 regSize)
       stream << "(_ extract 63 0)";
       break;
   }
-  
+
   return stream.str();
 }
 
 
-std::string smt2lib_declare(UINT64 idSymVar, UINT64 BitVecSize)
+std::string smt2lib_declare(uint64_t idSymVar, uint64_t BitVecSize)
 {
   std::stringstream stream;
 

--- a/src/solverEngine/solverEngine.cpp
+++ b/src/solverEngine/solverEngine.cpp
@@ -1,6 +1,5 @@
 
-#include "pin.H"
-#include "Triton.h"
+#include "SolverEngine.h"
 
 
 static std::string replaceEq(std::string str, const std::string from, const std::string to)
@@ -13,7 +12,7 @@ static std::string replaceEq(std::string str, const std::string from, const std:
 }
 
 
-static std::string formulaReconstruction(UINT64 id)
+static std::string formulaReconstruction(SymbolicEngine *symbolicEngine, uint64_t id)
 {
   int value;
   std::size_t found;
@@ -36,7 +35,7 @@ static std::string formulaReconstruction(UINT64 id)
 
     formula.str(replaceEq(formula.str(), from.str(), to.str()));
   }
-  
+
   return formula.str();
 }
 
@@ -52,11 +51,11 @@ SolverEngine::~SolverEngine()
 }
 
 
-VOID SolverEngine::solveFromID(UINT64 id)
+void SolverEngine::solveFromID(uint64_t id)
 {
   std::stringstream formula;
 
-  formula.str(formulaReconstruction(symEngine->symbolicReg[ID_ZF]));
+  formula.str(formulaReconstruction(symEngine, this->symEngine->symbolicReg[ID_ZF]));
 
   this->formula << "(set-logic QF_AUFBV)";
   this->formula << this->symEngine->getSmt2LibVarsDecl();
@@ -72,7 +71,7 @@ VOID SolverEngine::solveFromID(UINT64 id)
 }
 
 
-VOID SolverEngine::displayModel()
+void SolverEngine::displayModel()
 {
   z3::model m = this->solver->get_model();
   std::cout << "----- Model -----" << std::endl << m << std::endl << "-----------------" << std::endl;

--- a/src/symbolicEngine/symbolicElement.cpp
+++ b/src/symbolicEngine/symbolicElement.cpp
@@ -1,10 +1,9 @@
 
-#include "pin.H"
-#include "Triton.h"
+#include "TaintEngine.h"
+#include "SymbolicEngine.h"
 
 
-
-symbolicElement::symbolicElement(std::stringstream &dst, std::stringstream &src, UINT64 id)
+symbolicElement::symbolicElement(std::stringstream &dst, std::stringstream &src, uint64_t id)
 {
   this->isTainted   = !TAINTED;
   this->source      = new std::stringstream(src.str());
@@ -12,7 +11,7 @@ symbolicElement::symbolicElement(std::stringstream &dst, std::stringstream &src,
   this->expression  = new std::stringstream();
 
   *this->expression << (*this->destination).str() << " = " << (*this->source).str();
-  
+
   this->id = id;
 }
 
@@ -37,7 +36,7 @@ std::string symbolicElement::getSource()
 }
 
 
-UINT64 symbolicElement::getID()
+uint64_t symbolicElement::getID()
 {
   return this->id;
 }

--- a/src/symbolicEngine/symbolicEngine.cpp
+++ b/src/symbolicEngine/symbolicEngine.cpp
@@ -1,36 +1,34 @@
 
-#include "pin.H"
-#include "Triton.h"
-
+#include "SymbolicEngine.h"
 
 
 SymbolicEngine::SymbolicEngine()
 {
- this->symbolicReg[0]  = (UINT64)-1; /* ID_RAX   */
- this->symbolicReg[1]  = (UINT64)-1; /* ID_RBX   */
- this->symbolicReg[2]  = (UINT64)-1; /* ID_RCX   */
- this->symbolicReg[3]  = (UINT64)-1; /* ID_RDX   */
- this->symbolicReg[4]  = (UINT64)-1; /* ID_RDI   */
- this->symbolicReg[5]  = (UINT64)-1; /* ID_RSI   */
- this->symbolicReg[6]  = (UINT64)-1; /* ID_RBP   */
- this->symbolicReg[7]  = (UINT64)-1; /* ID_RSP   */
- this->symbolicReg[8]  = (UINT64)-1; /* ID_R8    */
- this->symbolicReg[9]  = (UINT64)-1; /* ID_R9    */
- this->symbolicReg[10] = (UINT64)-1; /* ID_R10   */
- this->symbolicReg[11] = (UINT64)-1; /* ID_R11   */
- this->symbolicReg[12] = (UINT64)-1; /* ID_R12   */
- this->symbolicReg[13] = (UINT64)-1; /* ID_R13   */
- this->symbolicReg[14] = (UINT64)-1; /* ID_R14   */
- this->symbolicReg[15] = (UINT64)-1; /* ID_R15   */
- this->symbolicReg[16] = (UINT64)-1; /* ID_CF    */
- this->symbolicReg[17] = (UINT64)-1; /* ID_PF    */
- this->symbolicReg[18] = (UINT64)-1; /* ID_AF    */
- this->symbolicReg[19] = (UINT64)-1; /* ID_ZF    */
- this->symbolicReg[20] = (UINT64)-1; /* ID_SF    */
- this->symbolicReg[21] = (UINT64)-1; /* ID_TF    */
- this->symbolicReg[22] = (UINT64)-1; /* ID_IF    */
- this->symbolicReg[23] = (UINT64)-1; /* ID_DF    */
- this->symbolicReg[24] = (UINT64)-1; /* ID_OF    */
+ this->symbolicReg[0]  = (uint64_t)-1; /* ID_RAX   */
+ this->symbolicReg[1]  = (uint64_t)-1; /* ID_RBX   */
+ this->symbolicReg[2]  = (uint64_t)-1; /* ID_RCX   */
+ this->symbolicReg[3]  = (uint64_t)-1; /* ID_RDX   */
+ this->symbolicReg[4]  = (uint64_t)-1; /* ID_RDI   */
+ this->symbolicReg[5]  = (uint64_t)-1; /* ID_RSI   */
+ this->symbolicReg[6]  = (uint64_t)-1; /* ID_RBP   */
+ this->symbolicReg[7]  = (uint64_t)-1; /* ID_RSP   */
+ this->symbolicReg[8]  = (uint64_t)-1; /* ID_R8    */
+ this->symbolicReg[9]  = (uint64_t)-1; /* ID_R9    */
+ this->symbolicReg[10] = (uint64_t)-1; /* ID_R10   */
+ this->symbolicReg[11] = (uint64_t)-1; /* ID_R11   */
+ this->symbolicReg[12] = (uint64_t)-1; /* ID_R12   */
+ this->symbolicReg[13] = (uint64_t)-1; /* ID_R13   */
+ this->symbolicReg[14] = (uint64_t)-1; /* ID_R14   */
+ this->symbolicReg[15] = (uint64_t)-1; /* ID_R15   */
+ this->symbolicReg[16] = (uint64_t)-1; /* ID_CF    */
+ this->symbolicReg[17] = (uint64_t)-1; /* ID_PF    */
+ this->symbolicReg[18] = (uint64_t)-1; /* ID_AF    */
+ this->symbolicReg[19] = (uint64_t)-1; /* ID_ZF    */
+ this->symbolicReg[20] = (uint64_t)-1; /* ID_SF    */
+ this->symbolicReg[21] = (uint64_t)-1; /* ID_TF    */
+ this->symbolicReg[22] = (uint64_t)-1; /* ID_IF    */
+ this->symbolicReg[23] = (uint64_t)-1; /* ID_DF    */
+ this->symbolicReg[24] = (uint64_t)-1; /* ID_OF    */
 
  this->numberOfSymVar = 0;
 }
@@ -41,9 +39,9 @@ SymbolicEngine::~SymbolicEngine()
 }
 
 
-INT32 SymbolicEngine::isMemoryReference(UINT64 addr)
+int32_t SymbolicEngine::isMemoryReference(uint64_t addr)
 {
-  std::list< std::pair<UINT64, UINT64> >::iterator i;
+  std::list< std::pair<uint64_t, uint64_t> >::iterator i;
 
   for(i = this->memoryReference.begin(); i != this->memoryReference.end(); i++){
     if (i->first == addr)
@@ -53,7 +51,7 @@ INT32 SymbolicEngine::isMemoryReference(UINT64 addr)
 }
 
 
-UINT64 SymbolicEngine::getUniqueID()
+uint64_t SymbolicEngine::getUniqueID()
 {
   return this->uniqueID++;
 }
@@ -62,8 +60,8 @@ UINT64 SymbolicEngine::getUniqueID()
 symbolicElement *SymbolicEngine::newSymbolicElement(std::stringstream &src)
 {
   std::stringstream dst;
-  UINT64            id;
-  
+  uint64_t          id;
+
   id = this->getUniqueID();
 
   dst << "#" << std::dec << id;
@@ -76,13 +74,13 @@ symbolicElement *SymbolicEngine::newSymbolicElement(std::stringstream &src)
 }
 
 
-VOID SymbolicEngine::setSymbolicReg(UINT64 reg, UINT64 referenceID)
+void SymbolicEngine::setSymbolicReg(uint64_t reg, uint64_t referenceID)
 {
   this->symbolicReg[reg] = referenceID;
 }
 
 
-symbolicElement *SymbolicEngine::getElementFromId(UINT64 id)
+symbolicElement *SymbolicEngine::getElementFromId(uint64_t id)
 {
   std::list<symbolicElement *>::iterator i;
 
@@ -105,25 +103,25 @@ std::string SymbolicEngine::getSmt2LibVarsDecl()
 }
 
 
-UINT64 SymbolicEngine::getUniqueSymVarID()
+uint64_t SymbolicEngine::getUniqueSymVarID()
 {
   return this->numberOfSymVar++;
 }
 
 
-VOID SymbolicEngine::addSymVarMemoryReference(UINT64 mem, UINT64 symVarID)
+void SymbolicEngine::addSymVarMemoryReference(uint64_t mem, uint64_t symVarID)
 {
-  this->symVarMemoryReference.push_front(make_pair(mem, symVarID));
+  this->symVarMemoryReference.push_front(std::make_pair(mem, symVarID));
 }
 
 
-VOID SymbolicEngine::addSmt2LibVarDecl(UINT64 symVarID, UINT64 readSize)
+void SymbolicEngine::addSmt2LibVarDecl(uint64_t symVarID, uint64_t readSize)
 {
   this->smt2libVarDeclList.push_front(smt2lib_declare(symVarID, readSize));
 }
 
-VOID SymbolicEngine::addMemoryReference(UINT64 mem, UINT64 id)
+void SymbolicEngine::addMemoryReference(uint64_t mem, uint64_t id)
 {
-  this->memoryReference.push_front(make_pair(mem, id));
+  this->memoryReference.push_front(std::make_pair(mem, id));
 }
 

--- a/src/taintEngine/taintEngine.cpp
+++ b/src/taintEngine/taintEngine.cpp
@@ -1,26 +1,24 @@
 
-#include "pin.H"
-#include "Triton.h"
-
+#include "TaintEngine.h"
 
 TaintEngine::TaintEngine(){
 
-  this->taintedReg[0]  = (UINT64)0; /* ID_RAX */
-  this->taintedReg[1]  = (UINT64)0; /* ID_RBX */
-  this->taintedReg[2]  = (UINT64)0; /* ID_RCX */
-  this->taintedReg[3]  = (UINT64)0; /* ID_RDX */
-  this->taintedReg[4]  = (UINT64)0; /* ID_RDI */
-  this->taintedReg[5]  = (UINT64)0; /* ID_RSI */
-  this->taintedReg[6]  = (UINT64)0; /* ID_RBP */
-  this->taintedReg[7]  = (UINT64)0; /* ID_RSP */
-  this->taintedReg[8]  = (UINT64)0; /* ID_R8  */
-  this->taintedReg[9]  = (UINT64)0; /* ID_R9  */
-  this->taintedReg[10] = (UINT64)0; /* ID_R10 */
-  this->taintedReg[11] = (UINT64)0; /* ID_R11 */
-  this->taintedReg[12] = (UINT64)0; /* ID_R12 */
-  this->taintedReg[13] = (UINT64)0; /* ID_R13 */
-  this->taintedReg[14] = (UINT64)0; /* ID_R14 */
-  this->taintedReg[15] = (UINT64)0; /* ID_R15 */
+  this->taintedReg[0]  = (uint64_t)0; /* ID_RAX */
+  this->taintedReg[1]  = (uint64_t)0; /* ID_RBX */
+  this->taintedReg[2]  = (uint64_t)0; /* ID_RCX */
+  this->taintedReg[3]  = (uint64_t)0; /* ID_RDX */
+  this->taintedReg[4]  = (uint64_t)0; /* ID_RDI */
+  this->taintedReg[5]  = (uint64_t)0; /* ID_RSI */
+  this->taintedReg[6]  = (uint64_t)0; /* ID_RBP */
+  this->taintedReg[7]  = (uint64_t)0; /* ID_RSP */
+  this->taintedReg[8]  = (uint64_t)0; /* ID_R8  */
+  this->taintedReg[9]  = (uint64_t)0; /* ID_R9  */
+  this->taintedReg[10] = (uint64_t)0; /* ID_R10 */
+  this->taintedReg[11] = (uint64_t)0; /* ID_R11 */
+  this->taintedReg[12] = (uint64_t)0; /* ID_R12 */
+  this->taintedReg[13] = (uint64_t)0; /* ID_R13 */
+  this->taintedReg[14] = (uint64_t)0; /* ID_R14 */
+  this->taintedReg[15] = (uint64_t)0; /* ID_R15 */
 
 }
 
@@ -29,9 +27,9 @@ TaintEngine::~TaintEngine(){
 }
 
 
-bool TaintEngine::isMemoryTainted(UINT64 addr)
+bool TaintEngine::isMemoryTainted(uint64_t addr)
 {
-  std::list<UINT64>::iterator i;
+  std::list<uint64_t>::iterator i;
   for(i = this->taintedAddresses.begin(); i != this->taintedAddresses.end(); i++){
     if (addr == *i)
       return true;
@@ -40,7 +38,7 @@ bool TaintEngine::isMemoryTainted(UINT64 addr)
 }
 
 
-bool TaintEngine::isRegTainted(UINT64 regID)
+bool TaintEngine::isRegTainted(uint64_t regID)
 {
   if (this->taintedReg[regID] == TAINTED)
     return true;
@@ -48,30 +46,30 @@ bool TaintEngine::isRegTainted(UINT64 regID)
 }
 
 
-UINT64 TaintEngine::getRegStatus(UINT64 regID)
+uint64_t TaintEngine::getRegStatus(uint64_t regID)
 {
   return this->taintedReg[regID];
 }
 
 
-VOID TaintEngine::taintReg(UINT64 regID)
+void TaintEngine::taintReg(uint64_t regID)
 {
   this->taintedReg[regID] = TAINTED;
 }
 
 
-VOID TaintEngine::untaintReg(UINT64 regID)
+void TaintEngine::untaintReg(uint64_t regID)
 {
   this->taintedReg[regID] = !TAINTED;
 }
 
 
-VOID TaintEngine::addAddress(UINT64 addr)
+void TaintEngine::addAddress(uint64_t addr)
 {
   this->taintedAddresses.push_front(addr);
 }
 
-VOID TaintEngine::removeAddress(UINT64 addr)
+void TaintEngine::removeAddress(uint64_t addr)
 {
   this->taintedAddresses.remove(addr);
 }


### PR DESCRIPTION
The goal was too delete some useless dependences to Triton.h
and pin.H.

The other key idea is too lighten Triton.h, it should contain
only the necessary include and definition/declaration useful in
core.cpp.

How do we achieve these goals ?

For pin.H, it's pretty simple most of the types define by pin.H (UINT64,
ADDRINT, ...) are here only for handle Microsoft and Unix platforms.
Right now, we focus only on Unix so we just need to use define in
stdint.h (uint64_h).

For Triton.h, it's trickier but the solution is ,the most often, to
define some headers or tweak the existing one. And then include this
"new" header in Triton.h.
