### PR TITLE
Immediate operand conversion

### DIFF
--- a/src/libtriton/arch/immediateOperand.cpp
+++ b/src/libtriton/arch/immediateOperand.cpp
@@ -19,13 +19,26 @@ namespace triton {
 
 
     ImmediateOperand::ImmediateOperand(triton::uint64 value, triton::uint32 size /* bytes */) {
-      this->value = value;
 
       if (size == 0)
         throw std::runtime_error("ImmediateOperand::ImmediateOperand(): size cannot be zero.");
 
       if (size != BYTE_SIZE && size != WORD_SIZE && size != DWORD_SIZE && size != QWORD_SIZE && size != DQWORD_SIZE && size != QQWORD_SIZE && size != DQQWORD_SIZE)
         throw std::runtime_error("ImmediateOperand::ImmediateOperand(): size must be aligned.");
+
+      switch (size) {
+        case BYTE_SIZE:
+          this->value = (triton::uint8) value;
+          break;
+        case WORD_SIZE:
+          this->value = (triton::uint16) value;
+          break;
+        case DWORD_SIZE:
+          this->value = (triton::uint32) value;
+          break;
+        default:
+          this->value = value;
+      }
 
       this->setPair(std::make_pair(((size * BYTE_SIZE_BIT) - 1), 0));
     }


### PR DESCRIPTION
Triton creates constraint

```lisp
ref!356633 = ((_ zero_extend 32) ((_ extract 31 0) (bvadd ((_ zero_extend 32) (_ bv18446744073709551568 32)) (bvadd ((_ extract 63 0) ref!356631) (bvmul (_ bv0 64) ((_ zero_extend 32) (_ bv1 32))))))) ; LEA        operation
```

with some strange constant `(_ bv18446744073709551568 32)` (18446744073709551568 = 2<sup>64</sup> - 48 > 2<sup>32</sup>).

Immediate value in Capstone has type `int64_t`, but `ImmediateOperand` takes `uint64` value. If value size is less than `QWORD_SIZE`, it may be too big. Proposed conversion creates more appropriate constant `(_ bv4294967248 32)` in

```lisp
ref!356663 = ((_ zero_extend 32) ((_ extract 31 0) (bvadd ((_ zero_extend 32) (_ bv4294967248 32)) (bvadd ((_ extract 63 0) ref!356661) (bvmul (_ bv0 64) ((_ zero_extend 32) (_ bv1 32))))))) ; LEA operation
```

I'm not sure fix is right. May be we should have a deal with signed constants instead of unsigned?