### PR TITLE
Pass Z3 header locations through CMake

### DIFF
--- a/src/examples/cpp/CMakeLists.txt
+++ b/src/examples/cpp/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(${Z3_INCLUDE_DIR})
 enable_testing()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")

--- a/src/tracer/pin/CMakeLists.txt
+++ b/src/tracer/pin/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(PROJECT_PINTOOL "pintool")
 add_definitions(-DTRITON_PINTOOL)
+include_directories(${Z3_INCLUDE_DIR})
 
 # Root directory of the Pin toolkit
 set(PIN_ROOT "${CMAKE_SOURCE_DIR}/../../.." CACHE PATH "Path to pin root directory")


### PR DESCRIPTION
If Z3 is installed in a non-standard location, but its path is given to cmake (say via `CMAKE_PREFIX_PATH`) then configuration will succeed  but compilation will fail because the include paths for Z3 are not propagated to the right place. The right fix here might be to have a `TRITON_INCLUDES` variable that wraps up all the includes necessary to compile something that includes a Triton header, but this quick fixes it for me for now. 