### PR TITLE
Issue13

### DIFF
--- a/src/includes/SymbolicEngine.h
+++ b/src/includes/SymbolicEngine.h
@@ -54,7 +54,7 @@ class SymbolicEngine {
     std::map<uint64_t, uint64_t> memoryReference;
 
     /*
-     * Addresses -> Z3 Symbolic Variable
+     * Z3 Symbolic Variable -> Addresses
      * item1: memory address
      * item2: symbolic variable ID
      */
@@ -73,7 +73,7 @@ class SymbolicEngine {
     uint64_t              symbolicReg[25];
 
     /* public methods */
-    uint64_t               isMemoryReference(uint64_t addr);
+    int32_t               isMemoryReference(uint64_t addr);
     std::string           getSmt2LibVarsDecl();
     symbolicElement       *getElementFromId(uint64_t id);
     symbolicElement       *newSymbolicElement(std::stringstream &src);

--- a/src/symbolicEngine/symbolicEngine.cpp
+++ b/src/symbolicEngine/symbolicEngine.cpp
@@ -39,11 +39,19 @@ SymbolicEngine::SymbolicEngine()
 
 SymbolicEngine::~SymbolicEngine()
 {
+  std::vector<symbolicElement *>::iterator it = this->symbolicVector.begin();
+
+  for (; it != this->symbolicVector.end(); ++it) {
+    symbolicElement *tmp = *it;
+    delete tmp;
+    tmp = NULL;
+  }
+
 }
 
 
 /* Returns the reference memory if it's referenced otherwise returns -1 */
-uint64_t SymbolicEngine::isMemoryReference(uint64_t addr)
+int32_t SymbolicEngine::isMemoryReference(uint64_t addr)
 {
   std::map<uint64_t, uint64_t>::iterator it;
   if ((it = this->memoryReference.find(addr)) != this->memoryReference.end())
@@ -105,11 +113,11 @@ uint64_t SymbolicEngine::getUniqueSymVarID()
   return this->numberOfSymVar++;
 }
 
-/* Assigns a memory address to a symbolic variable 
+/* Assigns a memory address to a symbolic variable
  * Mainly used to know where come from a symbolic variable */
 void SymbolicEngine::addSymVarMemoryReference(uint64_t mem, uint64_t symVarID)
 {
-  this->symVarMemoryReference.insert(std::make_pair(mem, symVarID));
+  this->symVarMemoryReference.insert(std::make_pair(symVarID, mem));
 }
 
 /* Add a new symbolic variable */
@@ -121,6 +129,6 @@ void SymbolicEngine::addSmt2LibVarDecl(uint64_t symVarID, uint64_t readSize)
 /* Add and assign a new memory reference */
 void SymbolicEngine::addMemoryReference(uint64_t mem, uint64_t id)
 {
-  this->memoryReference.insert(std::make_pair(mem, id));
+  this->memoryReference[mem] = id;
 }
 


### PR DESCRIPTION
Change the kind of containers used in SymbolicEngine to get better complexity:
- memoryReference : list -> map (O(log(n)) for search)
- symVarMemoryReference: list-> map (O(log(n)) for search)
- symbolicList : list->vector (Renamed) (Constant time for access by ID)

See commit [456ff46](https://github.com/JonathanSalwan/Triton/commit/456ff468839828f9982d210cf42364915b46ed51) for more details.
