### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:15.10
-MAINTAINER Pete Markowsky <pete@markowsky.us>
+FROM ubuntu:16.04
+LABEL maintainer="David Manouchehri"
 RUN apt-get update && apt-get dist-upgrade -y && \
     apt-get install -y git cmake build-essential clang ca-certificates curl \
     unzip libboost-dev python-dev python-pip && apt-get clean


### PR DESCRIPTION
Main mirrors for Ubuntu 15.10 are no longer up, so we should switch to 16.04 (Xenial).

Tested locally and also builds fine on Docker Hub. 

[`docker pull thawsystems/triton`](https://hub.docker.com/r/thawsystems/triton/builds/)