### PR TITLE
Create a real interface for SMT solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ endif()
 # FIXME: We should move the tracer away to not link with these libraries
 
 if(Z3_INTERFACE)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DZ3_INTERFACE")
 	# Find Z3
 	if(NOT Z3_INCLUDE_DIRS)
 		set(Z3_INCLUDE_DIRS "$ENV{Z3_INCLUDE_DIRS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(KERNEL4 "Pin will run on a Linux's kernel v4" ON)
 option(PINTOOL "Build Triton with the Pin tool as tracer" OFF)
 option(PYTHON_BINDINGS "Enable Python bindings into the libtriton" ON)
 option(STATICLIB "Build a static library" OFF)
+option(Z3_INTERFACE "Use Z3 as SMT solver" ON)
 
 if(PINTOOL AND NOT PYTHON_BINDINGS)
     MESSAGE(FATAL_ERROR "You can't have pintools without python binding.")
@@ -133,23 +134,25 @@ endif()
 # Look for dependencies as they may be required by examples
 # FIXME: We should move the tracer away to not link with these libraries
 
-# Find Z3
-if(NOT Z3_INCLUDE_DIRS)
-    set(Z3_INCLUDE_DIRS "$ENV{Z3_INCLUDE_DIRS}")
-endif()
+if(Z3_INTERFACE)
+	# Find Z3
+	if(NOT Z3_INCLUDE_DIRS)
+		set(Z3_INCLUDE_DIRS "$ENV{Z3_INCLUDE_DIRS}")
+	endif()
 
-if(NOT Z3_LIBRARIES)
-    set(Z3_LIBRARIES "$ENV{Z3_LIBRARIES}")
-endif()
+	if(NOT Z3_LIBRARIES)
+		set(Z3_LIBRARIES "$ENV{Z3_LIBRARIES}")
+	endif()
 
-if(NOT Z3_INCLUDE_DIRS AND NOT Z3_LIBRARIES)
-    find_package(Z3 REQUIRED)
-    if(NOT Z3_FOUND)
-        message(FATAL_ERROR "Z3 not found")
-    endif()
-endif()
+	if(NOT Z3_INCLUDE_DIRS AND NOT Z3_LIBRARIES)
+		find_package(Z3 REQUIRED)
+		if(NOT Z3_FOUND)
+			message(FATAL_ERROR "Z3 not found")
+		endif()
+	endif()
 
-include_directories(${Z3_INCLUDE_DIRS})
+	include_directories(${Z3_INCLUDE_DIRS})
+endif()
 
 # Find Capstone
 if(NOT CAPSTONE_INCLUDE_DIRS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,4 @@
 add_subdirectory(libtriton)
 add_subdirectory(tracer)
-
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    # Disable exemples for windows as linkage doesn't work. Exported function should
-    # be marked as exported on windows.
-    add_subdirectory(examples)
-else()
-    enable_testing()
-    add_test(DummyTest echo "Windows is awesome")
-endif()
-
+add_subdirectory(examples)
 add_subdirectory(testers)

--- a/src/examples/cpp/CMakeLists.txt
+++ b/src/examples/cpp/CMakeLists.txt
@@ -5,8 +5,10 @@ if(NOT STATICLIB)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=address -shared-libasan")
     endif()
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
-
+	if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+	endif()
+	
     add_executable(taint_reg taint_reg.cpp)
     target_link_libraries(taint_reg triton)
     add_test(TaintRegister taint_reg)
@@ -31,4 +33,8 @@ if(NOT STATICLIB)
     target_link_libraries(constraint triton)
     add_test(Constraint constraint)
     add_dependencies(check constraint)
+	
+	add_executable(custom_solver customSolver.cpp myCustomSolver.cpp)
+    target_link_libraries(custom_solver triton)
+    
 endif()

--- a/src/examples/cpp/customSolver.cpp
+++ b/src/examples/cpp/customSolver.cpp
@@ -1,0 +1,89 @@
+/*
+** Output:
+**
+**  RAX expr: (bvxor ((_ extract 63 0) SymVar_0) (_ bv287454020 64))
+**  constraint: (= (bvxor ((_ extract 63 0) SymVar_0) (_ bv287454020 64)) (_ bv0 64))
+**  Model:
+**    - Variable id  : 0
+**    - Variable name: SymVar_0
+**    - Value        : 11223344
+**
+*/
+
+
+#include <iostream>
+#include <triton/api.hpp>
+#include <triton/x86Specifications.hpp>
+#include "myCustomSolver.h"
+
+
+using namespace triton;
+using namespace triton::arch;
+
+
+struct op {
+	unsigned int    addr;
+	unsigned char*  inst;
+	unsigned int    size;
+};
+
+struct op trace[] = {
+	{ 0x400017, (unsigned char *)"\x48\x35\x44\x33\x22\x11", 6 }, /* xor rax, 0x11223344 */
+	{ 0x0, nullptr, 0 }
+};
+
+
+
+int main(int ac, const char **av) {
+
+	triton::API api;
+	/* Set the arch */
+	api.setArchitecture(ARCH_X86_64);
+
+	/* Create and set your custome solver instance*/
+	triton::engines::solver::MyCustomSolver* mysolver_instance =  new triton::engines::solver::MyCustomSolver(api.getSymbolicEngine());
+	api.setSolver(mysolver_instance);
+	
+	/* Build an instruction */
+	Instruction inst;
+
+	/* Setup opcode */
+	inst.setOpcode(trace[0].inst, trace[0].size);
+
+	/* Define RAX as symbolic variable */
+	api.convertRegisterToSymbolicVariable(triton::arch::Register(api.getRegister(ID_REG_RAX)));
+
+	/* Process everything */
+	api.processing(inst);
+
+	/* Get the RAX symbolic ID */
+	auto raxSym = api.getSymbolicRegister(api.getRegister(ID_REG_RAX));
+
+	/* Get the RAX full AST */
+	auto raxFullAst = api.unrollAst(raxSym->getAst());
+
+	/* Display RAX's AST*/
+	std::cout << "RAX expr: " << raxFullAst << std::endl;
+
+	/* Get the context to create and ast constraint*/
+	auto& C = api.getAstContext();
+
+	/* Modify RAX's AST to build the constraint */
+	auto constraint = C.equal(raxFullAst, C.bv(0, raxFullAst->getBitvectorSize()));
+
+	/* Display the AST */
+	std::cout << "constraint: " << constraint << std::endl;
+
+	/* Ask a model using the custome solver*/
+	auto model = api.getModel(constraint);
+
+	/* Display all symbolic variable value contained in the model */
+	std::cout << "Model:" << std::endl;
+	for (auto it = model.begin(); it != model.end(); it++) {
+		std::cout << "  - Variable id  : " << it->first << std::endl;
+		std::cout << "  - Variable name: " << it->second.getName() << std::endl;
+		std::cout << "  - Value        : " << std::hex << it->second.getValue() << std::endl;
+	}
+
+	return 0;
+}

--- a/src/examples/cpp/myCustomSolver.cpp
+++ b/src/examples/cpp/myCustomSolver.cpp
@@ -1,0 +1,52 @@
+
+
+#include <string>                        // for string
+
+#include <triton/astContext.hpp>         // for AstContext
+#include <triton/exceptions.hpp>         // for SolverEngine
+
+#include "MyCustomSolver.h"
+
+namespace triton {
+	namespace engines {
+		namespace solver {
+
+			MyCustomSolver::MyCustomSolver(triton::engines::symbolic::SymbolicEngine* symbolicEngine) {
+				if (symbolicEngine == nullptr)
+					throw triton::exceptions::SolverEngine("Z3Solver::Z3Solver(): The symbolicEngine API cannot be null.");
+				this->symbolicEngine = symbolicEngine;
+			}
+
+
+			MyCustomSolver::MyCustomSolver(const MyCustomSolver& other) {
+				this->symbolicEngine = other.symbolicEngine;
+			}
+
+
+			MyCustomSolver& MyCustomSolver::operator=(const MyCustomSolver& other) {
+				this->symbolicEngine = other.symbolicEngine;
+				return *this;
+			}
+
+
+			std::list<std::map<triton::uint32, SolverModel>> MyCustomSolver::getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit) const {
+				std::list<std::map<triton::uint32, SolverModel>> ret;
+				// Place your code here to solve the formulas
+				return ret;
+			}
+
+
+			std::map<triton::uint32, SolverModel> MyCustomSolver::getModel(const triton::ast::SharedAbstractNode& node) const {
+				std::map<triton::uint32, SolverModel> ret;
+				ret[0] = SolverModel("solver_Name", 0x31337);
+				return ret;
+			}
+
+
+			std::string MyCustomSolver::getName(void) const {
+				return "MyCustomSolver";
+			}
+
+		};
+	};
+};

--- a/src/examples/cpp/myCustomSolver.h
+++ b/src/examples/cpp/myCustomSolver.h
@@ -1,0 +1,89 @@
+//! \file
+/*
+**  Copyright (C) - Triton
+**
+**  This program is under the terms of the BSD License.
+*/
+
+#pragma once
+
+#include <list>
+#include <map>
+#include <string>
+
+#include <triton/ast.hpp>
+#include <triton/dllexport.hpp>
+#include <triton/solverInterface.hpp>
+#include <triton/solverModel.hpp>
+#include <triton/symbolicEngine.hpp>
+#include <triton/tritonTypes.hpp>
+
+
+
+//! The Triton namespace
+namespace triton {
+	/*!
+	*  \addtogroup triton
+	*  @{
+	*/
+	//! The Engines namespace
+	namespace engines {
+		/*!
+		*  \ingroup triton
+		*  \addtogroup engines
+		*  @{
+		*/
+		//! The Solver namespace
+		namespace solver {
+			/*!
+			*  \ingroup engines
+			*  \addtogroup solver
+			*  @{
+			*/
+
+			//! \class Z3Solver
+			/*! \brief Solver engine using z3. */
+			class MyCustomSolver : public SolverInterface {
+			private:
+				//! Symbolic Engine API
+				triton::engines::symbolic::SymbolicEngine* symbolicEngine;
+
+			public:
+				//! Constructor.
+				TRITON_EXPORT MyCustomSolver(triton::engines::symbolic::SymbolicEngine* symbolicEngine);
+
+				//! Constructor by copy.
+				TRITON_EXPORT MyCustomSolver(const MyCustomSolver& other);
+
+				//! Operator.
+				TRITON_EXPORT MyCustomSolver& operator=(const MyCustomSolver& other);
+
+				//! Computes and returns a model from a symbolic constraint.
+				/*! \brief map of symbolic variable id -> model
+				*
+				* \details
+				* **item1**: symbolic variable id<br>
+				* **item2**: model
+				*/
+				TRITON_EXPORT std::map<triton::uint32, SolverModel> getModel(const triton::ast::SharedAbstractNode& node) const;
+
+				//! Computes and returns several models from a symbolic constraint. The `limit` is the number of models returned.
+				/*! \brief list of map of symbolic variable id -> model
+				*
+				* \details
+				* **item1**: symbolic variable id<br>
+				* **item2**: model
+				*/
+				TRITON_EXPORT std::list<std::map<triton::uint32, SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit) const;
+
+				//! Returns the name of this solver.
+				TRITON_EXPORT std::string getName(void) const;
+			};
+
+			/*! @} End of solver namespace */
+		};
+		/*! @} End of engines namespace */
+	};
+	/*! @} End of triton namespace */
+};
+

