### PR TITLE
Type mismatch on install

### DIFF
--- a/src/libtriton/ast/z3/tritonToZ3Ast.cpp
+++ b/src/libtriton/ast/z3/tritonToZ3Ast.cpp
@@ -25,7 +25,12 @@ namespace triton {
 
 
     triton::__uint TritonToZ3Ast::getUintValue(const z3::expr& expr) {
-      triton::__uint result = 0;
+      #if defined(__x86_64__) || defined(_M_X64)
+      uint64_t result = 0;
+      #endif
+      #if defined(__i386) || defined(_M_IX86)
+      uint32_t result = 0;
+      #endif
 
       if (!expr.is_int())
         throw triton::exceptions::Exception("TritonToZ3Ast::getUintValue(): The ast is not a numerical value.");


### PR DESCRIPTION
I've followed your [instruction](https://triton.quarkslab.com/documentation/doxygen/#install_sec) to install libtriton, but when I tried to install it with `sudo make -j2 install` this is what I got:
```
Triton/src/libtriton/ast/z3/tritonToZ3Ast.cpp: In member function ‘triton::__uint triton::ast::TritonToZ3Ast
::getUintValue(const z3::expr&)’:
Triton/src/libtriton/ast/z3/tritonToZ3Ast.cpp:34:50: error: invalid conversion from ‘triton::__uint* {aka lo
ng long unsigned int*}’ to ‘uint64_t* {aka long unsigned int*}’ [-fpermissive]
       Z3_get_numeral_uint64(this->context, expr, &result);
                                                  ^~~~~~~
In file included from /usr/include/z3.h:28:0,
                 from /usr/include/z3++.h:28,
                 from Triton/src/libtriton/includes/triton/tritonToZ3Ast.hpp:11,
                 from Triton/src/libtriton/ast/z3/tritonToZ3Ast.cpp:10:
/usr/include/z3_api.h:4456:20: note:   initializing argument 3 of ‘Z3_bool Z3_get_numeral_uint64(Z3_context, Z3_ast, uint64_t*)’
     Z3_bool Z3_API Z3_get_numeral_uint64(Z3_context c, Z3_ast v, uint64_t* u);
                    ^~~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: error: unrecognized command line option ‘-Wno-mismatched-tags’ [-Werror]
cc1plus: all warnings being treated as errors
src/libtriton/CMakeFiles/triton.dir/build.make:552: recipe for target 'src/libtriton/CMakeFiles/triton.dir/ast/z3/tritonToZ3Ast.cpp.o' failed
make[2]: *** [src/libtriton/CMakeFiles/triton.dir/ast/z3/tritonToZ3Ast.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:1147: recipe for target 'src/libtriton/CMakeFiles/triton.dir/all' failed
make[1]: *** [src/libtriton/CMakeFiles/triton.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2
```
**Machine** info:
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
Model name:          Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
**OS** info:
Distributor ID: Ubuntu
Description:    Ubuntu Bionic Beaver (development branch)
Release:        18.04
Codename:       bionic

The error disappears also by changing `triton:_uint` from `unsigned long long int` to `unsigned long int`, but since this change felt too wide, I opted for the one in the one in the PR