### PR TITLE
Remove duplicate find python code

### DIFF
--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -281,8 +281,6 @@ install (DIRECTORY ${CMAKE_BINARY_DIR}/src/libtriton/includes/triton DESTINATION
 
 # Install Python bindings
 if(PYTHON_BINDINGS)
-    find_package(PythonInterp 2.7 REQUIRED)
-
     add_custom_target(python-triton ALL
       COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${CMAKE_SHARED_MODULE_PREFIX}triton${CMAKE_SHARED_LIBRARY_SUFFIX}" "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/triton${PYTHON_SUFFIX}"
       DEPENDS triton


### PR DESCRIPTION
I think this line should be redundant, maybe.
I am not sure, I haven't read all of `cmake` related code.
If I am wrong, correct me.
Thanks.