### PR TITLE
Semantics fixes

### DIFF
--- a/src/libtriton/arch/x86/x86Semantics.cpp
+++ b/src/libtriton/arch/x86/x86Semantics.cpp
@@ -8624,7 +8624,6 @@ namespace triton {
         auto dst1       = triton::arch::OperandWrapper(this->architecture->getRegister(ID_REG_EDI));
         auto dst2       = triton::arch::OperandWrapper(this->architecture->getRegister(ID_REG_ESI));
         auto dst3       = triton::arch::OperandWrapper(this->architecture->getRegister(ID_REG_EBP));
-        auto dst4       = triton::arch::OperandWrapper(this->architecture->getRegister(ID_REG_ESP));
         auto dst5       = triton::arch::OperandWrapper(this->architecture->getRegister(ID_REG_EBX));
         auto dst6       = triton::arch::OperandWrapper(this->architecture->getRegister(ID_REG_EDX));
         auto dst7       = triton::arch::OperandWrapper(this->architecture->getRegister(ID_REG_ECX));
@@ -8632,7 +8631,6 @@ namespace triton {
         auto src1       = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue+(stack.getSize() * 0), stack.getSize()));
         auto src2       = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue+(stack.getSize() * 1), stack.getSize()));
         auto src3       = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue+(stack.getSize() * 2), stack.getSize()));
-        auto src4       = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue+(stack.getSize() * 3), stack.getSize()));
         auto src5       = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue+(stack.getSize() * 4), stack.getSize()));
         auto src6       = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue+(stack.getSize() * 5), stack.getSize()));
         auto src7       = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue+(stack.getSize() * 6), stack.getSize()));
@@ -8642,7 +8640,6 @@ namespace triton {
         auto node1 = this->symbolicEngine->getOperandAst(inst, src1);
         auto node2 = this->symbolicEngine->getOperandAst(inst, src2);
         auto node3 = this->symbolicEngine->getOperandAst(inst, src3);
-        auto node4 = this->symbolicEngine->getOperandAst(inst, src4);
         auto node5 = this->symbolicEngine->getOperandAst(inst, src5);
         auto node6 = this->symbolicEngine->getOperandAst(inst, src6);
         auto node7 = this->symbolicEngine->getOperandAst(inst, src7);
@@ -8652,7 +8649,6 @@ namespace triton {
         auto expr1 = this->symbolicEngine->createSymbolicExpression(inst, node1, dst1, "POPAL EDI operation");
         auto expr2 = this->symbolicEngine->createSymbolicExpression(inst, node2, dst2, "POPAL ESI operation");
         auto expr3 = this->symbolicEngine->createSymbolicExpression(inst, node3, dst3, "POPAL EBP operation");
-        auto expr4 = this->symbolicEngine->createSymbolicExpression(inst, node4, dst4, "POPAL ESP operation");
         auto expr5 = this->symbolicEngine->createSymbolicExpression(inst, node5, dst5, "POPAL EBX operation");
         auto expr6 = this->symbolicEngine->createSymbolicExpression(inst, node6, dst6, "POPAL EDX operation");
         auto expr7 = this->symbolicEngine->createSymbolicExpression(inst, node7, dst7, "POPAL ECX operation");
@@ -8662,11 +8658,13 @@ namespace triton {
         expr1->isTainted = this->taintEngine->taintAssignment(dst1, src1);
         expr2->isTainted = this->taintEngine->taintAssignment(dst2, src2);
         expr3->isTainted = this->taintEngine->taintAssignment(dst3, src3);
-        expr4->isTainted = this->taintEngine->taintAssignment(dst4, src4);
         expr5->isTainted = this->taintEngine->taintAssignment(dst5, src5);
         expr6->isTainted = this->taintEngine->taintAssignment(dst6, src6);
         expr7->isTainted = this->taintEngine->taintAssignment(dst7, src7);
         expr8->isTainted = this->taintEngine->taintAssignment(dst8, src8);
+
+        /* Create the semantics - side effect */
+        alignAddStack_s(inst, stack.getSize() * 8);
 
         /* Upate the symbolic control flow */
         this->controlFlow_s(inst);

--- a/src/libtriton/arch/x86/x86Semantics.cpp
+++ b/src/libtriton/arch/x86/x86Semantics.cpp
@@ -9816,12 +9816,12 @@ namespace triton {
         if (src.getType() != triton::arch::OP_IMM)
           size = src.getSize();
 
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src);
+
         /* Create the semantics - side effect */
         auto  stackValue = alignSubStack_s(inst, size);
         auto  dst        = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue, size));
-
-        /* Create symbolic operands */
-        auto op1 = this->symbolicEngine->getOperandAst(inst, src);
 
         /* Create the semantics */
         auto node = this->astCtxt.zx(dst.getBitSize() - src.getBitSize(), op1);
@@ -12640,4 +12640,3 @@ namespace triton {
     }; /* x86 namespace */
   }; /* arch namespace */
 }; /* triton namespace */
-

--- a/src/libtriton/includes/triton/x86Semantics.hpp
+++ b/src/libtriton/includes/triton/x86Semantics.hpp
@@ -962,6 +962,9 @@ namespace triton {
           //! The POPAL semantics.
           void popal_s(triton::arch::Instruction& inst);
 
+          //! The POPF semantics.
+          void popf_s(triton::arch::Instruction& inst);
+
           //! The POPFD semantics.
           void popfd_s(triton::arch::Instruction& inst);
 


### PR DESCRIPTION
Fixed some stack instructions semantics.
Didn't find where to add the following unittests:
```
    def test_push_esp(self):
        ctx = TritonContext()
        ctx.setArchitecture(ARCH.X86)
        esp = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
        code = [
            (0xdeadbeaf, "\x54"),  # push esp
            (0xdeadbeb0, "\xc3"),  # ret
        ]
        for addr, opcode in code:
            insn = Instruction()
            insn.setOpcode(opcode)
            insn.setAddress(addr)
            ctx.processing(insn)
        eip = ctx.getRegisterAst(ctx.getRegister(REG.X86.EIP))
        self.assertFalse(ctx.isSat(eip != esp))

    def test_popal(self):
        ctx = TritonContext()
        ctx.setArchitecture(ARCH.X86)
        esp_old = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
        insn = Instruction()
        insn.setOpcode("\x61")  # popal
        ctx.processing(insn)
        esp_new = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
        self.assertFalse(ctx.isSat(esp_new != esp_old + 32))

    def test_popf_x86(self):
        ctx = TritonContext()
        ctx.setArchitecture(ARCH.X86)
        esp_old = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
        insn = Instruction()
        insn.setOpcode("\x66\x9d")  # popf
        ctx.processing(insn)
        esp_new = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
        self.assertFalse(ctx.isSat(esp_new != esp_old + 4))

    def test_popf_x86_64(self):
        ctx = TritonContext()
        ctx.setArchitecture(ARCH.X86_64)
        rsp_old = ctx.getRegisterAst(ctx.getRegister(REG.X86_64.RSP))
        insn = Instruction()
        insn.setOpcode("\x66\x9d")  # popf
        ctx.processing(insn)
        rsp_new = ctx.getRegisterAst(ctx.getRegister(REG.X86_64.RSP))
        self.assertFalse(ctx.isSat(rsp_new != rsp_old + 8))
```