### PR TITLE
Fix in assignSymbolicExpressionToMemory removing previous alignedMemo…

### DIFF
--- a/src/libtriton/arch/x86/x86Semantics.cpp
+++ b/src/libtriton/arch/x86/x86Semantics.cpp
@@ -4085,8 +4085,6 @@ namespace triton {
               auto  op3  = triton::api.buildSymbolicOperand(inst, src2);
               auto  node = triton::ast::bvmul(triton::ast::sx(src1.getBitSize(), op2), triton::ast::sx(src2.getBitSize(), op3));
               auto  expr = triton::api.createSymbolicExpression(inst, triton::ast::extract(dst.getBitSize()-1, 0, node), dst, "IMUL operation");
-              expr->isTainted = triton::api.taintUnion(dst, src1);
-              expr->isTainted = triton::api.taintUnion(dst, src2);
               triton::arch::x86::semantics::cfImul_s(inst, expr, dst, triton::ast::bvmul(op2, op3), node);
               triton::arch::x86::semantics::ofImul_s(inst, expr, dst, triton::ast::bvmul(op2, op3), node);
               break;

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -849,6 +849,12 @@ namespace triton {
         if (node->getBitvectorSize() != mem.getBitSize())
           throw triton::exceptions::SymbolicEngine("SymbolicEngine::assignSymbolicExpressionToMemory(): The size of the symbolic expression is not equal to the memory access.");
 
+        /* Record the aligned memory for a symbolic optimization */
+        if (triton::api.isSymbolicOptimizationEnabled(triton::engines::symbolic::ALIGNED_MEMORY)) {
+          this->removeAlignedMemory(address, writeSize);
+          this->alignedMemoryReference[std::make_pair(address, writeSize)] = node;
+        }
+
         /*
          * As the x86's memory can be accessed without alignment, each byte of the
          * memory must be assigned to an unique reference.


### PR DESCRIPTION
The function `assignSymbolicExpressionToMemory` is not removing the previous `alignedMemoryReferences`.

So if the `ALIGNED_MEMORY` optimization is enable, and we use `assignSymbolicExpressionToMemory` to set a SE to a memory, this SE is ignored when the buildSemantics finds the previous memory reference in the vector `alignedMemoryReferences`.

This commit should fix this behavior.