### PR TITLE
Improve getConcreteValue

### DIFF
--- a/examples/inject_model_with_snapshot.py
+++ b/examples/inject_model_with_snapshot.py
@@ -46,6 +46,7 @@ def cafter(instruction):
     # 0x40058b: movzx eax, byte ptr [rax]
     if instruction.address == 0x40058b:
         v = convertRegToSymVar(IDREF.REG.RAX, 32)
+        #print "Concrete value:\t%s\t%c" % (v, v.getConcreteValue())
 
     # 0x4005ae: cmp ecx, eax
     if instruction.address == 0x4005ae:

--- a/src/analysisProcessor/analysisProcessor.cpp
+++ b/src/analysisProcessor/analysisProcessor.cpp
@@ -257,7 +257,6 @@ smt2lib::smtAstAbstractNode *AnalysisProcessor::getFullExpression(smt2lib::smtAs
 SymbolicVariable *AnalysisProcessor::convertExprToSymVar(uint64 exprId, uint64 symVarSize, std::string symVarComment)
 {
   SymbolicVariable *symVar = this->symEngine.convertExprToSymVar(exprId, symVarSize, symVarComment);
-  symVar->setSymVarConcreteValue(SymVar::kind::UNDEF);
   return symVar;
 }
 

--- a/src/includes/SymbolicVariable.h
+++ b/src/includes/SymbolicVariable.h
@@ -32,10 +32,12 @@ class SymbolicVariable {
     uint64        symVarKindValue;
     uint64        symVarSize;
     uint128       symVarConcreteValue;
+    bool          symVarHasConcreteValue;
 
   public:
 
-    SymbolicVariable(SymVar::kind kind, uint64 kindValue, uint64 id, uint64 size, std::string comment, uint128 concreteValue = SymVar::kind::UNDEF);
+    SymbolicVariable(SymVar::kind kind, uint64 kindValue, uint64 id, uint64 size, std::string comment, uint128 concreteValue);
+    SymbolicVariable(SymVar::kind kind, uint64 kindValue, uint64 id, uint64 size, std::string comment);
     SymbolicVariable(const SymbolicVariable &copy);
     ~SymbolicVariable();
 
@@ -46,7 +48,9 @@ class SymbolicVariable {
     uint64        getSymVarKindValue(void);
     uint64        getSymVarSize(void);
     uint128       getConcreteValue(void);
+    bool          hasConcreteValue(void);
     void          setSymVarConcreteValue(uint128 value);
+
 
 };
 

--- a/src/symbolicEngine/symbolicVariable.cpp
+++ b/src/symbolicEngine/symbolicVariable.cpp
@@ -10,25 +10,37 @@ SymbolicVariable::SymbolicVariable(SymVar::kind kind,
                                    std::string comment,
                                    uint128 concreteValue)
 {
-  this->symVarComment       = comment;
-  this->symVarId            = id;
-  this->symVarKind          = kind;
-  this->symVarKindValue     = kindValue;
-  this->symVarName          = SYMVAR_NAME + std::to_string(id);
-  this->symVarSize          = size;
-  this->symVarConcreteValue = concreteValue;
+  this->symVarComment          = comment;
+  this->symVarId               = id;
+  this->symVarKind             = kind;
+  this->symVarKindValue        = kindValue;
+  this->symVarName             = SYMVAR_NAME + std::to_string(id);
+  this->symVarSize             = size;
+  this->symVarConcreteValue    = concreteValue;
+  this->symVarHasConcreteValue = true;
+}
+
+SymbolicVariable::SymbolicVariable(SymVar::kind kind,
+                                   uint64 kindValue,
+                                   uint64 id,
+                                   uint64 size,
+                                   std::string comment
+                                   ) : SymbolicVariable(kind, kindValue, id, size, comment, 0)
+{
+  this->symVarHasConcreteValue = false;
 }
 
 
 SymbolicVariable::SymbolicVariable(const SymbolicVariable &copy)
 {
-  this->symVarComment       = copy.symVarComment;
-  this->symVarId            = copy.symVarId;
-  this->symVarKind          = copy.symVarKind;
-  this->symVarKindValue     = copy.symVarKindValue;
-  this->symVarName          = copy.symVarName;
-  this->symVarSize          = copy.symVarSize;
-  this->symVarConcreteValue = copy.symVarConcreteValue;
+  this->symVarComment          = copy.symVarComment;
+  this->symVarId               = copy.symVarId;
+  this->symVarKind             = copy.symVarKind;
+  this->symVarKindValue        = copy.symVarKindValue;
+  this->symVarName             = copy.symVarName;
+  this->symVarSize             = copy.symVarSize;
+  this->symVarConcreteValue    = copy.symVarConcreteValue;
+  this->symVarHasConcreteValue = copy.symVarHasConcreteValue;
 }
 
 
@@ -75,12 +87,20 @@ std::string SymbolicVariable::getSymVarComment(void)
 
 uint128 SymbolicVariable::getConcreteValue(void)
 {
-  return this->symVarConcreteValue;
+  if (this->symVarHasConcreteValue)
+    return this->symVarConcreteValue;
+  else
+    throw std::runtime_error("SymbolicVariable: The symbolic variable has not a concrete value");
 }
 
+bool SymbolicVariable::hasConcreteValue(void)
+{
+  return this->symVarHasConcreteValue;
+}
 
 void SymbolicVariable::setSymVarConcreteValue(uint128 value)
 {
-  this->symVarConcreteValue = value;
+  this->symVarConcreteValue    = value;
+  this->symVarHasConcreteValue = true;
 }
 


### PR DESCRIPTION
I added
```cpp 
bool hasConcreteValue 
```
to the SymbolicVariable class because some symbolic variables hasn't concrete value and the previous commit didn't deal with this case.