### PR TITLE
Get only one syscalls table file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,10 @@ link_directories("${PIN_ROOT}/extras/xed-intel64/lib")
 # This following code tries to find the unistd_64.h header.
 FILE(
     GLOB_RECURSE
-    syscalls_table_file
+    syscalls_table_files
     /usr/include/*unistd_64.h
 )
+LIST(GET syscalls_table_files 0 syscalls_table_file)
 
 # If the unistd_64.h is not found, we exit
 if (NOT EXISTS ${syscalls_table_file})


### PR DESCRIPTION
This should fix #96. Another solution would be to have it just search in the `/usr/include/x86_64-linux-gnu` directory. That would require the installation of 64-bit libc dev headers (whereas now, the 32-bit ones will suffice for this specific check since they also seem to include the 64-bit headers), so I went with this option.