### PR TITLE
Attempting to fix warning from clang

### DIFF
--- a/src/contextHandler/PINContextHandler.cpp
+++ b/src/contextHandler/PINContextHandler.cpp
@@ -34,7 +34,7 @@ uint64_t PINContextHandler::getFlagValue(uint64_t TritFlagID) const
   uint64_t rflags;
   REG reg = safecast(PINConverter::convertTritonReg2DBIReg(ID_RFLAGS));
 
-  if (reg == -1 || !REG_valid(reg))
+  if (!REG_valid(reg))
     throw std::runtime_error("Error: getFlagValue() - Invalid PIN register id.");
 
   rflags = PIN_GetContextReg(this->_ctx, reg);
@@ -61,7 +61,7 @@ uint64_t PINContextHandler::getRegisterValue(uint64_t TritRegID) const
 {
   REG reg = safecast(PINConverter::convertTritonReg2DBIReg(TritRegID));
 
-  if (reg == -1 || !REG_valid(reg) || (TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
+  if (!REG_valid(reg) || (TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
     throw std::runtime_error("Error: getRegisterValue() - Invalid PIN register id.");
 
   return PIN_GetContextReg(this->_ctx, reg);
@@ -75,7 +75,7 @@ __uint128_t PINContextHandler::getSSERegisterValue(uint64_t TritRegID) const
   __uint128_t value       = 0;
   PIN_REGISTER tmp;
 
-  if (reg == -1 || !REG_valid(reg) || !(TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
+  if (!REG_valid(reg) || !(TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
     throw std::runtime_error("Error: getSSERegisterValue() - Invalid PIN register id.");
 
   PIN_GetContextRegval(this->_ctx, reg, reinterpret_cast<UINT8 *>(&tmp));
@@ -91,7 +91,7 @@ void PINContextHandler::setRegisterValue(uint64_t TritRegID, uint64_t value) con
 {
   REG reg = safecast(PINConverter::convertTritonReg2DBIReg(TritRegID));
 
-  if (reg == -1 || !REG_valid(reg) || (TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
+  if (!REG_valid(reg) || (TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
     throw std::runtime_error("Error: setRegisterValue() - Invalid PIN register id.");
 
   PIN_SetContextReg(this->_ctx, reg, value);
@@ -108,7 +108,7 @@ void PINContextHandler::setSSERegisterValue(uint64_t TritRegID, __uint128_t valu
   if (tmp == nullptr)
     throw std::runtime_error("Error: setSSERegisterValue() - Not enough memory.");
 
-  if (reg == -1 || !REG_valid(reg) || !(TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
+  if (!REG_valid(reg) || !(TritRegID >= ID_XMM0 && TritRegID <= ID_XMM15))
     throw std::runtime_error("Error: setSSERegisterValue() - Invalid PIN register id.");
 
   *(__uint128_t *)tmp = value;

--- a/src/includes/NullIRBuilder.h
+++ b/src/includes/NullIRBuilder.h
@@ -18,6 +18,7 @@ class NullIRBuilder: public BaseIRBuilder {
     void addOperand(const TritonOperand &operand){
     }
 
+    using BaseIRBuilder::getOperands;
     const std::vector<TritonOperand> &getOperands(void){
       return this->operands;
     }


### PR DESCRIPTION
Because Arch ships with gcc 5.1.0 and causes the following error when building the pin libs:
> ../../../source/include/pin/compiler_version_check2.H:102:2: error: #error The C++ ABI of your compiler does not match the ABI of the pin kit.

I tried to build with clang and hit a few minor errors.  I am unsure about if REG_valid() will correctly error when passed a -1 value.

original error with clang:
> src/contextHandler/PINContextHandler.cpp:37:11: error: comparison of constant -1 with expression of type 'REG' is always false [-Werror,-Wtautological-constant-out-of-range-compare]