### PR TITLE
Symbolized pointers mode

### DIFF
--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -673,7 +673,7 @@ namespace triton {
   }
 
 
-  triton::ast::SharedAbstractNode API::getMemoryAst(const triton::arch::Register& reg, triton::uint64 offset, triton::uint32 size) {
+  triton::ast::SharedAbstractNode API::getMemoryAst(const triton::ast::SharedAbstractNode& reg, triton::uint64 offset, triton::uint32 size) {
     this->checkSymbolic();
     return this->symbolic->getMemoryAst(reg, offset, size);
   }

--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -673,6 +673,12 @@ namespace triton {
   }
 
 
+  triton::ast::SharedAbstractNode API::getMemoryAst(const triton::arch::Register& reg, triton::uint64 offset, triton::uint32 size) {
+    this->checkSymbolic();
+    return this->symbolic->getMemoryAst(reg, offset, size);
+  }
+
+
   triton::ast::SharedAbstractNode API::getRegisterAst(const triton::arch::Register& reg) {
     this->checkSymbolic();
     return this->symbolic->getRegisterAst(reg);

--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -2307,7 +2307,7 @@ namespace triton {
       triton::uint512 h = this->kind, s = this->children.size();
       if (s) h = h * s;
       for (triton::uint32 index = 0; index < this->children.size(); index++)
-        h = h * triton::ast::pow(this->children[index]->hash(deep+1), index+1);
+        h = h * triton::ast::hash2n(this->children[index]->hash(deep+1), index+1);
       return triton::ast::rotl(h, deep);
     }
 
@@ -2341,7 +2341,7 @@ namespace triton {
       triton::uint512 h = this->kind, s = this->children.size();
       if (s) h = h * s;
       for (triton::uint32 index = 0; index < this->children.size(); index++)
-        h = h * triton::ast::pow(this->children[index]->hash(deep+1), index+1);
+        h = h * triton::ast::hash2n(this->children[index]->hash(deep+1), index+1);
       return triton::ast::rotl(h, deep);
     }
 
@@ -2376,7 +2376,7 @@ namespace triton {
       triton::uint512 h = this->kind, s = this->children.size();
       if (s) h = h * s;
       for (triton::uint32 index = 0; index < this->children.size(); index++)
-        h = h * triton::ast::pow(this->children[index]->hash(deep+1), index+1);
+        h = h * triton::ast::hash2n(this->children[index]->hash(deep+1), index+1);
       return triton::ast::rotl(h, deep);
     }
 

--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -2277,6 +2277,109 @@ namespace triton {
       return triton::ast::rotl(h, deep);
     }
 
+
+    /* ====== array */
+
+
+    ArrayNode::ArrayNode(triton::uint32 addrSize, AstContext& ctxt): AbstractNode(ARRAY_NODE, ctxt) {
+      this->addChild(ctxt.decimal(addrSize));
+    }
+
+
+    void ArrayNode::init(void) {
+      /* Init attributes */
+      this->eval        = 0;
+      this->size        = 8;
+      this->symbolized  = true;
+
+      /* Init children and spread information */
+      for (triton::uint32 index = 0; index < this->children.size(); index++) {
+        this->children[index]->setParent(this);
+        this->symbolized |= this->children[index]->isSymbolized();
+      }
+
+      /* Init parents */
+      this->initParents();
+    }
+
+
+    triton::uint512 ArrayNode::hash(triton::uint32 deep) const {
+      triton::uint512 h = this->kind, s = this->children.size();
+      if (s) h = h * s;
+      for (triton::uint32 index = 0; index < this->children.size(); index++)
+        h = h * triton::ast::pow(this->children[index]->hash(deep+1), index+1);
+      return triton::ast::rotl(h, deep);
+    }
+
+
+    /* ====== select */
+
+
+    SelectNode::SelectNode(const SharedAbstractNode& a, const SharedAbstractNode& i): AbstractNode(SELECT_NODE, a->getContext()) {
+      this->addChild(a);
+      this->addChild(i);
+    }
+
+
+    void SelectNode::init(void) {
+      /* Init attributes */
+      this->eval        = 0; // TODO
+      this->size        = this->children[0]->getBitvectorSize();
+
+      /* Init children and spread information */
+      for (triton::uint32 index = 0; index < this->children.size(); index++) {
+        this->children[index]->setParent(this);
+        this->symbolized |= this->children[index]->isSymbolized();
+      }
+
+      /* Init parents */
+      this->initParents();
+    }
+
+
+    triton::uint512 SelectNode::hash(triton::uint32 deep) const {
+      triton::uint512 h = this->kind, s = this->children.size();
+      if (s) h = h * s;
+      for (triton::uint32 index = 0; index < this->children.size(); index++)
+        h = h * triton::ast::pow(this->children[index]->hash(deep+1), index+1);
+      return triton::ast::rotl(h, deep);
+    }
+
+
+    /* ====== store */
+
+
+    StoreNode::StoreNode(const SharedAbstractNode& a, const SharedAbstractNode& i, const SharedAbstractNode& v): AbstractNode(STORE_NODE, a->getContext()) {
+      this->addChild(a);
+      this->addChild(i);
+      this->addChild(v);
+    }
+
+
+    void StoreNode::init(void) {
+      /* Init attributes */
+      this->eval        = 0; // TODO
+      this->size        = this->children[0]->getBitvectorSize();
+
+      /* Init children and spread information */
+      for (triton::uint32 index = 0; index < this->children.size(); index++) {
+        this->children[index]->setParent(this);
+        this->symbolized |= this->children[index]->isSymbolized();
+      }
+
+      /* Init parents */
+      this->initParents();
+    }
+
+
+    triton::uint512 StoreNode::hash(triton::uint32 deep) const {
+      triton::uint512 h = this->kind, s = this->children.size();
+      if (s) h = h * s;
+      for (triton::uint32 index = 0; index < this->children.size(); index++)
+        h = h * triton::ast::pow(this->children[index]->hash(deep+1), index+1);
+      return triton::ast::rotl(h, deep);
+    }
+
   }; /* ast namespace */
 }; /* triton namespace */
 
