### PR TITLE
fix startAnalysisFromEntry for PIE executable

### DIFF
--- a/src/tracer/pin/main.cpp
+++ b/src/tracer/pin/main.cpp
@@ -799,6 +799,7 @@ namespace tracer {
       /* Lock / Unlock the Analysis from a Entry point */
       if (tracer::pintool::options::startAnalysisFromEntry) {
         tracer::pintool::options::startAnalysisFromEntry = false;
+        /* IMG_LoadOffset(img) + IMG_Entry(img) for PIE binaries (see #524) */
         tracer::pintool::options::startAnalysisFromAddress.insert(IMG_LoadOffset(img) + IMG_Entry(img));
       }
 

--- a/src/tracer/pin/main.cpp
+++ b/src/tracer/pin/main.cpp
@@ -799,7 +799,7 @@ namespace tracer {
       /* Lock / Unlock the Analysis from a Entry point */
       if (tracer::pintool::options::startAnalysisFromEntry) {
         tracer::pintool::options::startAnalysisFromEntry = false;
-        tracer::pintool::options::startAnalysisFromAddress.insert(IMG_Entry(img));
+        tracer::pintool::options::startAnalysisFromAddress.insert(IMG_LoadOffset(img) + IMG_Entry(img));
       }
 
       /* Lock / Unlock the Analysis from a symbol */


### PR DESCRIPTION
When instrumenting a PIE binary, `IMG_Entry` return the offset of the entry point thus, the instrumentation never start. Adding `IMG_LoadOffset` ensure that the final address is really the full address of the entry point. For non-PIE binaries `IMG_LoadOffset` return 0 thus not altering the final address. **I have not checked on Windows but it does not seems to change**.

_I could have enforced by adding a switch on `IMG_Type` but as far as I understand the code the section can only be executed once for the first image of the executable (as it switch the boolean to false). Thus we might never get in this line of code for shared libraries._