### PR TITLE
Fix build script for distro with python3 as default python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,9 +307,9 @@ if(PYTHON_BINDINGS)
         ${CMAKE_SOURCE_DIR}/src/testers/libTriton_units_testing.py
         IMMEDIATE @ONLY
     )
-    find_program(PYTHON_BINARY "python")
+    find_program(ENV_BINARY "env")
     if(UNIX)
-      install (CODE "execute_process(COMMAND ${PYTHON_BINARY} ${CMAKE_BINARY_DIR}/setup.py install)")
+      install (CODE "execute_process(COMMAND ${ENV_BINARY} python2 ${CMAKE_BINARY_DIR}/setup.py install)")
     endif()
 endif()
 


### PR DESCRIPTION
The default build script call the setup.py with `python`. On some distro (like archlinux) this is python3 which thus causes troubles.

This simply calls `env python2` instead.