### PR TITLE
TRITON_EXPORT must be set to nothing in Windows if static lib created

### DIFF
--- a/src/libtriton/includes/triton/dllexport.hpp
+++ b/src/libtriton/includes/triton/dllexport.hpp
@@ -15,6 +15,8 @@
     #else
       #define TRITON_EXPORT __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
     #endif
+  #elif BUILDING_LIB
+    #define TRITON_EXPORT
   #else
     #ifdef __GNUC__
       #define TRITON_EXPORT __attribute__ ((dllimport))


### PR DESCRIPTION
If libtriton is created as dll then it works but if you try to link your project against libtriton as library it will produce linker errors.

If in Windows linking against libtriton as library (.lib) then use `BUILDING_LIB` as preprocessor.

