### PR TITLE
Fixing building with pin header path

### DIFF
--- a/src/tracer/pin/bindings.cpp
+++ b/src/tracer/pin/bindings.cpp
@@ -10,7 +10,7 @@
 #include <triton/pythonObjects.hpp>
 #include <triton/tritonTypes.hpp>
 
-#include <pin.H>
+#include <pin/pin.H>
 
 /* pintool */
 #include "api.hpp"
@@ -599,4 +599,3 @@ namespace tracer {
 
   };
 };
-

--- a/src/tracer/pin/bindings.hpp
+++ b/src/tracer/pin/bindings.hpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <list>
 
-#include <pin.H>
+#include <pin/pin.H>
 
 /* pintool */
 #include "snapshot.hpp"

--- a/src/tracer/pin/callbacks.cpp
+++ b/src/tracer/pin/callbacks.cpp
@@ -15,7 +15,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <pin.H>
+#include <pin/pin.H>
 
 /* pintool */
 #include "bindings.hpp"
@@ -239,4 +239,3 @@ namespace tracer {
     };
   };
 };
-

--- a/src/tracer/pin/context.hpp
+++ b/src/tracer/pin/context.hpp
@@ -8,7 +8,7 @@
 #ifndef TRITON_PIN_CONTEXT_H
 #define TRITON_PIN_CONTEXT_H
 
-#include <pin.H>
+#include <pin/pin.H>
 
 /* libTriton */
 #include <triton/tritonTypes.hpp>

--- a/src/tracer/pin/main.cpp
+++ b/src/tracer/pin/main.cpp
@@ -15,7 +15,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <pin.H>
+#include <pin/pin.H>
 
 /* Pintool */
 #include "api.hpp"
@@ -734,4 +734,3 @@ namespace tracer {
 int main(int argc, char *argv[]) {
   return tracer::pintool::main(argc, argv);
 }
-

--- a/src/tracer/pin/snapshot.hpp
+++ b/src/tracer/pin/snapshot.hpp
@@ -11,7 +11,7 @@
 #include <map>
 #include <set>
 
-#include <pin.H>
+#include <pin/pin.H>
 
 /* libTriton */
 #include <triton/ast.hpp>
@@ -112,4 +112,3 @@ namespace tracer {
 };
 
 #endif /* PINTOOL_SNAPSHOT_H */
-

--- a/src/tracer/pin/utils.hpp
+++ b/src/tracer/pin/utils.hpp
@@ -9,7 +9,7 @@
 #define TRITON_UTILS_H
 
 #include <string>
-#include <pin.H>
+#include <pin/pin.H>
 #include <triton/tritonTypes.hpp>
 
 


### PR DESCRIPTION
Since the building with pin, only find pin header in /usr/include not in /usr/include/pin & /usr/include/pin/gen