### PR TITLE
Makes newIstance call itself for new node's children. Closes #718

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -30,18 +30,6 @@ namespace triton {
     }
 
 
-    AbstractNode::AbstractNode(const AbstractNode& other, AstContext& ctxt): ctxt(ctxt) {
-      this->eval        = other.eval;
-      this->parents     = other.parents;
-      this->size        = other.size;
-      this->symbolized  = other.symbolized;
-      this->type        = other.type;
-
-      for (triton::uint32 index = 0; index < other.children.size(); index++)
-        this->children.push_back(triton::ast::newInstance(other.children[index].get()));
-    }
-
-
     AbstractNode::~AbstractNode() {
       /* virtual */
     }

--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -2470,6 +2470,15 @@ namespace triton {
       if (newNode == nullptr)
         throw triton::exceptions::Ast("triton::ast::newInstance(): No enough memory.");
 
+      // Remove parents as this is a new node which has no any connections with original AST
+      newNode->getParents().clear();
+
+      // Create new instances of children and set them new parents
+      auto &children = newNode->getChildren();
+      for (size_t idx = 0; idx < children.size(); ++idx) {
+        children[idx] = triton::ast::newInstance(children[idx].get());
+        children[idx]->setParent(newNode.get());
+      }
       return newNode;
     }
 

--- a/src/libtriton/includes/triton/ast.hpp
+++ b/src/libtriton/includes/triton/ast.hpp
@@ -91,9 +91,6 @@ namespace triton {
         //! Constructor.
         TRITON_EXPORT AbstractNode(triton::ast::ast_e type, AstContext& ctxt);
 
-        //! Constructor by copy.
-        TRITON_EXPORT AbstractNode(const AbstractNode& other, AstContext& ctxt);
-
         //! Destructor.
         TRITON_EXPORT virtual ~AbstractNode();
 


### PR DESCRIPTION
Don't see a better way to create deep copy.
Also I think constructor `AbstractNode::AbstractNode(const AbstractNode& other, AstContext& ctxt): ctxt(ctxt)` should be deleted as there's no way to use it. Can update this pull request if you agree with it