### PR TITLE
Python Header To The Top

### DIFF
--- a/src/libtriton/bindings/python/init.cpp
+++ b/src/libtriton/bindings/python/init.cpp
@@ -5,12 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <iostream>
-
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonXFunctions.hpp>
 #include <triton/pythonBindings.hpp>
 
+#include <iostream>
 
 
 namespace triton {

--- a/src/libtriton/bindings/python/modules/astCallbacks.cpp
+++ b/src/libtriton/bindings/python/modules/astCallbacks.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
+#include <triton/pythonObjects.hpp>
+#include <triton/pythonUtils.hpp>
 #include <triton/api.hpp>
 #include <triton/ast.hpp>
 #include <triton/exceptions.hpp>
-#include <triton/pythonObjects.hpp>
-#include <triton/pythonUtils.hpp>
 
 
 

--- a/src/libtriton/bindings/python/modules/tritonCallbacks.cpp
+++ b/src/libtriton/bindings/python/modules/tritonCallbacks.cpp
@@ -5,15 +5,15 @@
 **  This program is under the terms of the BSD License.
 */
 
+#include <triton/pythonBindings.hpp>
+#include <triton/pythonObjects.hpp>
+#include <triton/pythonUtils.hpp>
+#include <triton/pythonXFunctions.hpp>
 #include <triton/api.hpp>
 #include <triton/exceptions.hpp>
 #include <triton/bitsVector.hpp>
 #include <triton/immediate.hpp>
 #include <triton/memoryAccess.hpp>
-#include <triton/pythonBindings.hpp>
-#include <triton/pythonObjects.hpp>
-#include <triton/pythonUtils.hpp>
-#include <triton/pythonXFunctions.hpp>
 #include <triton/register.hpp>
 
 

--- a/src/libtriton/bindings/python/namespaces/initArchNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initArchNamespace.cpp
@@ -5,9 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/architecture.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/architecture.hpp>
 
 
 

--- a/src/libtriton/bindings/python/namespaces/initAstNodeNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initAstNodeNamespace.cpp
@@ -5,9 +5,10 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/ast.hpp>
+
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/ast.hpp>
 
 
 

--- a/src/libtriton/bindings/python/namespaces/initAstRepresentationNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initAstRepresentationNamespace.cpp
@@ -5,10 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/astRepresentation.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
-
+#include <triton/astRepresentation.hpp>
 
 
 /*! \page py_AST_REPRESENTATION_page AST_REPRESENTATION

--- a/src/libtriton/bindings/python/namespaces/initCallbackNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initCallbackNamespace.cpp
@@ -5,9 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/callbacks.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/callbacks.hpp>
 
 
 

--- a/src/libtriton/bindings/python/namespaces/initCpuSizeNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initCpuSizeNamespace.cpp
@@ -5,10 +5,10 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/api.hpp>
-#include <triton/cpuSize.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/api.hpp>
+#include <triton/cpuSize.hpp>
 
 
 

--- a/src/libtriton/bindings/python/namespaces/initModeNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initModeNamespace.cpp
@@ -5,9 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/modes.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/modes.hpp>
 
 
 

--- a/src/libtriton/bindings/python/namespaces/initOperandNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initOperandNamespace.cpp
@@ -5,9 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/operandInterface.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/operandInterface.hpp>
 
 
 

--- a/src/libtriton/bindings/python/namespaces/initRegNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initRegNamespace.cpp
@@ -5,10 +5,10 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/api.hpp>
-#include <triton/architecture.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonObjects.hpp>
+#include <triton/api.hpp>
+#include <triton/architecture.hpp>
 #include <triton/x86Specifications.hpp>
 
 

--- a/src/libtriton/bindings/python/namespaces/initSyscallNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initSyscallNamespace.cpp
@@ -7,10 +7,10 @@
 
 #if defined(__unix__) || defined(__APPLE__)
 
-#include <triton/api.hpp>
-#include <triton/architecture.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/api.hpp>
+#include <triton/architecture.hpp>
 #include <triton/unix.hpp>
 
 

--- a/src/libtriton/bindings/python/namespaces/initX86OpcodesNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initX86OpcodesNamespace.cpp
@@ -5,9 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/api.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/api.hpp>
 #include <triton/x86Specifications.hpp>
 
 

--- a/src/libtriton/bindings/python/namespaces/initX86PrefixesNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initX86PrefixesNamespace.cpp
@@ -5,9 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/api.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/api.hpp>
 #include <triton/x86Specifications.hpp>
 
 

--- a/src/libtriton/bindings/python/objects/pyAstNode.cpp
+++ b/src/libtriton/bindings/python/objects/pyAstNode.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/ast.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/ast.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyBitvector.cpp
+++ b/src/libtriton/bindings/python/objects/pyBitvector.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/bitsVector.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/bitsVector.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyElf.cpp
+++ b/src/libtriton/bindings/python/objects/pyElf.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/elf.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/elf.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyElfDynamicTable.cpp
+++ b/src/libtriton/bindings/python/objects/pyElfDynamicTable.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/elfDynamicTable.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/elfDynamicTable.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyElfHeader.cpp
+++ b/src/libtriton/bindings/python/objects/pyElfHeader.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/elfHeader.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/elfHeader.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyElfProgramHeader.cpp
+++ b/src/libtriton/bindings/python/objects/pyElfProgramHeader.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/elfProgramHeader.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/elfProgramHeader.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyElfRelocationTable.cpp
+++ b/src/libtriton/bindings/python/objects/pyElfRelocationTable.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/elfRelocationTable.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/elfRelocationTable.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyElfSectionHeader.cpp
+++ b/src/libtriton/bindings/python/objects/pyElfSectionHeader.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/elfSectionHeader.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/elfSectionHeader.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyElfSymbolTable.cpp
+++ b/src/libtriton/bindings/python/objects/pyElfSymbolTable.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/elfSymbolTable.hpp>
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/elfSymbolTable.hpp>
+#include <triton/exceptions.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyImmediate.cpp
+++ b/src/libtriton/bindings/python/objects/pyImmediate.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/immediate.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/immediate.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyInstruction.cpp
+++ b/src/libtriton/bindings/python/objects/pyInstruction.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/instruction.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/instruction.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyMemoryAccess.cpp
+++ b/src/libtriton/bindings/python/objects/pyMemoryAccess.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/memoryAccess.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/memoryAccess.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPathConstraint.cpp
+++ b/src/libtriton/bindings/python/objects/pyPathConstraint.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/pathConstraint.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/pathConstraint.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPe.cpp
+++ b/src/libtriton/bindings/python/objects/pyPe.cpp
@@ -5,11 +5,12 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/pe.hpp>
+
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/pe.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPeExportEntry.cpp
+++ b/src/libtriton/bindings/python/objects/pyPeExportEntry.cpp
@@ -5,11 +5,12 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/peExportDirectory.hpp>
+
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/peExportDirectory.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPeExportTable.cpp
+++ b/src/libtriton/bindings/python/objects/pyPeExportTable.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/peExportDirectory.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/peExportDirectory.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPeHeader.cpp
+++ b/src/libtriton/bindings/python/objects/pyPeHeader.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/peHeader.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/peHeader.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPeImportLookup.cpp
+++ b/src/libtriton/bindings/python/objects/pyPeImportLookup.cpp
@@ -5,11 +5,12 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/peImportDirectory.hpp>
+
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/peImportDirectory.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPeImportTable.cpp
+++ b/src/libtriton/bindings/python/objects/pyPeImportTable.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/peImportDirectory.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/peImportDirectory.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyPeSectionHeader.cpp
+++ b/src/libtriton/bindings/python/objects/pyPeSectionHeader.cpp
@@ -5,11 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
-#include <triton/peHeader.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
+#include <triton/peHeader.hpp>
 
 
 

--- a/src/libtriton/bindings/python/objects/pyRegister.cpp
+++ b/src/libtriton/bindings/python/objects/pyRegister.cpp
@@ -5,10 +5,10 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
 #include <triton/register.hpp>
 
 

--- a/src/libtriton/bindings/python/objects/pySolverModel.cpp
+++ b/src/libtriton/bindings/python/objects/pySolverModel.cpp
@@ -5,10 +5,10 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
 #include <triton/solverModel.hpp>
 
 

--- a/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
+++ b/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
@@ -5,10 +5,10 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
 #include <triton/symbolicExpression.hpp>
 
 

--- a/src/libtriton/bindings/python/objects/pySymbolicVariable.cpp
+++ b/src/libtriton/bindings/python/objects/pySymbolicVariable.cpp
@@ -5,10 +5,11 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
+
 #include <triton/pythonObjects.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/pythonXFunctions.hpp>
+#include <triton/exceptions.hpp>
 #include <triton/symbolicVariable.hpp>
 
 

--- a/src/libtriton/bindings/python/pyXFunctions.cpp
+++ b/src/libtriton/bindings/python/pyXFunctions.cpp
@@ -5,9 +5,8 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <iostream>
 #include <triton/pythonXFunctions.hpp>
-
+#include <iostream>
 
 
 namespace triton {

--- a/src/libtriton/bindings/python/utils.cpp
+++ b/src/libtriton/bindings/python/utils.cpp
@@ -5,9 +5,9 @@
 **  This program is under the terms of the BSD License.
 */
 
-#include <triton/exceptions.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
+#include <triton/exceptions.hpp>
 #include <triton/tritonTypes.hpp>
 
 

--- a/src/libtriton/includes/triton/pythonObjects.hpp
+++ b/src/libtriton/includes/triton/pythonObjects.hpp
@@ -9,6 +9,7 @@
 #ifndef TRITON_PYOBJECT_H
 #define TRITON_PYOBJECT_H
 
+#include <triton/pythonBindings.hpp>
 #include <triton/ast.hpp>
 #include <triton/bitsVector.hpp>
 #include <triton/elf.hpp>
@@ -24,7 +25,6 @@
 #include <triton/instruction.hpp>
 #include <triton/memoryAccess.hpp>
 #include <triton/pathConstraint.hpp>
-#include <triton/pythonBindings.hpp>
 #include <triton/register.hpp>
 #include <triton/solverModel.hpp>
 #include <triton/symbolicExpression.hpp>


### PR DESCRIPTION
Ref #549 -- I was able to get the compiler errors worked out. The core issue is that some systems the python header files define system values that conflict with global values in other header files. It turns out, the solution for this is to import the python header files first. The other core system includes actually check for these values already being set and do not attempt to set them again.

All the changes made here are to move the python header includes to the top. I can confirm that these changes allowed Triton to be built in my case.