### PR TITLE
Update CMakeLists.txt (fix 64bit syscall table bug)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,16 +131,12 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 # Triton have to generate a syscalls table from the kernel source
 # This following code tries to find the unistd_64.h or unistd_32.h header depending on the architecture.
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    FILE(
-        GLOB_RECURSE
-        syscalls_table_files
-        if(${ARCHITECTURE} STREQUAL "i386")
-            /usr/include/*unistd_32.h
-        endif(${ARCHITECTURE} STREQUAL "i386")
-        if(${ARCHITECTURE} STREQUAL "amd64")
-            /usr/include/*unistd_64.h
-        endif(${ARCHITECTURE} STREQUAL "amd64")
-    )
+    if(ARCHITECTURE STREQUAL "i386")
+        FILE(GLOB_RECURSE syscalls_table_files /usr/include/*unistd_32.h)
+    endif(ARCHITECTURE STREQUAL "i386")
+    if(ARCHITECTURE STREQUAL "amd64")
+        FILE(GLOB_RECURSE syscalls_table_files /usr/include/*unistd_64.h)
+    endif(ARCHITECTURE STREQUAL "amd64")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
in 64bit env, syscall table is setted wrong value look like 32bit table.

in this case, variable syscalls_table_files contain 32bit header + 64bit header
[/usr/include/x86_64-linux-gnu/asm/unistd_32.h, /usr/include/x86_64-linux-gnu/asm/unistd_64.h]

though 64bit env, LIST(GET syscalls_table_files 0 syscalls_table_file) is set syscalls_table_file to unistd_32.h
