### PR TITLE
libtriton/CMakeLists.txt: don't access head of list if list is empty

### DIFF
--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -169,11 +169,11 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/os/unix/)
 set(EXTRACT_SYSCALL_SCRIPT ${CMAKE_SOURCE_DIR}/src/scripts/extract_syscall.py)
 
 macro(gen_syscall bits)
-    LIST(GET syscalls${bits}_table_files 0 syscalls${bits}_table_file)
     # If the unistd_64.h or syscall.h is not found, we exit
-    if(NOT EXISTS ${syscalls${bits}_table_file})
+    if(NOT syscalls${bits}_table_files)
         message(FATAL_ERROR "unistd_${bits}.h or syscall.h is missing")
     endif()
+    LIST(GET syscalls${bits}_table_files 0 syscalls${bits}_table_file)
 
     set(OUT_SYSCALL${bits} ${CMAKE_CURRENT_BINARY_DIR}/os/unix/syscalls${bits}.cpp)
 


### PR DESCRIPTION
We currently try to access the first element of
`syscalls${bits}_table_files`, then check if it's defined to print an error
message about missing `unistd_${bits}.h or syscall.h`.

This can't work, as Cmake will complain first about acessing the first
element of an empty list:

```
CMake Error at src/libtriton/CMakeLists.txt:172 (LIST):
  LIST GET given empty list
Call Stack (most recent call first):
  src/libtriton/CMakeLists.txt:194 (gen_syscall)

CMake Error at src/libtriton/CMakeLists.txt:172 (LIST):
  LIST GET given empty list
Call Stack (most recent call first):
  src/libtriton/CMakeLists.txt:203 (gen_syscall)
```

Fix this by checking if the list is empty instead.