### PR TITLE
Remove assumptions that the system python is python2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,7 +91,7 @@ install:
   - cmd: echo Downloading LIEF...
   - cmd: appveyor DownloadFile https://github.com/lief-project/LIEF/releases/download/0.7.0/%LIEF_ZIP%
   - cmd: echo Install LIEF...
-  - cmd: python -m pip install %LIEF_ZIP%
+  - cmd: python2 -m pip install %LIEF_ZIP%
 
 #build:
 # Build manually until we can build every target. For now, we can't run test-python

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,7 +91,7 @@ install:
   - cmd: echo Downloading LIEF...
   - cmd: appveyor DownloadFile https://github.com/lief-project/LIEF/releases/download/0.7.0/%LIEF_ZIP%
   - cmd: echo Install LIEF...
-  - cmd: python2 -m pip install %LIEF_ZIP%
+  - cmd: python -m pip install %LIEF_ZIP%
 
 #build:
 # Build manually until we can build every target. For now, we can't run test-python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(PYTHONPATH_CMD ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR
 if(PYTHON_BINDINGS)
     find_package(PythonInterp 2.7 REQUIRED)
     add_custom_target(test-python
-        COMMAND ${PYTHONPATH_CMD} python2 -m unittest discover ${CMAKE_SOURCE_DIR}/src/testers/unittests
+        COMMAND ${PYTHONPATH_CMD} ${PYTHON_EXECUTABLE} -m unittest discover ${CMAKE_SOURCE_DIR}/src/testers/unittests
         DEPENDS python-triton
     )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(PYTHONPATH_CMD ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR
 if(PYTHON_BINDINGS)
     find_package(PythonInterp 2.7 REQUIRED)
     add_custom_target(test-python
-        COMMAND ${PYTHONPATH_CMD} python -m unittest discover ${CMAKE_SOURCE_DIR}/src/testers/unittests
+        COMMAND ${PYTHONPATH_CMD} python2 -m unittest discover ${CMAKE_SOURCE_DIR}/src/testers/unittests
         DEPENDS python-triton
     )
 else()


### PR DESCRIPTION
The calls to the unittests failed when "python" was a link to "python3" and not to "python2" and thus make check failed at least on an Arch Linux.

I only tested it without the PIN integration, but I don't think this anything.