--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -69,13 +69,9 @@ set(LIBTRITON_SOURCE_FILES
     ast/astContext.cpp
     ast/representations/astPythonRepresentation.cpp
     ast/representations/astRepresentation.cpp
-    ast/representations/astSmtRepresentation.cpp
-    ast/z3/tritonToZ3Ast.cpp
-    ast/z3/z3Interface.cpp
-    ast/z3/z3ToTritonAst.cpp
+    ast/representations/astSmtRepresentation.cpp  
     callbacks/callbacks.cpp
-    engines/solver/solverModel.cpp
-    engines/solver/z3/z3Solver.cpp
+    engines/solver/solverModel.cpp   
     engines/symbolic/pathConstraint.cpp
     engines/symbolic/pathManager.cpp
     engines/symbolic/symbolicEngine.cpp
@@ -87,6 +83,17 @@ set(LIBTRITON_SOURCE_FILES
     os/unix/syscallNumberToString.cpp
     utils/coreUtils.cpp
 )
+
+if(Z3_INTERFACE)
+	set(Z3_SOURCE_FILES
+	ast/z3/tritonToZ3Ast.cpp
+    ast/z3/z3Interface.cpp
+    ast/z3/z3ToTritonAst.cpp
+	engines/solver/z3/z3Solver.cpp
+	)
+else()
+    set(Z3_SOURCE_FILES)
+endif()
 
 if(PYTHON_BINDINGS)
     set(LIBTRITON_PYTHON_SOURCE_FILES
@@ -198,7 +205,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "
 endif()
 
 # Define library's properties
-add_library(${PROJECT_LIBTRITON} ${LIBTRITON_KIND_LINK} ${LIBTRITON_SOURCE_FILES} ${LIBTRITON_PYTHON_SOURCE_FILES})
+add_library(${PROJECT_LIBTRITON} ${LIBTRITON_KIND_LINK} ${LIBTRITON_SOURCE_FILES} ${LIBTRITON_PYTHON_SOURCE_FILES} ${Z3_SOIRCE_FILE})
 add_dependencies(${PROJECT_LIBTRITON} gen-syscall32 gen-syscall64)
 
 # Link Triton's dependencies

--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -949,6 +949,8 @@ namespace triton {
 
 
   void API::setSolver(triton::engines::solver::SolverInterface* solver) {
+	  if (this->solver)
+		  delete this->solver;
 	  this->solver = solver;
   }
 

--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -427,13 +427,17 @@ namespace triton {
       delete this->solver;
       delete this->symbolic;
       delete this->taint;
+#ifdef Z3_INTERFACE
       delete this->z3Interface;
+#endif
 
       this->irBuilder           = nullptr;
       this->solver              = nullptr;
       this->symbolic            = nullptr;
       this->taint               = nullptr;
+#ifdef Z3_INTERFACE
       this->z3Interface         = nullptr;
+#endif
     }
 
     // Use default modes.
@@ -941,6 +945,11 @@ namespace triton {
   void API::checkSolver(void) const {
     if (!this->solver)
       throw triton::exceptions::API("API::checkSolver(): Solver engine is undefined, you should define an architecture first.");
+  }
+
+
+  void API::setSolver(triton::engines::solver::SolverInterface* solver) {
+	  this->solver = solver;
   }
 
 

--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -397,9 +397,13 @@ namespace triton {
     if (this->symbolic == nullptr)
       throw triton::exceptions::API("API::initEngines(): No enough memory.");
 
+#ifdef Z3_INTERFACE
     this->solver = new(std::nothrow) triton::engines::solver::Z3Solver(this->symbolic);
     if (this->solver == nullptr)
       throw triton::exceptions::API("API::initEngines(): No enough memory.");
+#else
+	this->solver = nullptr; // Needs to be implemented in the client
+#endif
 
     this->taint = new(std::nothrow) triton::engines::taint::TaintEngine(this->symbolic, *this->getCpu());
     if (this->taint == nullptr)
@@ -409,9 +413,11 @@ namespace triton {
     if (this->irBuilder == nullptr)
       throw triton::exceptions::API("API::initEngines(): No enough memory.");
 
+#ifdef Z3_INTERFACE
     this->z3Interface = new(std::nothrow) triton::ast::Z3Interface(this->symbolic);
     if (this->z3Interface == nullptr)
       throw triton::exceptions::API("API::initEngines(): No enough memory.");
+#endif
   }
 
 
@@ -769,10 +775,12 @@ namespace triton {
 
   triton::ast::SharedAbstractNode API::processSimplification(const triton::ast::SharedAbstractNode& node, bool z3) const {
     this->checkSymbolic();
+#ifdef Z3_INTERFACE
     if (z3 == true) {
       auto snode = this->processZ3Simplification(node);
       return this->symbolic->processSimplification(snode);
     }
+#endif
     return this->symbolic->processSimplification(node);
   }
 
@@ -948,7 +956,7 @@ namespace triton {
   }
 
 
-
+#ifdef Z3_INTERFACE
   /* Z3 interface API ============================================================================== */
 
   void API::checkZ3Interface(void) const {
@@ -967,7 +975,7 @@ namespace triton {
     this->checkZ3Interface();
     return this->z3Interface->simplify(node);
   }
-
+#endif
 
 
   /* Taint engine API ============================================================================== */

--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -12,7 +12,13 @@
 #include <triton/astContext.hpp>
 #include <triton/astRepresentation.hpp>
 #include <triton/exceptions.hpp>
+
+
+#ifdef Z3_INTERFACE
 #include <triton/tritonToZ3Ast.hpp>
+#else
+#include <triton/cpuSize.hpp>
+#endif
 
 
 

--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -18,6 +18,7 @@
 #include <triton/tritonToZ3Ast.hpp>
 #else
 #include <triton/cpuSize.hpp>
+#include <triton/symbolicEngine.hpp>
 #endif
 
 

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -65,9 +65,10 @@ namespace triton {
         //! The IR builder.
         triton::arch::IrBuilder* irBuilder = nullptr;
 
+#ifdef Z3_INTERFACE
         //! The Z3 interface between Triton and Z3.
         triton::ast::Z3Interface* z3Interface = nullptr;
-
+#endif
 
       public:
         //! Constructor of the API.
@@ -477,6 +478,9 @@ namespace triton {
 
 
         /* Solver engine API ============================================================================= */
+
+		//! [**solver api**] - Sets a SMT solver to be used by Triton.
+		TRITON_EXPORT void setSolver(triton::engines::solver::SolverInterface* solver);
 
         //! [**solver api**] - Raises an exception if the solver engine is not initialized.
         TRITON_EXPORT void checkSolver(void) const;

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -500,7 +500,7 @@ namespace triton {
         TRITON_EXPORT std::list<std::map<triton::uint32, triton::engines::solver::SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit) const;
 
 
-
+#ifdef Z3_INTERFACE
         /* Z3 interface API ============================================================================== */
 
         //! [**z3 api**] - Raises an exception if the z3 interface is not initialized.
@@ -511,7 +511,7 @@ namespace triton {
 
         //! [**z3 api**] - Converts a Triton's AST to a Z3's AST, perform a Z3 simplification and returns a Triton's AST.
         TRITON_EXPORT triton::ast::SharedAbstractNode processZ3Simplification(const triton::ast::SharedAbstractNode& node) const;
-
+#endif
 
 
         /* Taint engine API ============================================================================== */


### PR DESCRIPTION
 Fix #663 

- Added the API `setSolver` to set a custom SMT solver.
- I've created examples on how to use a custom Solver interface.
- I've removed a CMakeLists condition to build tests for Windows too.
- Restrict some flags to only apply to *NIX builds.