### PR TITLE
Add -ifeellucky pin option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,12 @@ target_link_libraries(
 # Generate the triton's shortcut script
 set(PIN_BIN_PATH ${PIN_ROOT}/pin.sh)
 set(TRITON_LIB_PATH ${CMAKE_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(FLAG_IFEELLUCKY "")
+
+if(${KERNEL4} MATCHES "yes")
+  set(FLAG_IFEELLUCKY "-ifeellucky")
+endif()
+
 configure_file(
     ${CMAKE_SOURCE_DIR}/scripts/triton.in
     ${CMAKE_SOURCE_DIR}/triton

--- a/scripts/triton.in
+++ b/scripts/triton.in
@@ -17,5 +17,5 @@ if [ -z "$2" ]
     exit
 fi
 
-$PIN_BIN_PATH -t $TRITON_LIB_PATH -script $1 -- ${@:2}
+$PIN_BIN_PATH @FLAG_IFEELLUCKY@ -t $TRITON_LIB_PATH -script $1 -- ${@:2}
 


### PR DESCRIPTION
This PR provides the `-ifeellucky` option to execute Triton on a `4.x` Kernel