### PR TITLE
Fix segfault on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
             apt:
               sources: ['ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports']
               packages: ['g++-5', 'ccache', 'libpython2.7', 'libboost1.55-all-dev', 'cmake', 'cmake-data']
-          env: [ CXX_COMPILER=g++-5, C_COMPILER=gcc-5, PYTHON_VERSION=2.7, GCOV=ON]
+          env: [ GCOV=ON, CXX_COMPILER=g++-5, C_COMPILER=gcc-5, PYTHON_VERSION=2.7 ]
 
         # Linux clang 3.5
         - os: linux
@@ -64,6 +64,15 @@ matrix:
               sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7', 'boost-latest', 'george-edison55-precise-backports']
               packages: ['clang-3.7', 'ccache', 'libpython2.7', 'libboost1.55-all-dev', 'cmake', 'cmake-data']
           env: [ CXX_COMPILER=clang++-3.7, C_COMPILER=clang-3.7, PYTHON_VERSION=2.7 ]
+
+        # Linux clang 3.8
+        - os: linux
+          compiler: clang
+          addons:
+            apt:
+              sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8', 'boost-latest', 'george-edison55-precise-backports']
+              packages: ['clang-3.8', 'ccache', 'libpython2.7', 'libboost1.55-all-dev', 'cmake', 'cmake-data']
+          env: [ CXX_COMPILER=clang++-3.8, C_COMPILER=clang-3.8, PYTHON_VERSION=2.7 ]
 
         # OSX xcode 7.3
         - os: osx
@@ -145,7 +154,7 @@ install:
 script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cmake -DPINTOOL=on -DKERNEL4=on -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER .. -DGCOV=${GCOV:OFF}; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then cmake $TT_PYTHON_ENV ..; fi
-  - sudo make -j2
+  - make -j2
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo sh -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"; fi
   - make check
   # Check installation succeed

--- a/src/libtriton/arch/register.cpp
+++ b/src/libtriton/arch/register.cpp
@@ -26,6 +26,14 @@ namespace triton {
     }
 
 
+    RegisterSpec::RegisterSpec(const RegisterSpec& other)
+      : BitsVector(other) {
+        this->name    = other.name;
+        this->id      = other.id;
+        this->parent  = other.parent;
+    }
+
+
     triton::arch::registers_e RegisterSpec::getId(void) const {
       return this->id;
     }
@@ -75,13 +83,21 @@ namespace triton {
     }
 
 
