### PR TITLE
Fix #148

### DIFF
--- a/src/bindings/python/modules/tritonCallbacks.cpp
+++ b/src/bindings/python/modules/tritonCallbacks.cpp
@@ -350,12 +350,8 @@ static PyObject *Triton_getMemValue(PyObject *self, PyObject *args)
     return PyErr_Format(PyExc_TypeError, "getMemValue(): The targeted address memory can not be read");
 
   /* If this is a 128-bits read size, we must use uint128ToPyLongObject() */
-  if (rs == DQWORD_SIZE){
-    uint128 value = ap.getMemValue(ad, rs);
-    return uint128ToPyLongObject(value);
-  }
-
-  return Py_BuildValue("k", ap.getMemValue(ad, rs));
+  uint128 value = ap.getMemValue(ad, rs);
+  return uint128ToPyLongObject(value);
 }
 
 
@@ -846,7 +842,7 @@ static PyObject *Triton_setRegValue(PyObject *self, PyObject *args)
   if (tr >= ID_XMM0 && tr <= ID_XMM15)
     ap.setSSERegisterValue(tr, va);
   else
-    ap.setRegisterValue(tr, va);
+    ap.setRegisterValue(tr, boost::numeric_cast<uint64>(va));
 
   Py_INCREF(Py_None);
   return Py_None;

--- a/src/bindings/python/objects/PySmtAstNode.cpp
+++ b/src/bindings/python/objects/PySmtAstNode.cpp
@@ -1,6 +1,7 @@
 
 #include <TritonPyObject.h>
 #include <xPyFunc.h>
+#include <PythonUtils.h>
 
 /*
  * Class SmtAstNode:
@@ -46,7 +47,7 @@ static PyObject *SmtAstNode_getValue(PyObject *self, PyObject *noarg)
   smt2lib::smtAstAbstractNode *node = PySmtAstNode_AsSmtAstNode(self);
 
   if (node->getKind() == smt2lib::DECIMAL_NODE)
-    return Py_BuildValue("k", reinterpret_cast<smt2lib::smtAstDecimalNode *>(node)->getValue());
+    return uint128ToPyLongObject(reinterpret_cast<smt2lib::smtAstDecimalNode *>(node)->getValue());
 
   else if (node->getKind() == smt2lib::STRING_NODE)
     return Py_BuildValue("s", reinterpret_cast<smt2lib::smtAstStringNode *>(node)->getValue().c_str());

--- a/src/contextHandler/PINContextHandler.cpp
+++ b/src/contextHandler/PINContextHandler.cpp
@@ -151,16 +151,16 @@ void PINContextHandler::setMemValue(uint64 mem, uint32 writeSize, uint128 value)
 
   switch(writeSize){
     case BYTE_SIZE:
-      *((char *)mem) = value;
+      *((char *)mem) = boost::numeric_cast<char>(value);
       break;
     case WORD_SIZE:
-      *((short *)mem) = value;
+      *((short *)mem) = boost::numeric_cast<short>(value);
       break;
     case DWORD_SIZE:
-      *((uint32 *)mem) = value;
+      *((uint32 *)mem) = boost::numeric_cast<uint32>(value);
       break;
     case QWORD_SIZE:
-      *((uint64 *)mem) = value;
+      *((uint64 *)mem) = boost::numeric_cast<uint64>(value);
       break;
     case DQWORD_SIZE:
       *((uint128 *)mem) = value;

--- a/src/includes/SMT2Lib.h
+++ b/src/includes/SMT2Lib.h
@@ -422,7 +422,7 @@ namespace smt2lib {
   class smtAstBvNode : public smtAstAbstractNode
   {
     public:
-      smtAstBvNode(uint64 value, uint64 size);
+      smtAstBvNode(uint128 value, uint64 size);
       smtAstBvNode(const smtAstBvNode &copy);
       ~smtAstBvNode();
       virtual void accept(Visitor& v);
@@ -457,14 +457,14 @@ namespace smt2lib {
   class smtAstDecimalNode : public smtAstAbstractNode
   {
     protected:
-      uint64 value;
+      uint128 value;
 
     public:
-      smtAstDecimalNode(uint64 value);
+      smtAstDecimalNode(uint128 value);
       smtAstDecimalNode(const smtAstDecimalNode &copy);
       ~smtAstDecimalNode();
 
-      uint64 getValue(void);
+      uint128 getValue(void);
       virtual void accept(Visitor& v);
   };
 
@@ -646,7 +646,7 @@ namespace smt2lib {
 
 
   /* Node builders */
-  smtAstAbstractNode *bv(uint64 value, uint64 size);
+  smtAstAbstractNode *bv(uint128 value, uint64 size);
   smtAstAbstractNode *bvadd(smtAstAbstractNode *expr1, smtAstAbstractNode *expr2);
   smtAstAbstractNode *bvand(smtAstAbstractNode *expr1, smtAstAbstractNode *expr2);
   smtAstAbstractNode *bvashr(smtAstAbstractNode *expr1, smtAstAbstractNode *expr2);
