### PR TITLE
Changed solverModel destructor

### DIFF
--- a/src/libtriton/includes/solverModel.hpp
+++ b/src/libtriton/includes/solverModel.hpp
@@ -79,7 +79,7 @@ namespace triton {
           SolverModel(const SolverModel& other);
 
           //! Destructor.
-          virtual ~SolverModel();
+          ~SolverModel();
 
           //! Copies a SolverModel
           void operator=(const SolverModel& other);


### PR DESCRIPTION
solverModel destructor is not virtual anymore to be able to compile
Triton with Ponce.