-    bool RegisterSpec::operator==(const RegisterSpec& reg1) const {
-      return getId() == reg1.getId();
+    bool RegisterSpec::operator==(const RegisterSpec& other) const {
+      return getId() == other.getId();
     }
 
 
-    bool RegisterSpec::operator!=(const RegisterSpec& reg1) const {
-      return !(*this == reg1);
+    bool RegisterSpec::operator!=(const RegisterSpec& other) const {
+      return !(*this == other);
+    }
+
+
+    void RegisterSpec::operator=(const RegisterSpec& other) {
+      BitsVector::operator=(other);
+      this->name    = other.name;
+      this->id      = other.id;
+      this->parent  = other.parent;
     }
 
 
@@ -110,14 +126,15 @@ namespace triton {
 
     Register::Register()
       : RegisterSpec(triton::arch::ID_REG_INVALID, "unknown", triton::arch::ID_REG_INVALID, 0, 0),
-      concreteValue(0),
-      concreteValueDefined(false) {
+        concreteValue(0),
+        concreteValueDefined(false) {
     }
 
 
-    Register::Register(const RegisterSpec& spec, triton::uint512 concreteValue)
-      : RegisterSpec(spec) {
-      this->setConcreteValue(concreteValue);
+    Register::Register(const Register& other)
+      : RegisterSpec(other) {
+        this->concreteValue        = other.concreteValue;
+        this->concreteValueDefined = other.concreteValueDefined;
     }
 
 
@@ -125,6 +142,12 @@ namespace triton {
       : RegisterSpec(spec),
         concreteValue(0),
         concreteValueDefined(false) {
+    }
+
+
+    Register::Register(const RegisterSpec& spec, triton::uint512 concreteValue)
+      : RegisterSpec(spec) {
+      this->setConcreteValue(concreteValue);
     }
 
 
@@ -160,13 +183,20 @@ namespace triton {
     }
 
 
-    bool Register::operator==(const Register& reg1) const {
-      return (RegisterSpec::operator==(reg1) && getConcreteValue() == reg1.getConcreteValue());
+    bool Register::operator==(const Register& other) const {
+      return (RegisterSpec::operator==(other) && getConcreteValue() == other.getConcreteValue());
     }
 
 
-    bool Register::operator!=(const Register& reg1) const {
-      return !(*this == reg1);
+    bool Register::operator!=(const Register& other) const {
+      return !(*this == other);
+    }
+
+
+    void Register::operator=(const Register& other) {
+      RegisterSpec::operator=(other);
+      this->concreteValue         = other.concreteValue;
+      this->concreteValueDefined  = other.concreteValueDefined;
     }
 
 

--- a/src/libtriton/arch/x86/x8664Cpu.cpp
+++ b/src/libtriton/arch/x86/x8664Cpu.cpp
@@ -432,6 +432,9 @@ namespace triton {
         triton::extlibs::capstone::cs_option(handle, triton::extlibs::capstone::CS_OPT_DETAIL, triton::extlibs::capstone::CS_OPT_ON);
         triton::extlibs::capstone::cs_option(handle, triton::extlibs::capstone::CS_OPT_SYNTAX, triton::extlibs::capstone::CS_OPT_SYNTAX_INTEL);
 
+        /* Clear instructicon's operands if alredy defined */
+        inst.operands.clear();
+
         /* Let's disass and build our operands */
         count = triton::extlibs::capstone::cs_disasm(handle, inst.getOpcodes(), inst.getSize(), inst.getAddress(), 0, &insn);
         if (count > 0) {

--- a/src/libtriton/arch/x86/x86Cpu.cpp
+++ b/src/libtriton/arch/x86/x86Cpu.cpp
@@ -310,6 +310,9 @@ namespace triton {
         triton::extlibs::capstone::cs_option(handle, triton::extlibs::capstone::CS_OPT_DETAIL, triton::extlibs::capstone::CS_OPT_ON);
         triton::extlibs::capstone::cs_option(handle, triton::extlibs::capstone::CS_OPT_SYNTAX, triton::extlibs::capstone::CS_OPT_SYNTAX_INTEL);
 
+        /* Clear instructicon's operands if alredy defined */
+        inst.operands.clear();
+
         /* Let's disass and build our operands */
         count = triton::extlibs::capstone::cs_disasm(handle, inst.getOpcodes(), inst.getSize(), inst.getAddress(), 0, &insn);
         if (count > 0) {

--- a/src/libtriton/ast/astGarbageCollector.cpp
+++ b/src/libtriton/ast/astGarbageCollector.cpp
@@ -91,7 +91,7 @@ namespace triton {
         return;
 
       uniqueNodes.insert(root);
-      for (auto it = root->getChilds().begin(); it != root->getChilds().end(); it++)
+      for (auto it = root->getChilds().cbegin(); it != root->getChilds().cend(); it++)
         this->extractUniqueAstNodes(uniqueNodes, *it);
     }
 

--- a/src/libtriton/bindings/python/pyXFunctions.cpp
+++ b/src/libtriton/bindings/python/pyXFunctions.cpp
@@ -54,8 +54,14 @@ namespace triton {
 
       PyObject* xPyClass_New(PyObject* b, PyObject* d, PyObject* n) {
         PyObject* c = PyClass_New(b, d, n);
+
         if (!c)
           notEnoughMemory();
+
+        Py_CLEAR(b);
+        Py_CLEAR(d);
+        Py_CLEAR(n);
+
         return c;
       }
 

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -254,7 +254,8 @@ namespace triton {
       /* Adds an aligned memory */
       void SymbolicEngine::addAlignedMemory(triton::uint64 address, triton::uint32 size, triton::ast::AbstractNode* node) {
         this->removeAlignedMemory(address, size);
-        this->alignedMemoryReference[std::make_pair(address, size)] = node;
+        if (!(this->modes.isModeEnabled(triton::modes::ONLY_ON_SYMBOLIZED) && node->isSymbolized() == false))
+          this->alignedMemoryReference[std::make_pair(address, size)] = node;
       }
 
 
@@ -569,9 +570,7 @@ namespace triton {
         if (expression->getAst())
             this->setConcreteSymbolicVariableValue(*symVar, expression->getAst()->evaluate());
 
-        tmp->setParent(expression->getAst()->getParents());
         expression->setAst(tmp);
-        tmp->init();
 
         return symVar;
       }
@@ -616,9 +615,7 @@ namespace triton {
           }
           else {
             se = this->getSymbolicExpressionFromId(memSymId);
-            tmp->setParent(se->getAst()->getParents());
             se->setAst(tmp);
-            tmp->init();
             se->setOriginMemory(triton::arch::MemoryAccess(memAddr+index, BYTE_SIZE, tmp->evaluate()));
           }
 
@@ -665,9 +662,7 @@ namespace triton {
           /* Setup the concrete value to the symbolic variable */
           this->setConcreteSymbolicVariableValue(*symVar, cv);
           /* Set the AST node */
-          tmp->setParent(expression->getAst()->getParents());
           expression->setAst(tmp);
-          tmp->init();
         }
 
         return symVar;
@@ -878,7 +873,7 @@ namespace triton {
           /* Synchronize the concrete state */
           this->architecture->setConcreteMemoryValue(mem);
           /* Define the memory store */
-          inst.setStoreAccess(mem, node);
+          inst.setStoreAccess(mem, tmp);
           return se;
         }
 
@@ -895,7 +890,7 @@ namespace triton {
         se->setOriginMemory(triton::arch::MemoryAccess(address, mem.getSize(), tmp->evaluate()));
 
         /* Define the memory store */
-        inst.setStoreAccess(mem, node);
+        inst.setStoreAccess(mem, tmp);
         inst.addSymbolicExpression(se);
         return se;
       }

--- a/src/libtriton/includes/triton/irBuilder.hpp
+++ b/src/libtriton/includes/triton/irBuilder.hpp
@@ -61,6 +61,18 @@ namespace triton {
         //! Removes all symbolic expressions of an instruction.
         void removeSymbolicExpressions(triton::arch::Instruction& inst, std::set<triton::ast::AbstractNode*>& uniqueNodes);
 
+        //! Collects nodes from a set.
+        template <typename T> void collectNodes(std::set<triton::ast::AbstractNode*>& uniqueNodes, T& items) const;
+
+        //! Collects nodes from operands.
+        void collectNodes(std::set<triton::ast::AbstractNode*>& uniqueNodes, std::vector<triton::arch::OperandWrapper>& operands, bool gc) const;
+
+        //! Collects unsymbolized nodes from a set.
+        template <typename T> void collectUnsymbolizedNodes(T& items) const;
+
+        //! Collects unsymbolized nodes from operands.
+        void collectUnsymbolizedNodes(std::set<triton::ast::AbstractNode*>& uniqueNodes, std::vector<triton::arch::OperandWrapper>& operands) const;
+
       protected:
         //! x86 ISA builder.
         triton::arch::SemanticsInterface* x86Isa;

--- a/src/libtriton/includes/triton/register.hpp
+++ b/src/libtriton/includes/triton/register.hpp
@@ -55,6 +55,9 @@ namespace triton {
         //! Constructor.
         RegisterSpec(triton::arch::registers_e regId, std::string name, triton::arch::registers_e parent, triton::uint32 high, triton::uint32 low);
 
+        //! Constructor.
+        RegisterSpec(const RegisterSpec& other);
+
         //! Returns the parent id of the register.
         registers_e getParent(void) const;
 
@@ -83,10 +86,13 @@ namespace triton {
         triton::uint32 getType(void) const;
 
         //! Compare two registers specifications
-        bool operator==(const RegisterSpec& r) const;
+        bool operator==(const RegisterSpec& other) const;
 
         //! Compare two registers specifications
-        bool operator!=(const RegisterSpec& r) const;
+        bool operator!=(const RegisterSpec& other) const;
+
+        //! Copies a RegisterSpec.
+        void operator=(const RegisterSpec& other);
     };
 
     /*! \class Register
@@ -106,16 +112,19 @@ namespace triton {
         Register();
 
         //! Constructor.
-        Register(const triton::arch::CpuInterface&, triton::arch::registers_e regId);
+        Register(const Register& spec);
 
         //! Constructor.
-        Register(const triton::arch::CpuInterface&, triton::arch::registers_e regId, triton::uint512 concreteValue);
+        Register(const RegisterSpec& spec);
 
         //! Constructor.
         Register(const RegisterSpec& spec, triton::uint512 concreteValue);
 
         //! Constructor.
-        explicit Register(const RegisterSpec& spec);
+        Register(const triton::arch::CpuInterface&, triton::arch::registers_e regId);
+
+        //! Constructor.
+        Register(const triton::arch::CpuInterface&, triton::arch::registers_e regId, triton::uint512 concreteValue);
 
         //! Returns true if the register contains a concrete value.
         bool hasConcreteValue(void) const;
@@ -126,11 +135,14 @@ namespace triton {
         //! Sets the concrete value of the register.
         void setConcreteValue(triton::uint512 concreteValue);
 
-        //! Compare two registers
-        bool operator==(const Register& reg) const;
+        //! Compare two Register
+        bool operator==(const Register& other) const;
 
-        //! Compare two registers
-        bool operator!=(const Register& reg) const;
+        //! Compare two Register
+        bool operator!=(const Register& other) const;
+
+        //! Copies a Register.
+        void operator=(const Register& other);
     };
 
     //! Displays a Register.

--- a/src/libtriton/includes/triton/solverModel.hpp
+++ b/src/libtriton/includes/triton/solverModel.hpp
@@ -36,8 +36,7 @@ namespace triton {
 
       //! \class SolverModel
       /*! \brief This class is used to represent a constraint model solved. */
-      class SolverModel
-      {
+      class SolverModel {
         protected:
           //! The name of the variable. Names are always something like this: SymVar_X.
           std::string name;

--- a/src/testers/unittests/test_semantics.py
+++ b/src/testers/unittests/test_semantics.py
@@ -149,6 +149,27 @@ class TestIRQemu(unittest.TestCase):
 
             self.assertTrue(ret)
 
+            try:
+                for se in instruction.getSymbolicExpressions():
+                    str(se.getAst())
+
+                for x, y in instruction.getLoadAccess():
+                    str(y)
+
+                for x, y in instruction.getStoreAccess():
+                    str(y)
+
+                for x, y in instruction.getReadRegisters():
+                    str(y)
+
+                for x, y in instruction.getWrittenRegisters():
+                    str(y)
+
+                for x, y in instruction.getReadImmediates():
+                    str(y)
+            except:
+                self.fail("str(ast): raised unexpectedly!")
+
             # Simulate routines
             self.hooking_handler()
 

--- a/src/testers/unittests/test_semantics.py
+++ b/src/testers/unittests/test_semantics.py
@@ -9,6 +9,36 @@ from triton import (TritonContext, ARCH, Instruction, OPCODE, Elf, REG, CPUSIZE,
                     MemoryAccess, MODE)
 
 
+def checkAstIntegrity(instruction):
+    """
+    This function check if all ASTs under an Instruction class are still
+    available.
+    """
+    try:
+        for se in instruction.getSymbolicExpressions():
+            str(se.getAst())
+
+        for x, y in instruction.getLoadAccess():
+            str(y)
+
+        for x, y in instruction.getStoreAccess():
+            str(y)
+
+        for x, y in instruction.getReadRegisters():
+            str(y)
+
+        for x, y in instruction.getWrittenRegisters():
+            str(y)
+
+        for x, y in instruction.getReadImmediates():
+            str(y)
+
+        return True
+
+    except:
+        return False
+
+
 class TestIR(unittest.TestCase):
 
     """Test IR."""
@@ -148,27 +178,7 @@ class TestIRQemu(unittest.TestCase):
                 break
 
             self.assertTrue(ret)
-
-            try:
-                for se in instruction.getSymbolicExpressions():
-                    str(se.getAst())
-
-                for x, y in instruction.getLoadAccess():
-                    str(y)
-
-                for x, y in instruction.getStoreAccess():
-                    str(y)
-
-                for x, y in instruction.getReadRegisters():
-                    str(y)
-
-                for x, y in instruction.getWrittenRegisters():
-                    str(y)
-
-                for x, y in instruction.getReadImmediates():
-                    str(y)
-            except:
-                self.fail("str(ast): raised unexpectedly!")
+            self.assertTrue(checkAstIntegrity(instruction))
 
             # Simulate routines
             self.hooking_handler()

--- a/src/testers/unittests/test_simulation.py
+++ b/src/testers/unittests/test_simulation.py
@@ -33,6 +33,27 @@ class DefCamp2015(object):
             # Process
             self.Triton.processing(instruction)
 
+            try:
+                for se in instruction.getSymbolicExpressions():
+                    str(se.getAst())
+
+                for x, y in instruction.getLoadAccess():
+                    str(y)
+
+                for x, y in instruction.getStoreAccess():
+                    str(y)
+
+                for x, y in instruction.getReadRegisters():
+                    str(y)
+
+                for x, y in instruction.getWrittenRegisters():
+                    str(y)
+
+                for x, y in instruction.getReadImmediates():
+                    str(y)
+            except:
+                self.fail("str(ast): raised unexpectedly!")
+
             # 40078B: cmp eax, 1
             # eax must be equal to 1 at each round.
             if instruction.getAddress() == 0x40078B:
@@ -203,6 +224,27 @@ class SeedCoverage(object):
             # Process everything
             self.Triton.processing(inst)
 
+            try:
+                for se in inst.getSymbolicExpressions():
+                    str(se.getAst())
+
+                for x, y in inst.getLoadAccess():
+                    str(y)
+
+                for x, y in inst.getStoreAccess():
+                    str(y)
+
+                for x, y in inst.getReadRegisters():
+                    str(y)
+
+                for x, y in inst.getWrittenRegisters():
+                    str(y)
+
+                for x, y in inst.getReadImmediates():
+                    str(y)
+            except:
+                self.fail("str(ast): raised unexpectedly!")
+
             # Next instruction
             ip = self.Triton.buildSymbolicRegister(self.Triton.Register(REG.X86_64.RIP)).evaluate()
 
@@ -321,6 +363,27 @@ class Emu1(object):
 
             # Check if triton doesn't supports this instruction
             self.assertTrue(self.Triton.processing(instruction))
+
+            try:
+                for se in instruction.getSymbolicExpressions():
+                    str(se.getAst())
+
+                for x, y in instruction.getLoadAccess():
+                    str(y)
+
+                for x, y in instruction.getStoreAccess():
+                    str(y)
+
+                for x, y in instruction.getReadRegisters():
+                    str(y)
+
+                for x, y in instruction.getWrittenRegisters():
+                    str(y)
+
+                for x, y in instruction.getReadImmediates():
+                    str(y)
+            except:
+                self.fail("str(ast): raised unexpectedly!")
 
             pc = self.Triton.getConcreteRegisterValue(self.Triton.Register(REG.X86_64.RIP))
 
@@ -446,6 +509,26 @@ class TestSymbolicEngineConcreteAst(BaseTestSimulation, unittest.TestCase):
         pass
 
     @unittest.skip("No defcamp with concretization")
+    def test_defcamp_2015(self):
+        pass
+
+
+class TestSymbolicEngineDisable(BaseTestSimulation, unittest.TestCase):
+
+    """Testing the emulation with the symbolic engine disabled."""
+
+    def setUp(self):
+        """Define the arch and modes."""
+        self.Triton = TritonContext()
+        self.Triton.setArchitecture(ARCH.X86_64)
+        self.Triton.enableSymbolicEngine(False)
+        super(TestSymbolicEngineDisable, self).setUp()
+
+    @unittest.skip("Not possible.")
+    def test_seed_coverage(self):
+        pass
+
+    @unittest.skip("Not possiblen")
     def test_defcamp_2015(self):
         pass
 

--- a/src/testers/unittests/test_simulation.py
+++ b/src/testers/unittests/test_simulation.py
@@ -9,6 +9,36 @@ from triton import (Instruction, ARCH, REG, CPUSIZE, MemoryAccess, Elf, MODE,
                     TritonContext)
 
 
+def checkAstIntegrity(instruction):
+    """
+    This function check if all ASTs under an Instruction class are still
+    available.
+    """
+    try:
+        for se in instruction.getSymbolicExpressions():
+            str(se.getAst())
+
+        for x, y in instruction.getLoadAccess():
+            str(y)
+
+        for x, y in instruction.getStoreAccess():
+            str(y)
+
+        for x, y in instruction.getReadRegisters():
+            str(y)
+
+        for x, y in instruction.getWrittenRegisters():
+            str(y)
+
+        for x, y in instruction.getReadImmediates():
+            str(y)
+
+        return True
+
+    except:
+        return False
+
+
 class DefCamp2015(object):
 
     """Test for DefCamp2015 challenge."""
@@ -32,27 +62,7 @@ class DefCamp2015(object):
 
             # Process
             self.Triton.processing(instruction)
-
-            try:
-                for se in instruction.getSymbolicExpressions():
-                    str(se.getAst())
-
-                for x, y in instruction.getLoadAccess():
-                    str(y)
-
-                for x, y in instruction.getStoreAccess():
-                    str(y)
-
-                for x, y in instruction.getReadRegisters():
-                    str(y)
-
-                for x, y in instruction.getWrittenRegisters():
-                    str(y)
-
-                for x, y in instruction.getReadImmediates():
-                    str(y)
-            except:
-                self.fail("str(ast): raised unexpectedly!")
+            self.assertTrue(checkAstIntegrity(instruction))
 
             # 40078B: cmp eax, 1
             # eax must be equal to 1 at each round.
@@ -223,27 +233,7 @@ class SeedCoverage(object):
 
             # Process everything
             self.Triton.processing(inst)
-
-            try:
-                for se in inst.getSymbolicExpressions():
-                    str(se.getAst())
-
-                for x, y in inst.getLoadAccess():
-                    str(y)
-
-                for x, y in inst.getStoreAccess():
-                    str(y)
-
-                for x, y in inst.getReadRegisters():
-                    str(y)
-
-                for x, y in inst.getWrittenRegisters():
-                    str(y)
-
-                for x, y in inst.getReadImmediates():
-                    str(y)
-            except:
-                self.fail("str(ast): raised unexpectedly!")
+            self.assertTrue(checkAstIntegrity(inst))
 
             # Next instruction
             ip = self.Triton.buildSymbolicRegister(self.Triton.Register(REG.X86_64.RIP)).evaluate()
@@ -363,27 +353,7 @@ class Emu1(object):
 
             # Check if triton doesn't supports this instruction
             self.assertTrue(self.Triton.processing(instruction))
-
-            try:
-                for se in instruction.getSymbolicExpressions():
-                    str(se.getAst())
-
-                for x, y in instruction.getLoadAccess():
-                    str(y)
-
-                for x, y in instruction.getStoreAccess():
-                    str(y)
-
-                for x, y in instruction.getReadRegisters():
-                    str(y)
-
-                for x, y in instruction.getWrittenRegisters():
-                    str(y)
-
-                for x, y in instruction.getReadImmediates():
-                    str(y)
-            except:
-                self.fail("str(ast): raised unexpectedly!")
+            self.assertTrue(checkAstIntegrity(instruction))
 
             pc = self.Triton.getConcreteRegisterValue(self.Triton.Register(REG.X86_64.RIP))
 


### PR DESCRIPTION
- Add more tests
- Fix segfault on OSX
- Fix #552
- Add testing with Linux clang 3.8 on Travis
- Fix memory leaks over the CPython API
- Fix some wrong behaviors related to implicit / explicit semantics
- Remove useless code