@@ -2415,6 +2518,9 @@ namespace triton {
         case SX_NODE:                   newNode = std::make_shared<SxNode>(*reinterpret_cast<SxNode*>(node)); break;
         case VARIABLE_NODE:             newNode = std::make_shared<VariableNode>(*reinterpret_cast<VariableNode*>(node)); break;
         case ZX_NODE:                   newNode = std::make_shared<ZxNode>(*reinterpret_cast<ZxNode*>(node)); break;
+        case ARRAY_NODE:                newNode = std::make_shared<ArrayNode>(*reinterpret_cast<ArrayNode*>(node)); break;
+        case SELECT_NODE:               newNode = std::make_shared<SelectNode>(*reinterpret_cast<SelectNode*>(node)); break;
+        case STORE_NODE:                newNode = std::make_shared<StoreNode>(*reinterpret_cast<StoreNode*>(node)); break;
         default:
           throw triton::exceptions::Ast("triton::ast::newInstance(): Invalid kind node.");
       }

--- a/src/libtriton/ast/astContext.cpp
+++ b/src/libtriton/ast/astContext.cpp
@@ -547,6 +547,39 @@ namespace triton {
     }
 
 
+    SharedAbstractNode AstContext::array(triton::uint32 addrSize) {
+      SharedAbstractNode node = std::make_shared<ArrayNode>(addrSize, *this);
+
+      if (node == nullptr)
+        throw triton::exceptions::Ast("Node builders - Not enough memory");
+
+      node->init();
+      return node;
+    }
+
+
+    SharedAbstractNode AstContext::select(const SharedAbstractNode& a, const SharedAbstractNode& i) {
+      SharedAbstractNode node = std::make_shared<SelectNode>(a, i);
+
+      if (node == nullptr)
+        throw triton::exceptions::Ast("Node builders - Not enough memory");
+
+      node->init();
+      return node;
+    }
+
+
+    SharedAbstractNode AstContext::store(const SharedAbstractNode& a, const SharedAbstractNode& i, const SharedAbstractNode& v) {
+      SharedAbstractNode node = std::make_shared<StoreNode>(a, i, v);
+
+      if (node == nullptr)
+        throw triton::exceptions::Ast("Node builders - Not enough memory");
+
+      node->init();
+      return node;
+    }
+
+
     void AstContext::initVariable(const std::string& name, const triton::uint512& value, const SharedAbstractNode& node) {
       auto it = this->valueMapping.find(name);
       if (it == this->valueMapping.end())

--- a/src/libtriton/ast/representations/astPythonRepresentation.cpp
+++ b/src/libtriton/ast/representations/astPythonRepresentation.cpp
@@ -71,6 +71,9 @@ namespace triton {
           case SX_NODE:                   return this->print(stream, reinterpret_cast<triton::ast::SxNode*>(node)); break;
           case VARIABLE_NODE:             return this->print(stream, reinterpret_cast<triton::ast::VariableNode*>(node)); break;
           case ZX_NODE:                   return this->print(stream, reinterpret_cast<triton::ast::ZxNode*>(node)); break;
+          case ARRAY_NODE:                return this->print(stream, reinterpret_cast<triton::ast::ArrayNode*>(node)); break;
+          case SELECT_NODE:               return this->print(stream, reinterpret_cast<triton::ast::SelectNode*>(node)); break;
+          case STORE_NODE:                return this->print(stream, reinterpret_cast<triton::ast::StoreNode*>(node)); break;
           default:
             throw triton::exceptions::AstRepresentation("AstPythonRepresentation::print(AbstractNode): Invalid kind node.");
         }
@@ -449,6 +452,27 @@ namespace triton {
       /* zx representation */
       std::ostream& AstPythonRepresentation::print(std::ostream& stream, triton::ast::ZxNode* node) {
         stream << node->getChildren()[1];
+        return stream;
+      }
+
+
+      /* array representation */
+      std::ostream& AstPythonRepresentation::print(std::ostream& stream, triton::ast::ArrayNode* node) {
+        stream << 'M';
+        return stream;
+      }
+
+
+      /* select representation */
+      std::ostream& AstPythonRepresentation::print(std::ostream& stream, triton::ast::SelectNode* node) {
+        stream << node->getChildren()[0] << '[' << node->getChildren()[1] << ']';
+        return stream;
+      }
+
+
+      /* store representation */
+      std::ostream& AstPythonRepresentation::print(std::ostream& stream, triton::ast::StoreNode* node) {
+        stream << '(' << node->getChildren()[0] << '[' << node->getChildren()[1] << "] = " << node->getChildren()[2] << ")";
         return stream;
       }
 

--- a/src/libtriton/ast/representations/astSmtRepresentation.cpp
+++ b/src/libtriton/ast/representations/astSmtRepresentation.cpp
@@ -71,6 +71,9 @@ namespace triton {
           case SX_NODE:                   return this->print(stream, reinterpret_cast<triton::ast::SxNode*>(node)); break;
           case VARIABLE_NODE:             return this->print(stream, reinterpret_cast<triton::ast::VariableNode*>(node)); break;
           case ZX_NODE:                   return this->print(stream, reinterpret_cast<triton::ast::ZxNode*>(node)); break;
+          case ARRAY_NODE:                return this->print(stream, reinterpret_cast<triton::ast::ArrayNode*>(node)); break;
+          case SELECT_NODE:               return this->print(stream, reinterpret_cast<triton::ast::SelectNode*>(node)); break;
+          case STORE_NODE:                return this->print(stream, reinterpret_cast<triton::ast::StoreNode*>(node)); break;
           default:
             throw triton::exceptions::AstRepresentation("AstSmtRepresentation::print(AbstractNode): Invalid kind node.");
         }
@@ -439,6 +442,27 @@ namespace triton {
       /* zx representation */
       std::ostream& AstSmtRepresentation::print(std::ostream& stream, triton::ast::ZxNode* node) {
         stream << "((_ zero_extend " << node->getChildren()[0] << ") " << node->getChildren()[1] << ")";
+        return stream;
+      }
+
+
+      /* array representation */
+      std::ostream& AstSmtRepresentation::print(std::ostream& stream, triton::ast::ArrayNode* node) {
+        stream << "(Array (_ BitVec " << node->getChildren()[0] << ") (_ BitVec 8))";
+        return stream;
+      }
+
+
+      /* select representation */
+      std::ostream& AstSmtRepresentation::print(std::ostream& stream, triton::ast::SelectNode* node) {
+        stream << "(select " << node->getChildren()[0] << ' ' << node->getChildren()[1] << ")";
+        return stream;
+      }
+
+
+      /* store representation */
+      std::ostream& AstSmtRepresentation::print(std::ostream& stream, triton::ast::StoreNode* node) {
+        stream << "(store " << node->getChildren()[0] << ' ' << node->getChildren()[1] << ' ' << node->getChildren()[2] << ")";
         return stream;
       }
 

--- a/src/libtriton/ast/z3/tritonToZ3Ast.cpp
+++ b/src/libtriton/ast/z3/tritonToZ3Ast.cpp
@@ -293,6 +293,31 @@ namespace triton {
           return to_expr(this->context, Z3_mk_zero_ext(this->context, extv, value));
         }
 
+        case ARRAY_NODE: {
+          z3::expr size        = this->convert(node->getChildren()[0]);
+          triton::uint32 sizev = static_cast<triton::uint32>(this->getUintValue(size));
+          auto isort           = this->context.bv_sort(sizev);
+          auto vsort           = this->context.bv_sort(8);
+          auto asort           = this->context.array_sort(isort, vsort);
+
+          return this->context.constant(("M" + std::to_string(sizev)).c_str(), asort);
+        }
+
+        case SELECT_NODE: {
+          z3::expr a = this->convert(node->getChildren()[0]);
+          z3::expr i = this->convert(node->getChildren()[1]);
+
+          return to_expr(this->context, Z3_mk_select(this->context, a, i));
+        }
+
+        case STORE_NODE: {
+          z3::expr a = this->convert(node->getChildren()[0]);
+          z3::expr i = this->convert(node->getChildren()[1]);
+          z3::expr v = this->convert(node->getChildren()[2]);
+
+          return to_expr(this->context, Z3_mk_store(this->context, a, i, v));
+        }
+
         default:
           throw triton::exceptions::AstTranslations("TritonToZ3Ast::convert(): Invalid kind of node.");
       }

--- a/src/libtriton/bindings/python/namespaces/initModeNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initModeNamespace.cpp
@@ -59,6 +59,7 @@ namespace triton {
         xPyDict_SetItemString(modeDict, "ONLY_ON_TAINTED",        PyLong_FromUint32(triton::modes::ONLY_ON_TAINTED));
         xPyDict_SetItemString(modeDict, "PC_TRACKING_SYMBOLIC",   PyLong_FromUint32(triton::modes::PC_TRACKING_SYMBOLIC));
         xPyDict_SetItemString(modeDict, "TAINT_THROUGH_POINTERS", PyLong_FromUint32(triton::modes::TAINT_THROUGH_POINTERS));
+        xPyDict_SetItemString(modeDict, "SYMBOLIZED_POINTERS",    PyLong_FromUint32(triton::modes::SYMBOLIZED_POINTERS));
       }
 
     }; /* python namespace */

--- a/src/libtriton/bindings/python/objects/pyAstContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyAstContext.cpp
@@ -1466,6 +1466,67 @@ namespace triton {
       }
 
 
+      static PyObject* AstContext_array(PyObject* self, PyObject* addrSize) {
+        if (!PyLong_Check(addrSize) && !PyInt_Check(addrSize))
+          return PyErr_Format(PyExc_TypeError, "array(): expected an integer as first argument");
+
+        try {
+          return PyAstNode(PyAstContext_AsAstContext(self)->array(PyLong_AsUint32(addrSize)));
+        }
+        catch (const triton::exceptions::Exception& e) {
+          return PyErr_Format(PyExc_TypeError, "%s", e.what());
+        }
+      }
+
+
+      static PyObject* AstContext_select(PyObject* self, PyObject* args) {
+        PyObject* op1 = nullptr;
+        PyObject* op2 = nullptr;
+
+        /* Extract arguments */
+        PyArg_ParseTuple(args, "|OO", &op1, &op2);
+
+        if (op1 == nullptr || !PyAstNode_Check(op1))
+          return PyErr_Format(PyExc_TypeError, "select(): expected a AstNode as first argument");
+
+        if (op2 == nullptr || !PyAstNode_Check(op2))
+          return PyErr_Format(PyExc_TypeError, "select(): expected a AstNode as second argument");
+
+        try {
+          return PyAstNode(PyAstContext_AsAstContext(self)->select(PyAstNode_AsAstNode(op1), PyAstNode_AsAstNode(op2)));
+        }
+        catch (const triton::exceptions::Exception& e) {
+          return PyErr_Format(PyExc_TypeError, "%s", e.what());
+        }
+      }
+
+
+      static PyObject* AstContext_store(PyObject* self, PyObject* args) {
+        PyObject* op1 = nullptr;
+        PyObject* op2 = nullptr;
+        PyObject* op3 = nullptr;
+
+        /* Extract arguments */
+        PyArg_ParseTuple(args, "|OOO", &op1, &op2, &op3);
+
+        if (op1 == nullptr || !PyAstNode_Check(op1))
+          return PyErr_Format(PyExc_TypeError, "store(): expected a AstNode as first argument");
+
+        if (op2 == nullptr || !PyAstNode_Check(op2))
+          return PyErr_Format(PyExc_TypeError, "store(): expected a AstNode as second argument");
+
+        if (op3 == nullptr || !PyAstNode_Check(op3))
+          return PyErr_Format(PyExc_TypeError, "store(): expected a AstNode as third argument");
+
+        try {
+          return PyAstNode(PyAstContext_AsAstContext(self)->store(PyAstNode_AsAstNode(op1), PyAstNode_AsAstNode(op2), PyAstNode_AsAstNode(op3)));
+        }
+        catch (const triton::exceptions::Exception& e) {
+          return PyErr_Format(PyExc_TypeError, "%s", e.what());
+        }
+      }
+
+
       //! AstContext methods.
       PyMethodDef AstContext_callbacks[] = {
         {"assert_",       AstContext_assert,          METH_O,           ""},
@@ -1518,6 +1579,9 @@ namespace triton {
         {"sx",            AstContext_sx,              METH_VARARGS,     ""},
         {"variable",      AstContext_variable,        METH_O,           ""},
         {"zx",            AstContext_zx,              METH_VARARGS,     ""},
+        {"array",         AstContext_array,           METH_O,           ""},
+        {"select",        AstContext_select,          METH_VARARGS,     ""},
+        {"store",         AstContext_store,           METH_VARARGS,     ""},
         {nullptr,         nullptr,                    0,                nullptr}
       };
 

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -1338,8 +1338,8 @@ namespace triton {
           }
         }
 
-        if (!PyRegister_Check(mem))
-          return PyErr_Format(PyExc_TypeError, "getMemoryAst(): Expects a Register as first argument.");
+        if (!PyAstNode_Check(mem))
+          return PyErr_Format(PyExc_TypeError, "getMemoryAst(): Expects an AstNode as first argument.");
 
         if (offset == nullptr || (!PyLong_Check(offset) && !PyInt_Check(offset)))
           return PyErr_Format(PyExc_TypeError, "getMemoryAst(): Expects an offset as second argument.");
@@ -1348,7 +1348,7 @@ namespace triton {
           return PyErr_Format(PyExc_TypeError, "getMemoryAst(): Expects a size as third argument.");
 
         try {
-          return PyAstNode(PyTritonContext_AsTritonContext(self)->getMemoryAst(*PyRegister_AsRegister(mem), PyLong_AsUint64(offset), PyLong_AsUint32(size)));
+          return PyAstNode(PyTritonContext_AsTritonContext(self)->getMemoryAst(PyAstNode_AsAstNode(mem), PyLong_AsUint64(offset), PyLong_AsUint32(size)));
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -683,8 +683,8 @@ namespace triton {
           if (!address)
             throw triton::exceptions::SymbolicEngine("SymbolicEngine::getMemoryAst(): Memory operand lea AST is not present.");
           auto addrSize = this->architecture->gprBitSize();
-          if (address->getBitvectorSize() != addrSize)
-            throw triton::exceptions::SymbolicEngine("SymbolicEngine::getMemoryAst(): Memory operand size is not consistent.");
+          if (address->getBitvectorSize() < addrSize)
+            address = this->astCtxt.zx(addrSize - address->getBitvectorSize(), address);
           triton::uint32 size                     = mem.getSize();
           auto h = std::make_pair(address->hash(1), size);
           if (this->symbolicMemoryReference.count(h))
@@ -781,9 +781,7 @@ namespace triton {
 
       /* Returns the AST corresponding to the memory [reg + offset] */
       triton::ast::SharedAbstractNode SymbolicEngine::getMemoryAst(const triton::ast::SharedAbstractNode& reg, triton::uint64 offset, triton::uint32 size) {
-        auto addrSize = this->architecture->gprBitSize();
-        if (reg->getBitvectorSize() != addrSize)
-          throw triton::exceptions::SymbolicEngine("SymbolicEngine::getMemoryAst(): Invalid register size.");
+        auto addrSize = reg->getBitvectorSize();
 
         triton::arch::MemoryAccess mem(offset, size);
         if (!offset) {
@@ -852,8 +850,8 @@ namespace triton {
           if (!address)
             throw triton::exceptions::SymbolicEngine("SymbolicEngine::createSymbolicMemoryExpression(): Memory operand lea AST is not present.");
           auto addrSize = this->architecture->gprBitSize();
-          if (address->getBitvectorSize() != addrSize)
-            throw triton::exceptions::SymbolicEngine("SymbolicEngine::createSymbolicMemoryExpression(): Memory operand size is not consistent.");
+          if (address->getBitvectorSize() < addrSize)
+            address = this->astCtxt.zx(addrSize - address->getBitvectorSize(), address);
           if (!this->symbolicMem) {
             tmp = this->astCtxt.array(this->architecture->gprBitSize());
             this->symbolicMem = this->newSymbolicExpression(tmp, triton::engines::symbolic::MEM, "Initial memory Array reference");

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -91,8 +91,6 @@ namespace triton {
         this->uniqueSymVarId    = 0;
 
         this->symbolicReg.resize(this->numberOfRegisters);
-        auto tmp = this->astCtxt.array(this->architecture->gprBitSize());
-        this->symbolicMem = this->newSymbolicExpression(tmp, triton::engines::symbolic::MEM, "Initial memory Array reference");
       }
 
 
@@ -691,6 +689,10 @@ namespace triton {
           auto h = std::make_pair(address->hash(1), size);
           if (this->symbolicMemoryReference.count(h))
             return this->astCtxt.reference(this->symbolicMemoryReference[h]);
+          if (!this->symbolicMem) {
+            tmp = this->astCtxt.array(this->architecture->gprBitSize());
+            this->symbolicMem = this->newSymbolicExpression(tmp, triton::engines::symbolic::MEM, "Initial memory Array reference");
+          }
           tmp = this->astCtxt.reference(this->symbolicMem);
           if (size == 1) {
             tmp = this->astCtxt.select(tmp, address);
@@ -852,6 +854,10 @@ namespace triton {
           auto addrSize = this->architecture->gprBitSize();
           if (address->getBitvectorSize() != addrSize)
             throw triton::exceptions::SymbolicEngine("SymbolicEngine::createSymbolicMemoryExpression(): Memory operand size is not consistent.");
+          if (!this->symbolicMem) {
+            tmp = this->astCtxt.array(this->architecture->gprBitSize());
+            this->symbolicMem = this->newSymbolicExpression(tmp, triton::engines::symbolic::MEM, "Initial memory Array reference");
+          }
           triton::uint32 writeSize                = mem.getSize();
           auto h = std::make_pair(address->hash(1), writeSize);
           if (writeSize == 1) {

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -762,18 +762,17 @@ namespace triton {
 
 
       /* Returns the AST corresponding to the memory [reg + offset] */
-      triton::ast::SharedAbstractNode SymbolicEngine::getMemoryAst(const triton::arch::Register& reg, triton::uint64 offset, triton::uint32 size) {
-        if (reg.getSize() != this->architecture->gprSize())
+      triton::ast::SharedAbstractNode SymbolicEngine::getMemoryAst(const triton::ast::SharedAbstractNode& reg, triton::uint64 offset, triton::uint32 size) {
+        auto addrSize = this->architecture->gprBitSize();
+        if (reg->getBitvectorSize() != addrSize)
           throw triton::exceptions::SymbolicEngine("SymbolicEngine::getMemoryAst(): Invalid register size.");
 
         triton::arch::MemoryAccess mem(offset, size);
-        mem.setBaseRegister(reg);
-        auto base = this->getRegisterAst(reg);
         if (!offset) {
-          mem.setLeaAst(base);
+          mem.setLeaAst(reg);
         } else {
-          auto off = this->astCtxt.bv(offset, this->architecture->gprBitSize());
-          mem.setLeaAst(this->astCtxt.bvadd(base, off));
+          auto off = this->astCtxt.bv(offset, addrSize);
+          mem.setLeaAst(this->astCtxt.bvadd(reg, off));
         }
 
         return this->getMemoryAst(mem);

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -680,6 +680,8 @@ namespace triton {
          */
         if (this->modes.isModeEnabled(triton::modes::SYMBOLIZED_POINTERS)) {
           triton::ast::SharedAbstractNode address = mem.getLeaAst();
+          if (!address)
+            throw triton::exceptions::SymbolicEngine("SymbolicEngine::getMemoryAst(): Memory operand lea AST is not present.");
           triton::uint32 size                     = mem.getSize();
           if (size == 1)
             return this->astCtxt.select(this->symbolicMem, address);
@@ -826,6 +828,8 @@ namespace triton {
          */
         if (this->modes.isModeEnabled(triton::modes::SYMBOLIZED_POINTERS)) {
           triton::ast::SharedAbstractNode address = mem.getLeaAst();
+          if (!address)
+            throw triton::exceptions::SymbolicEngine("SymbolicEngine::createSymbolicMemoryExpression(): Memory operand lea AST is not present.");
           triton::uint32 writeSize                = mem.getSize();
           if (writeSize == 1) {
             this->symbolicMem = this->astCtxt.store(this->symbolicMem, address, node);

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -357,7 +357,7 @@ namespace triton {
         TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(triton::arch::Instruction& inst, const triton::arch::MemoryAccess& mem);
 
         //! [**symbolic api**] - Returns the AST corresponding to the memory [reg + offset].
-        TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(const triton::arch::Register& reg, triton::uint64 offset, triton::uint32 size);
+        TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(const triton::ast::SharedAbstractNode& reg, triton::uint64 offset, triton::uint32 size);
 
         //! [**symbolic api**] - Returns the AST corresponding to the register.
         TRITON_EXPORT triton::ast::SharedAbstractNode getRegisterAst(const triton::arch::Register& reg);

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -356,6 +356,9 @@ namespace triton {
         //! [**symbolic api**] - Returns the AST corresponding to the memory and defines the memory cell as input of the instruction.
         TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(triton::arch::Instruction& inst, const triton::arch::MemoryAccess& mem);
 
+        //! [**symbolic api**] - Returns the AST corresponding to the memory [reg + offset].
+        TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(const triton::arch::Register& reg, triton::uint64 offset, triton::uint32 size);
+
         //! [**symbolic api**] - Returns the AST corresponding to the register.
         TRITON_EXPORT triton::ast::SharedAbstractNode getRegisterAst(const triton::arch::Register& reg);
 

--- a/src/libtriton/includes/triton/ast.hpp
+++ b/src/libtriton/includes/triton/ast.hpp
@@ -635,6 +635,33 @@ namespace triton {
         TRITON_EXPORT triton::uint512 hash(triton::uint32 deep) const;
     };
 
+
+    //! `(Array (_ BitVec <addrSize>) (_ BitVec 8))` node
+    class ArrayNode : public AbstractNode {
+      public:
+        TRITON_EXPORT ArrayNode(triton::uint32 addrSize, AstContext& ctxt);
+        TRITON_EXPORT void init(void);
+        TRITON_EXPORT triton::uint512 hash(triton::uint32 deep) const;
+    };
+
+
+    //! `(select <a> <i>)` node
+    class SelectNode : public AbstractNode {
+      public:
+        TRITON_EXPORT SelectNode(const SharedAbstractNode& a, const SharedAbstractNode& i);
+        TRITON_EXPORT void init(void);
+        TRITON_EXPORT triton::uint512 hash(triton::uint32 deep) const;
+    };
+
+
+    //! `(store <a> <i> <v>)` node
+    class StoreNode : public AbstractNode {
+      public:
+        TRITON_EXPORT StoreNode(const SharedAbstractNode& a, const SharedAbstractNode& i, const SharedAbstractNode& v);
+        TRITON_EXPORT void init(void);
+        TRITON_EXPORT triton::uint512 hash(triton::uint32 deep) const;
+    };
+
     //! Displays the node in ast representation.
     TRITON_EXPORT std::ostream& operator<<(std::ostream& stream, AbstractNode* node);
 

--- a/src/libtriton/includes/triton/astContext.hpp
+++ b/src/libtriton/includes/triton/astContext.hpp
@@ -256,6 +256,15 @@ namespace triton {
         //! AST C++ API - zx node builder
         TRITON_EXPORT SharedAbstractNode zx(triton::uint32 sizeExt, const SharedAbstractNode& expr);
 
+        //! AST C++ API - array node builder
+        TRITON_EXPORT SharedAbstractNode array(triton::uint32 addrSize);
+
+        //! AST C++ API - select node builder
+        TRITON_EXPORT SharedAbstractNode select(const SharedAbstractNode& a, const SharedAbstractNode& i);
+
+        //! AST C++ API - store node builder
+        TRITON_EXPORT SharedAbstractNode store(const SharedAbstractNode& a, const SharedAbstractNode& i, const SharedAbstractNode& v);
+
         //! Initializes a variable in the context
         TRITON_EXPORT void initVariable(const std::string& name, const triton::uint512& value, const SharedAbstractNode& node);
 

--- a/src/libtriton/includes/triton/astEnums.hpp
+++ b/src/libtriton/includes/triton/astEnums.hpp
@@ -76,6 +76,9 @@ namespace triton {
       SX_NODE = 229,                  /*!< ((_ sign_extend x) y) */
       VARIABLE_NODE = 233,            /*!< Variable node */
       ZX_NODE = 239,                  /*!< ((_ zero_extend x) y) */
+      ARRAY_NODE = 241,               /*!< (Array (_ BitVec addrSize) (_ BitVec 8)) */
+      SELECT_NODE = 251,              /*!< (select a i) */
+      STORE_NODE = 257                /*!< (store a i v) */
     };
 
   /*! @} End of ast namespace */

--- a/src/libtriton/includes/triton/astPythonRepresentation.hpp
+++ b/src/libtriton/includes/triton/astPythonRepresentation.hpp
@@ -191,6 +191,15 @@ namespace triton {
 
           //! Displays the node according to the representation mode.
           TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::ZxNode* node);
+
+          //! Displays the node according to the representation mode.
+          TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::ArrayNode* node);
+
+          //! Displays the node according to the representation mode.
+          TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::SelectNode* node);
+
+          //! Displays the node according to the representation mode.
+          TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::StoreNode* node);
       };
 
 

--- a/src/libtriton/includes/triton/astSmtRepresentation.hpp
+++ b/src/libtriton/includes/triton/astSmtRepresentation.hpp
@@ -191,6 +191,15 @@ namespace triton {
 
           //! Displays the node according to the representation mode.
           TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::ZxNode* node);
+
+          //! Displays the node according to the representation mode.
+          TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::ArrayNode* node);
+
+          //! Displays the node according to the representation mode.
+          TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::SelectNode* node);
+
+          //! Displays the node according to the representation mode.
+          TRITON_EXPORT std::ostream& print(std::ostream& stream, triton::ast::StoreNode* node);
       };
 
     /*! @} End of representations namespace */

--- a/src/libtriton/includes/triton/modes.hpp
+++ b/src/libtriton/includes/triton/modes.hpp
@@ -35,6 +35,7 @@ namespace triton {
       ONLY_ON_TAINTED,        //!< [symbolic mode] Perform symbolic execution only on tainted instructions.
       PC_TRACKING_SYMBOLIC,   //!< [symbolic mode] Track path constraints only if they are symbolized.
       TAINT_THROUGH_POINTERS, //!< [taint mode] Spread the taint if an index pointer is already tainted (see #725).
+      SYMBOLIZED_POINTERS,    //!< [symbolic mode] Symbolize all memory pointers.
     };
 
 

--- a/src/libtriton/includes/triton/symbolicEngine.hpp
+++ b/src/libtriton/includes/triton/symbolicEngine.hpp
@@ -224,7 +224,7 @@ namespace triton {
           TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(triton::arch::Instruction& inst, const triton::arch::MemoryAccess& mem);
 
           //! Returns the AST corresponding to the memory [reg + offset].
-          TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(const triton::arch::Register& reg, triton::uint64 offset, triton::uint32 size);
+          TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(const triton::ast::SharedAbstractNode& reg, triton::uint64 offset, triton::uint32 size);
 
           //! Returns the AST corresponding to the register.
           TRITON_EXPORT triton::ast::SharedAbstractNode getRegisterAst(const triton::arch::Register& reg);

--- a/src/libtriton/includes/triton/symbolicEngine.hpp
+++ b/src/libtriton/includes/triton/symbolicEngine.hpp
@@ -111,7 +111,15 @@ namespace triton {
           std::vector<SharedSymbolicExpression> symbolicReg;
 
           //! Symbolic memory state.
-          triton::ast::SharedAbstractNode symbolicMem;
+          SharedSymbolicExpression symbolicMem;
+
+          /*! \brief map of <lea AST hash:size> -> symbolic expression.
+           *
+           * \details
+           * **item1**: <lea AST hash:size><br>
+           * **item2**: shared symbolic expression
+           */
+          std::map<std::pair<triton::uint512, triton::uint32>, SharedSymbolicExpression> symbolicMemoryReference;
 
         private:
           //! Architecture API

--- a/src/libtriton/includes/triton/symbolicEngine.hpp
+++ b/src/libtriton/includes/triton/symbolicEngine.hpp
@@ -110,6 +110,9 @@ namespace triton {
           //! Symbolic register state.
           std::vector<SharedSymbolicExpression> symbolicReg;
 
+          //! Symbolic memory state.
+          triton::ast::SharedAbstractNode symbolicMem;
+
         private:
           //! Architecture API
           triton::arch::Architecture* architecture;
@@ -219,6 +222,9 @@ namespace triton {
 
           //! Returns the AST corresponding to the memory and defines the memory as input of the instruction.
           TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(triton::arch::Instruction& inst, const triton::arch::MemoryAccess& mem);
+
+          //! Returns the AST corresponding to the memory [reg + offset].
+          TRITON_EXPORT triton::ast::SharedAbstractNode getMemoryAst(const triton::arch::Register& reg, triton::uint64 offset, triton::uint32 size);
 
           //! Returns the AST corresponding to the register.
           TRITON_EXPORT triton::ast::SharedAbstractNode getRegisterAst(const triton::arch::Register& reg);

--- a/src/libtriton/includes/triton/symbolicEngine.hpp
+++ b/src/libtriton/includes/triton/symbolicEngine.hpp
@@ -121,15 +121,16 @@ namespace triton {
            */
           std::map<std::pair<triton::uint512, triton::uint32>, SharedSymbolicExpression> symbolicMemoryReference;
 
+        public:
+          //! Modes API.
+          const triton::modes::Modes& modes;
+
         private:
           //! Architecture API
           triton::arch::Architecture* architecture;
 
           //! Callbacks API
           triton::callbacks::Callbacks* callbacks;
-
-          //! Modes API.
-          const triton::modes::Modes& modes;
 
           //! Slices all expressions from a given node.
           void sliceExpressions(const triton::ast::SharedAbstractNode& node, std::map<triton::usize, SharedSymbolicExpression>& exprs);

--- a/src/testers/unittests/test_symbolized_pointers.py
+++ b/src/testers/unittests/test_symbolized_pointers.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python2
+# coding: utf-8
+"""Test SYMBOLIZED_POINTERS mode."""
+
+import os
+import unittest
+
+from triton import *
+
+
+class TestSymbolizedPointers(unittest.TestCase):
+    """Test SYMBOLIZED_POINTERS mode"""
+
+    def test_array(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86)
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.EAX))
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.EBX))
+        eax = ctx.getRegisterAst(ctx.getRegister(REG.X86.EAX))
+        bl = ctx.getRegisterAst(ctx.getRegister(REG.X86.BL))
+        ast = ctx.getAstContext()
+        a = ast.array(32)
+        val = ast.select(ast.store(a, eax, bl), eax)
+        self.assertFalse(ctx.isSat(val != bl))
+
+    def test_array_concat(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86)
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.EAX))
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.EBX))
+        eax = ctx.getRegisterAst(ctx.getRegister(REG.X86.EAX))
+        ebx = ctx.getRegisterAst(ctx.getRegister(REG.X86.EBX))
+        ast = ctx.getAstContext()
+        a = ast.array(32)
+        for i in range(4):
+            a = ast.store(a, eax + i, ast.extract(8 * i + 7, 8 * i, ebx))
+        val = ast.concat([ast.select(a, eax + 3 - i) for i in range(4)])
+        self.assertFalse(ctx.isSat(val != ebx))
+
+    def test_symbolic_pointers(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86)
+        ctx.enableMode(MODE.SYMBOLIZED_POINTERS, True)
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.EAX), "eax")
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.EBX), "ebx")
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.ECX), "ecx")
+        eax = ctx.getRegisterAst(ctx.getRegister(REG.X86.EAX))
+        ebx = ctx.getRegisterAst(ctx.getRegister(REG.X86.EBX))
+        ecx = ctx.getRegisterAst(ctx.getRegister(REG.X86.ECX))
+        insn = Instruction()
+        insn.setOpcode("\x89\x18")
+        ctx.processing(insn)
+        mem = ctx.getMemoryAst(ecx, 0, 4)
+        self.assertTrue(ctx.isSat(mem != ebx))
+        mem = ctx.getMemoryAst(eax, 0, 4)
+        self.assertFalse(ctx.isSat(mem != ebx))
+
+    def test_symbolic_pointers_ret(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86)
+        ctx.enableMode(MODE.SYMBOLIZED_POINTERS, True)
+        insn = Instruction()
+        insn.setOpcode("\xc3")
+        self.assertTrue(ctx.processing(insn))
+
+    def test_push_esp(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86)
+        ctx.enableMode(MODE.SYMBOLIZED_POINTERS, True)
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.ESP))
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.EIP))
+        esp = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
+        code = [
+            (0xdeadbeaf, "\x54"),  # push esp
+            (0xdeadbeb0, "\xc3"),  # ret
+        ]
+        for addr, opcode in code:
+            insn = Instruction()
+            insn.setOpcode(opcode)
+            insn.setAddress(addr)
+            ctx.processing(insn)
+        eip = ctx.getRegisterAst(ctx.getRegister(REG.X86.EIP))
+        self.assertFalse(ctx.isSat(eip != esp))
+
+    def test_popal(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86)
+        ctx.enableMode(MODE.SYMBOLIZED_POINTERS, True)
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.ESP))
+        esp_old = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
+        insn = Instruction()
+        insn.setOpcode("\x61")  # popal
+        ctx.processing(insn)
+        esp_new = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
+        self.assertFalse(ctx.isSat(esp_new != esp_old + 32))
+
+    def test_popf_x86(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86)
+        ctx.enableMode(MODE.SYMBOLIZED_POINTERS, True)
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86.ESP))
+        esp_old = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
+        insn = Instruction()
+        insn.setOpcode("\x66\x9d")  # popf
+        ctx.processing(insn)
+        esp_new = ctx.getRegisterAst(ctx.getRegister(REG.X86.ESP))
+        self.assertFalse(ctx.isSat(esp_new != esp_old + 4))
+
+    def test_popf_x86_64(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.enableMode(MODE.SYMBOLIZED_POINTERS, True)
+        ctx.convertRegisterToSymbolicVariable(ctx.getRegister(REG.X86_64.RSP))
+        rsp_old = ctx.getRegisterAst(ctx.getRegister(REG.X86_64.RSP))
+        insn = Instruction()
+        insn.setOpcode("\x66\x9d")  # popf
+        ctx.processing(insn)
+        rsp_new = ctx.getRegisterAst(ctx.getRegister(REG.X86_64.RSP))
+        self.assertFalse(ctx.isSat(rsp_new != rsp_old + 8))


### PR DESCRIPTION
Added support for symbolic memory addresses. A special SYMBOLIZED_POINTERS mode is added. Memory is represented as a Z3 array. All memory reads/writes are implemented with corresponding selects/stores on this array.

New API for getMemoryAst is added as follows:
```
ctx.getMemoryAst(baseRegister, offset, size)  # [baseRegister+offset] of size
```

P.S. docs for getMemoryAst are not considered.