### PR TITLE
Added a Dockerfile to generate a container with Ubuntu 14.04 with Triton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:15.10
 MAINTAINER Pete Markowsky <pete@markowsky.us>
 RUN apt-get update && apt-get dist-upgrade -y && \
     apt-get install -y git cmake build-essential clang ca-certificates curl \
@@ -25,7 +25,7 @@ RUN cd /opt && curl -o pin.tgz -L http://software.intel.com/sites/landingpage/pi
 # RUN cd /opt && git clone https://github.com/JonathanSalwan/Triton.git && \
 #     cd Triton && mkdir build && cd build && cmake -G "Unix Makefiles" .. && \
 #     make install &&  cd .. && python setup.py install
-RUN cd /opt && \
+RUN cd /opt/pin-2.14-71313-gcc.4.4.7-linux/source/tools/ && \
    curl -o master.zip -L https://github.com/JonathanSalwan/Triton/archive/master.zip && unzip master.zip && cd Triton-master/ && mkdir build && cd build && \
-   cmake -G "Unix Makefiles" .. && make install && cd .. && python setup.py install
+   cmake -G "Unix Makefiles" -DPINTOOL=yes -DKERNEL4=yes .. && make install && cd .. && python setup.py install
 ENTRYPOINT /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:14.04
+MAINTAINER Pete Markowsky <pete@markowsky.us>
+RUN apt-get update && apt-get dist-upgrade -y && \
+    apt-get install -y git cmake build-essential clang ca-certificates curl \
+    unzip libboost-dev python-dev python-pip && apt-get clean
+# get and install the latest z3 relesae
+RUN cd /tmp && \
+    curl -o z3.tgz -L  https://github.com/Z3Prover/z3/archive/z3-4.4.1.tar.gz && \
+    tar zxf z3.tgz && cd z3-z3-4.4.1 && \
+    CC=clang CXX=clang++ python scripts/mk_make.py && cd build && make \
+    && make install && cd /tmp && rm -rf /tmp/z3-z3-4.4.1
+
+# Install capstone
+RUN cd /tmp && \
+    curl -o cap.tgz -L https://github.com/aquynh/capstone/archive/3.0.4.tar.gz && \
+    tar xvf cap.tgz && cd capstone-3.0.4/ && ./make.sh install && cd /tmp && \
+    rm -rf /tmp/capstone-3.0.4
+
+
+# Install pintool
+RUN cd /opt && curl -o pin.tgz -L http://software.intel.com/sites/landingpage/pintool/downloads/pin-2.14-71313-gcc.4.4.7-linux.tar.gz && tar zxf pin.tgz
+
+# now install Triton
+# uncomment below to pull form git
+# RUN cd /opt && git clone https://github.com/JonathanSalwan/Triton.git && \
+#     cd Triton && mkdir build && cd build && cmake -G "Unix Makefiles" .. && \
+#     make install &&  cd .. && python setup.py install
+RUN cd /opt && \
+   curl -o master.zip -L https://github.com/JonathanSalwan/Triton/archive/master.zip && unzip master.zip && cd Triton-master/ && mkdir build && cd build && \
+   cmake -G "Unix Makefiles" .. && make install && cd .. && python setup.py install
+ENTRYPOINT /bin/bash


### PR DESCRIPTION
Added a simple Docker container to allow people to try out Triton on Ubuntu 14.04. This grabs sets up a basic enviornment with clang-3.6.2 and pulls Boost from Ubuntu's packages and then builds Z3, Capstone, and Triton from source. 

Pin is also pulled down to */opt/pin-2.14-71313-gcc.4.4.7-linux*

Triton's built in */opt/Triton-master/build* or */opt/Triton/build* depending upon if you use the release link or git.

This makes setting up a development environment with Triton as simple as 

```
[ peterm@ubuntu ( 7:24AM) ~/dockerfiles/triton  ]                                  
$  docker build --tag=triton . 
```

Where you can then run it by

```
[ peterm@ubuntu ( 7:32AM) ~/dockerfiles/triton  ]                                  
$  docker run -it --rm trition
root@62e5de69f584:/# python
Python 2.7.6 (default, Jun 22 2015, 17:58:13) 
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import triton
>>>
```