@@ -684,7 +684,7 @@ namespace smt2lib {
   smtAstAbstractNode *concat(smtAstAbstractNode *expr1, smtAstAbstractNode *expr2);
   smtAstAbstractNode *concat(std::vector<smtAstAbstractNode *> exprs);
   smtAstAbstractNode *concat(std::list<smtAstAbstractNode *> exprs);
-  smtAstAbstractNode *decimal(uint64 value);
+  smtAstAbstractNode *decimal(uint128 value);
   smtAstAbstractNode *declare(std::string symVarName, uint64 symVarSize);
   smtAstAbstractNode *distinct(smtAstAbstractNode *expr1, smtAstAbstractNode *expr2);
   smtAstAbstractNode *equal(smtAstAbstractNode *expr1, smtAstAbstractNode *expr2);

--- a/src/includes/TritonTypes.h
+++ b/src/includes/TritonTypes.h
@@ -2,20 +2,21 @@
 #ifndef   TRITONTYPES_H
 #define   TRITONTYPES_H
 #include <boost/multiprecision/cpp_int.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 #define BIT_MAX 512
 
 typedef unsigned char                       uint8;
 typedef unsigned short                      uint16;
 typedef unsigned int                        uint32;
 typedef unsigned long long                  uint64;
-typedef __uint128_t                         uint128;
+typedef boost::multiprecision::uint128_t    uint128;
 typedef boost::multiprecision::uint512_t    uint512;
 
 typedef signed char                         sint8;
 typedef signed short                        sint16;
 typedef signed int                          sint32;
 typedef signed long long                    sint64;
-typedef __int128_t                          sint128;
+typedef boost::multiprecision::int128_t     sint128;
 typedef boost::multiprecision::int512_t     sint512;
 
 

--- a/src/includes/Z3Result.h
+++ b/src/includes/Z3Result.h
@@ -11,14 +11,13 @@ class Z3Result {
     ~Z3Result();
     Z3Result(const Z3Result& copy);
 
-    void setExpr(z3::expr& expr);
     void printExpr(void) const;
+    void setExpr(z3::expr& expr);
 
-    z3::expr& getExpr(void);
-    std::string getStringValue(void) const;
-    z3::context& getContext(void);
-    uint64 getUint64Value(void) const;
-
+    z3::context&  getContext(void);
+    z3::expr&     getExpr(void);
+    std::string   getStringValue(void) const;
+    uint64        getUint64Value(void) const;
 
   private:
     z3::context context;

--- a/src/smt2lib/smt2lib.cpp
+++ b/src/smt2lib/smt2lib.cpp
@@ -843,7 +843,7 @@ void smtAstBvxorNode::accept(Visitor& v) {
 // ====== bv
 
 
-smtAstBvNode::smtAstBvNode(uint64 value, uint64 size) {
+smtAstBvNode::smtAstBvNode(uint128 value, uint64 size) {
   this->kind = BV_NODE;
   this->addChild(new smtAstDecimalNode(value));
   this->addChild(new smtAstDecimalNode(size));
@@ -947,7 +947,7 @@ void smtAstConcatNode::accept(Visitor& v) {
 // ====== Decimal node
 
 
-smtAstDecimalNode::smtAstDecimalNode(uint64 value) {
+smtAstDecimalNode::smtAstDecimalNode(uint128 value) {
   this->kind  = DECIMAL_NODE;
   this->value = value;
 }
@@ -964,7 +964,7 @@ smtAstDecimalNode::~smtAstDecimalNode() {
 }
 
 
-uint64 smtAstDecimalNode::getValue(void) {
+uint128 smtAstDecimalNode::getValue(void) {
   return this->value;
 }
 
@@ -1659,7 +1659,7 @@ namespace smt2lib {
   }
 
 
-  smtAstAbstractNode *bv(uint64 value, uint64 size) {
+  smtAstAbstractNode *bv(uint128 value, uint64 size) {
     smtAstAbstractNode *node = new smtAstBvNode(value, size);
     if (node == nullptr)
       throw std::runtime_error("Node builders - Not enough memory");
@@ -1963,7 +1963,7 @@ namespace smt2lib {
   }
 
 
-  smtAstAbstractNode *decimal(uint64 value) {
+  smtAstAbstractNode *decimal(uint128 value) {
     smtAstAbstractNode *node = new smtAstDecimalNode(value);
     if (node == nullptr)
       throw std::runtime_error("Node builders - Not enough memory");


### PR DESCRIPTION
* Change __int128 to boost's int128
* Bv node and Decimal node can handle 128 bits value
```
[OK] 0x4006c8: movapd xmm0, xmmword ptr [rax]
[OK] 0x4006cc: movapd xmm1, xmm2
[OK] 0x4006d0: movapd xmm3, xmm0
[OK] 0x4006d4: lea rax, ptr [rbp-0x10]
[OK] 0x4006d8: movaps xmm0, xmmword ptr [rax]
[OK] 0x4006db: movaps xmm1, xmm2
[OK] 0x4006de: movaps xmm3, xmm0
[OK] 0x4006e1: movdqa xmm4, xmm2
[OK] 0x4006e5: movdqu xmm5, xmm0
[OK] 0x4006e9: movhlps xmm6, xmm4
[OK] 0x4006ec: movlhps xmm7, xmm5
[OK] 0x4006ef: orpd xmm0, xmm1
[OK] 0x4006f3: orps xmm1, xmm3
[OK] 0x4006f6: xorpd xmm0, xmm1
[OK] 0x4006fa: xorps xmm1, xmm3
[OK] 0x4006fd: andpd xmm1, xmm3
[OK] 0x400701: andps xmm1, xmm3
[OK] 0x400704: andnpd xmm1, xmm3
[OK] 0x400708: andnps xmm1, xmm3
```