### PR TITLE
Py2-3 compatibility changes

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -32,7 +32,7 @@ if(PYTHON_BINDINGS_AUTOCOMPLETE)
     )
     # replace backlsash with forwardslash to not generate an error on windows
     execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} -c [[from distutils.sysconfig import get_python_lib; lib = get_python_lib(); print lib.replace("\\", "/")]]
+        COMMAND ${PYTHON_EXECUTABLE} -c [[from __future__ import print_function; from distutils.sysconfig import get_python_lib; lib = get_python_lib(); print(lib.replace("\\", "/"))]]
         OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     install(

--- a/src/examples/python/backward_slicing.py
+++ b/src/examples/python/backward_slicing.py
@@ -9,6 +9,7 @@
 ## [slicing] 0x400597: mov ecx, eax
 ##
 
+from __future__ import print_function
 import  sys
 
 from triton import *
@@ -16,36 +17,36 @@ from triton import *
 
 # A dumb function to emulate.
 function = {
-  0x40056d: "\x55",                           #   push    rbp
-  0x40056e: "\x48\x89\xe5",                   #   mov     rbp,rsp
-  0x400571: "\x48\x89\x7d\xe8",               #   mov     QWORD PTR [rbp-0x18],rdi
-  0x400575: "\xc7\x45\xfc\x00\x00\x00\x00",   #   mov     DWORD PTR [rbp-0x4],0x0
-  0x40057c: "\xeb\x3f",                       #   jmp     4005bd <check+0x50>
-  0x40057e: "\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
-  0x400581: "\x48\x63\xd0",                   #   movsxd  rdx,eax
-  0x400584: "\x48\x8b\x45\xe8",               #   mov     rax,QWORD PTR [rbp-0x18]
-  0x400588: "\x48\x01\xd0",                   #   add     rax,rdx
-  0x40058b: "\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
-  0x40058e: "\x0f\xbe\xc0",                   #   movsx   eax,al
-  0x400591: "\x83\xe8\x01",                   #   sub     eax,0x1
-  0x400594: "\x83\xf0\x55",                   #   xor     eax,0x55
-  0x400597: "\x89\xc1",                       #   mov     ecx,eax
-  0x400599: "\x48\x8b\x15\xa0\x0a\x20\x00",   #   mov     rdx,QWORD PTR [rip+0x200aa0]        # 601040 <serial>
-  0x4005a0: "\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
-  0x4005a3: "\x48\x98",                       #   cdqe
-  0x4005a5: "\x48\x01\xd0",                   #   add     rax,rdx
-  0x4005a8: "\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
-  0x4005ab: "\x0f\xbe\xc0",                   #   movsx   eax,al
-  0x4005ae: "\x39\xc1",                       #   cmp     ecx,eax
-  0x4005b0: "\x74\x07",                       #   je      4005b9 <check+0x4c>
-  0x4005b2: "\xb8\x01\x00\x00\x00",           #   mov     eax,0x1
-  0x4005b7: "\xeb\x0f",                       #   jmp     4005c8 <check+0x5b>
-  0x4005b9: "\x83\x45\xfc\x01",               #   add     DWORD PTR [rbp-0x4],0x1
-  0x4005bd: "\x83\x7d\xfc\x04",               #   cmp     DWORD PTR [rbp-0x4],0x4
-  0x4005c1: "\x7e\xbb",                       #   jle     40057e <check+0x11>
-  0x4005c3: "\xb8\x00\x00\x00\x00",           #   mov     eax,0x0
-  0x4005c8: "\x5d",                           #   pop     rbp
-  0x4005c9: "\xc3",                           #   ret
+  0x40056d: b"\x55",                           #   push    rbp
+  0x40056e: b"\x48\x89\xe5",                   #   mov     rbp,rsp
+  0x400571: b"\x48\x89\x7d\xe8",               #   mov     QWORD PTR [rbp-0x18],rdi
+  0x400575: b"\xc7\x45\xfc\x00\x00\x00\x00",   #   mov     DWORD PTR [rbp-0x4],0x0
+  0x40057c: b"\xeb\x3f",                       #   jmp     4005bd <check+0x50>
+  0x40057e: b"\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
+  0x400581: b"\x48\x63\xd0",                   #   movsxd  rdx,eax
+  0x400584: b"\x48\x8b\x45\xe8",               #   mov     rax,QWORD PTR [rbp-0x18]
+  0x400588: b"\x48\x01\xd0",                   #   add     rax,rdx
+  0x40058b: b"\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
+  0x40058e: b"\x0f\xbe\xc0",                   #   movsx   eax,al
+  0x400591: b"\x83\xe8\x01",                   #   sub     eax,0x1
+  0x400594: b"\x83\xf0\x55",                   #   xor     eax,0x55
+  0x400597: b"\x89\xc1",                       #   mov     ecx,eax
+  0x400599: b"\x48\x8b\x15\xa0\x0a\x20\x00",   #   mov     rdx,QWORD PTR [rip+0x200aa0]        # 601040 <serial>
+  0x4005a0: b"\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
+  0x4005a3: b"\x48\x98",                       #   cdqe
+  0x4005a5: b"\x48\x01\xd0",                   #   add     rax,rdx
+  0x4005a8: b"\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
+  0x4005ab: b"\x0f\xbe\xc0",                   #   movsx   eax,al
+  0x4005ae: b"\x39\xc1",                       #   cmp     ecx,eax
+  0x4005b0: b"\x74\x07",                       #   je      4005b9 <check+0x4c>
+  0x4005b2: b"\xb8\x01\x00\x00\x00",           #   mov     eax,0x1
+  0x4005b7: b"\xeb\x0f",                       #   jmp     4005c8 <check+0x5b>
+  0x4005b9: b"\x83\x45\xfc\x01",               #   add     DWORD PTR [rbp-0x4],0x1
+  0x4005bd: b"\x83\x7d\xfc\x04",               #   cmp     DWORD PTR [rbp-0x4],0x4
+  0x4005c1: b"\x7e\xbb",                       #   jle     40057e <check+0x11>
+  0x4005c3: b"\xb8\x00\x00\x00\x00",           #   mov     eax,0x0
+  0x4005c8: b"\x5d",                           #   pop     rbp
+  0x4005c9: b"\xc3",                           #   ret
 }
 
 

--- a/src/examples/python/symbolic_emulation_1.py
+++ b/src/examples/python/symbolic_emulation_1.py
@@ -62,16 +62,17 @@
 ##  Compute  AH       : 0x47L
 ##
 
+from __future__ import print_function
+import sys
 
-import  sys
-from    triton import TritonContext, ARCH, Instruction, MemoryAccess, CPUSIZE
+from triton import TritonContext, ARCH, Instruction, MemoryAccess, CPUSIZE
 
 
 code = [
-    (0x400000, "\x48\xB8\x48\x47\x46\x45\x44\x43\x42\x41"),     # movabs rax, 0x4142434445464748
-    (0x40000a, "\x48\xC7\xC6\x08\x00\x00\x00"),                 # mov    rsi, 0x8
-    (0x400011, "\x48\xC7\xC7\x00\x00\x01\x00"),                 # mov    rdi, 0x10000
-    (0x400018, "\x48\x89\x84\x77\x34\x12\x00\x00"),             # mov    QWORD PTR [rdi+rsi*2+0x1234], rax
+    (0x400000, b"\x48\xB8\x48\x47\x46\x45\x44\x43\x42\x41"),     # movabs rax, 0x4142434445464748
+    (0x40000a, b"\x48\xC7\xC6\x08\x00\x00\x00"),                 # mov    rsi, 0x8
+    (0x400011, b"\x48\xC7\xC7\x00\x00\x01\x00"),                 # mov    rdi, 0x10000
+    (0x400018, b"\x48\x89\x84\x77\x34\x12\x00\x00"),             # mov    QWORD PTR [rdi+rsi*2+0x1234], rax
 ]
 
 

--- a/src/examples/python/symbolic_emulation_2.py
+++ b/src/examples/python/symbolic_emulation_2.py
@@ -23,18 +23,19 @@
 ##  Next ip: 0x99999999L
 ##
 
-import  sys
+from __future__ import print_function
+import sys
 
 from triton import TritonContext, ARCH, Instruction, MODE
 
 
 function = {
-  0x40056d:   "\x55",                         #   push    rbp
-  0x40056e:   "\x48\xC7\xC0\x44\x43\x42\x41", #   mov     rax, 0x41424344
-  0x400575:   "\xFF\xD0",                     #   call    rax
-  0x400577:   "\xc3",                         #   ret
-  0x41424344: "\x48\x31\xDB",                 #   xor     rbx, rbx
-  0x41424347: "\xc3",                         #   ret
+  0x40056d:   b"\x55",                         #   push    rbp
+  0x40056e:   b"\x48\xC7\xC0\x44\x43\x42\x41", #   mov     rax, 0x41424344
+  0x400575:   b"\xFF\xD0",                     #   call    rax
+  0x400577:   b"\xc3",                         #   ret
+  0x41424344: b"\x48\x31\xDB",                 #   xor     rbx, rbx
+  0x41424347: b"\xc3",                         #   ret
 }
 
 Triton = TritonContext()

--- a/src/examples/python/symbolic_emulation_crackme_xor.py
+++ b/src/examples/python/symbolic_emulation_crackme_xor.py
@@ -1,42 +1,43 @@
 #!/usr/bin/env python2
 ## -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import  sys
 
 from triton     import TritonContext, ARCH, MODE, Instruction
 
 function = {
                                               #   <serial> function
-  0x40056d: "\x55",                           #   push    rbp
-  0x40056e: "\x48\x89\xe5",                   #   mov     rbp,rsp
-  0x400571: "\x48\x89\x7d\xe8",               #   mov     QWORD PTR [rbp-0x18],rdi
-  0x400575: "\xc7\x45\xfc\x00\x00\x00\x00",   #   mov     DWORD PTR [rbp-0x4],0x0
-  0x40057c: "\xeb\x3f",                       #   jmp     4005bd <check+0x50>
-  0x40057e: "\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
-  0x400581: "\x48\x63\xd0",                   #   movsxd  rdx,eax
-  0x400584: "\x48\x8b\x45\xe8",               #   mov     rax,QWORD PTR [rbp-0x18]
-  0x400588: "\x48\x01\xd0",                   #   add     rax,rdx
-  0x40058b: "\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
-  0x40058e: "\x0f\xbe\xc0",                   #   movsx   eax,al
-  0x400591: "\x83\xe8\x01",                   #   sub     eax,0x1
-  0x400594: "\x83\xf0\x55",                   #   xor     eax,0x55
-  0x400597: "\x89\xc1",                       #   mov     ecx,eax
-  0x400599: "\x48\x8b\x15\xa0\x0a\x20\x00",   #   mov     rdx,QWORD PTR [rip+0x200aa0]        # 601040 <serial>
-  0x4005a0: "\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
-  0x4005a3: "\x48\x98",                       #   cdqe
-  0x4005a5: "\x48\x01\xd0",                   #   add     rax,rdx
-  0x4005a8: "\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
-  0x4005ab: "\x0f\xbe\xc0",                   #   movsx   eax,al
-  0x4005ae: "\x39\xc1",                       #   cmp     ecx,eax
-  0x4005b0: "\x74\x07",                       #   je      4005b9 <check+0x4c>
-  0x4005b2: "\xb8\x01\x00\x00\x00",           #   mov     eax,0x1
-  0x4005b7: "\xeb\x0f",                       #   jmp     4005c8 <check+0x5b>
-  0x4005b9: "\x83\x45\xfc\x01",               #   add     DWORD PTR [rbp-0x4],0x1
-  0x4005bd: "\x83\x7d\xfc\x04",               #   cmp     DWORD PTR [rbp-0x4],0x4
-  0x4005c1: "\x7e\xbb",                       #   jle     40057e <check+0x11>
-  0x4005c3: "\xb8\x00\x00\x00\x00",           #   mov     eax,0x0
-  0x4005c8: "\x5d",                           #   pop     rbp
-  0x4005c9: "\xc3",                           #   ret
+  0x40056d: b"\x55",                           #   push    rbp
+  0x40056e: b"\x48\x89\xe5",                   #   mov     rbp,rsp
+  0x400571: b"\x48\x89\x7d\xe8",               #   mov     QWORD PTR [rbp-0x18],rdi
+  0x400575: b"\xc7\x45\xfc\x00\x00\x00\x00",   #   mov     DWORD PTR [rbp-0x4],0x0
+  0x40057c: b"\xeb\x3f",                       #   jmp     4005bd <check+0x50>
+  0x40057e: b"\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
+  0x400581: b"\x48\x63\xd0",                   #   movsxd  rdx,eax
+  0x400584: b"\x48\x8b\x45\xe8",               #   mov     rax,QWORD PTR [rbp-0x18]
+  0x400588: b"\x48\x01\xd0",                   #   add     rax,rdx
+  0x40058b: b"\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
+  0x40058e: b"\x0f\xbe\xc0",                   #   movsx   eax,al
+  0x400591: b"\x83\xe8\x01",                   #   sub     eax,0x1
+  0x400594: b"\x83\xf0\x55",                   #   xor     eax,0x55
+  0x400597: b"\x89\xc1",                       #   mov     ecx,eax
+  0x400599: b"\x48\x8b\x15\xa0\x0a\x20\x00",   #   mov     rdx,QWORD PTR [rip+0x200aa0]        # 601040 <serial>
+  0x4005a0: b"\x8b\x45\xfc",                   #   mov     eax,DWORD PTR [rbp-0x4]
+  0x4005a3: b"\x48\x98",                       #   cdqe
+  0x4005a5: b"\x48\x01\xd0",                   #   add     rax,rdx
+  0x4005a8: b"\x0f\xb6\x00",                   #   movzx   eax,BYTE PTR [rax]
+  0x4005ab: b"\x0f\xbe\xc0",                   #   movsx   eax,al
+  0x4005ae: b"\x39\xc1",                       #   cmp     ecx,eax
+  0x4005b0: b"\x74\x07",                       #   je      4005b9 <check+0x4c>
+  0x4005b2: b"\xb8\x01\x00\x00\x00",           #   mov     eax,0x1
+  0x4005b7: b"\xeb\x0f",                       #   jmp     4005c8 <check+0x5b>
+  0x4005b9: b"\x83\x45\xfc\x01",               #   add     DWORD PTR [rbp-0x4],0x1
+  0x4005bd: b"\x83\x7d\xfc\x04",               #   cmp     DWORD PTR [rbp-0x4],0x4
+  0x4005c1: b"\x7e\xbb",                       #   jle     40057e <check+0x11>
+  0x4005c3: b"\xb8\x00\x00\x00\x00",           #   mov     eax,0x0
+  0x4005c8: b"\x5d",                           #   pop     rbp
+  0x4005c9: b"\xc3",                           #   ret
 }
 
 

--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -259,7 +259,7 @@ if(PYTHON_BINDINGS)
         DEPENDS triton
     )
 
-    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from __future__ import print_function; from distutils.sysconfig import get_python_lib; print(get_python_lib())" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" AND NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
         install (FILES ${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}/triton${PYTHON_SUFFIX} DESTINATION ${PYTHON_SITE_PACKAGES})
     else()

--- a/src/libtriton/arch/aarch64/aarch64Cpu.cpp
+++ b/src/libtriton/arch/aarch64/aarch64Cpu.cpp
@@ -551,8 +551,12 @@ namespace triton {
 
 
       void AArch64Cpu::setConcreteRegisterValue(const triton::arch::Register& reg, const triton::uint512& value) {
-        if (value > reg.getMaxValue())
-          throw triton::exceptions::Register("AArch64Cpu::setConcreteRegisterValue(): You cannot set this concrete value (too big) to this register.");
+        if (value > reg.getMaxValue()) {
+          std::ostringstream oss;
+          oss << "AArch64Cpu::setConcreteRegisterValue(): You cannot set this concrete value ";
+          oss << std::hex << value << " (too big) to this register.";
+          throw triton::exceptions::Register(oss.str());
+        }
 
         if (this->callbacks)
           this->callbacks->processCallbacks(triton::callbacks::SET_CONCRETE_REGISTER_VALUE, reg, value);

--- a/src/libtriton/arch/x86/x8664Cpu.cpp
+++ b/src/libtriton/arch/x86/x8664Cpu.cpp
@@ -821,8 +821,12 @@ namespace triton {
 
 
       void x8664Cpu::setConcreteRegisterValue(const triton::arch::Register& reg, const triton::uint512& value) {
-        if (value > reg.getMaxValue())
-          throw triton::exceptions::Register("x8664Cpu::setConcreteRegisterValue(): You cannot set this concrete value (too big) to this register.");
+        if (value > reg.getMaxValue()) {
+          std::ostringstream oss;
+          oss << "x8664Cpu::setConcreteRegisterValue(): You cannot set this concrete value ";
+          oss << std::hex << value << " (too big) to this register.";
+          throw triton::exceptions::Register(oss.str());
+        }
 
         if (this->callbacks)
           this->callbacks->processCallbacks(triton::callbacks::SET_CONCRETE_REGISTER_VALUE, reg, value);

--- a/src/libtriton/bindings/python/namespaces/initConditionsNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initConditionsNamespace.cpp
@@ -85,8 +85,6 @@ namespace triton {
         PyDict_Clear(conditionsDict);
 
         PyObject* aarch64ConditionsDict      = xPyDict_New();
-        PyObject* aarch64ConditionsDictClass = xPyClass_New(nullptr, aarch64ConditionsDict, xPyString_FromString("AARCH64"));
-        xPyDict_SetItemString(conditionsDict, "AARCH64", aarch64ConditionsDictClass);
 
         xPyDict_SetItemString(aarch64ConditionsDict, "INVALID", PyLong_FromUint32(triton::arch::aarch64::ID_CONDITION_INVALID));
         xPyDict_SetItemString(aarch64ConditionsDict, "AL",      PyLong_FromUint32(triton::arch::aarch64::ID_CONDITION_AL));
@@ -104,6 +102,9 @@ namespace triton {
         xPyDict_SetItemString(aarch64ConditionsDict, "PL",      PyLong_FromUint32(triton::arch::aarch64::ID_CONDITION_PL));
         xPyDict_SetItemString(aarch64ConditionsDict, "VC",      PyLong_FromUint32(triton::arch::aarch64::ID_CONDITION_VC));
         xPyDict_SetItemString(aarch64ConditionsDict, "VS",      PyLong_FromUint32(triton::arch::aarch64::ID_CONDITION_VS));
+
+        PyObject* aarch64ConditionsDictClass = xPyClass_New(nullptr, aarch64ConditionsDict, xPyString_FromString("AARCH64"));
+        xPyDict_SetItemString(conditionsDict, "AARCH64", aarch64ConditionsDictClass);
       }
 
     }; /* python namespace */

--- a/src/libtriton/bindings/python/namespaces/initExtendNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initExtendNamespace.cpp
@@ -64,8 +64,6 @@ namespace triton {
         PyDict_Clear(extendDict);
 
         PyObject* aarch64ExtendDict      = xPyDict_New();
-        PyObject* aarch64ExtendDictClass = xPyClass_New(nullptr, aarch64ExtendDict, xPyString_FromString("AARCH64"));
-        xPyDict_SetItemString(extendDict, "AARCH64", aarch64ExtendDictClass);
 
         xPyDict_SetItemString(aarch64ExtendDict, "INVALID", PyLong_FromUint32(triton::arch::aarch64::ID_EXTEND_INVALID));
         xPyDict_SetItemString(aarch64ExtendDict, "UXTB",    PyLong_FromUint32(triton::arch::aarch64::ID_EXTEND_UXTB));
@@ -76,6 +74,9 @@ namespace triton {
         xPyDict_SetItemString(aarch64ExtendDict, "SXTH",    PyLong_FromUint32(triton::arch::aarch64::ID_EXTEND_SXTH));
         xPyDict_SetItemString(aarch64ExtendDict, "SXTW",    PyLong_FromUint32(triton::arch::aarch64::ID_EXTEND_SXTW));
         xPyDict_SetItemString(aarch64ExtendDict, "SXTX",    PyLong_FromUint32(triton::arch::aarch64::ID_EXTEND_SXTX));
+
+        PyObject* aarch64ExtendDictClass = xPyClass_New(nullptr, aarch64ExtendDict, xPyString_FromString("AARCH64"));
+        xPyDict_SetItemString(extendDict, "AARCH64", aarch64ExtendDictClass);
       }
 
     }; /* python namespace */

--- a/src/libtriton/bindings/python/namespaces/initOpcodesNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initOpcodesNamespace.cpp
@@ -1754,8 +1754,6 @@ namespace triton {
         PyDict_Clear(opcodesDict);
 
         PyObject* x86OpcodesDict      = xPyDict_New();
-        PyObject* x86OpcodesDictClass = xPyClass_New(nullptr, x86OpcodesDict, xPyString_FromString("X86"));
-        xPyDict_SetItemString(opcodesDict, "X86", x86OpcodesDictClass);
 
         xPyDict_SetItemString(x86OpcodesDict, "INVALID", PyLong_FromUint32(triton::arch::x86::ID_INS_INVALID));
         xPyDict_SetItemString(x86OpcodesDict, "AAA", PyLong_FromUint32(triton::arch::x86::ID_INS_AAA));
@@ -3053,9 +3051,10 @@ namespace triton {
         xPyDict_SetItemString(x86OpcodesDict, "XSTORE", PyLong_FromUint32(triton::arch::x86::ID_INS_XSTORE));
         xPyDict_SetItemString(x86OpcodesDict, "XTEST", PyLong_FromUint32(triton::arch::x86::ID_INS_XTEST));
 
+        PyObject* x86OpcodesDictClass = xPyClass_New(nullptr, x86OpcodesDict, xPyString_FromString("X86"));
+        xPyDict_SetItemString(opcodesDict, "X86", x86OpcodesDictClass);
+
         PyObject* Aarch64OpcodesDict      = xPyDict_New();
-        PyObject* Aarch64OpcodesDictClass = xPyClass_New(nullptr, Aarch64OpcodesDict, xPyString_FromString("AARCH64"));
-        xPyDict_SetItemString(opcodesDict, "AARCH64", Aarch64OpcodesDictClass);
 
         xPyDict_SetItemString(Aarch64OpcodesDict, "ABS", PyLong_FromUint32(triton::arch::aarch64::ID_INS_ABS));
         xPyDict_SetItemString(Aarch64OpcodesDict, "ADC", PyLong_FromUint32(triton::arch::aarch64::ID_INS_ADC));
@@ -3473,6 +3472,9 @@ namespace triton {
         xPyDict_SetItemString(Aarch64OpcodesDict, "XTN", PyLong_FromUint32(triton::arch::aarch64::ID_INS_XTN));
         xPyDict_SetItemString(Aarch64OpcodesDict, "ZIP1", PyLong_FromUint32(triton::arch::aarch64::ID_INS_ZIP1));
         xPyDict_SetItemString(Aarch64OpcodesDict, "ZIP2", PyLong_FromUint32(triton::arch::aarch64::ID_INS_ZIP2));
+
+        PyObject* Aarch64OpcodesDictClass = xPyClass_New(nullptr, Aarch64OpcodesDict, xPyString_FromString("AARCH64"));
+        xPyDict_SetItemString(opcodesDict, "AARCH64", Aarch64OpcodesDictClass);
       }
 
     }; /* python namespace */

--- a/src/libtriton/bindings/python/namespaces/initPrefixesNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initPrefixesNamespace.cpp
@@ -44,14 +44,15 @@ namespace triton {
         PyDict_Clear(prefixesDict);
 
         PyObject* x86PrefixesDict      = xPyDict_New();
-        PyObject* x86PrefixesDictClass = xPyClass_New(nullptr, x86PrefixesDict, xPyString_FromString("X86"));
-        xPyDict_SetItemString(prefixesDict, "X86", x86PrefixesDictClass);
 
         xPyDict_SetItemString(x86PrefixesDict, "INVALID", PyLong_FromUint32(triton::arch::x86::ID_PREFIX_INVALID));
         xPyDict_SetItemString(x86PrefixesDict, "LOCK",    PyLong_FromUint32(triton::arch::x86::ID_PREFIX_LOCK));
         xPyDict_SetItemString(x86PrefixesDict, "REP",     PyLong_FromUint32(triton::arch::x86::ID_PREFIX_REP));
         xPyDict_SetItemString(x86PrefixesDict, "REPE",    PyLong_FromUint32(triton::arch::x86::ID_PREFIX_REPE));
         xPyDict_SetItemString(x86PrefixesDict, "REPNE",   PyLong_FromUint32(triton::arch::x86::ID_PREFIX_REPNE));
+
+        PyObject* x86PrefixesDictClass = xPyClass_New(nullptr, x86PrefixesDict, xPyString_FromString("X86"));
+        xPyDict_SetItemString(prefixesDict, "X86", x86PrefixesDictClass);
       }
 
     }; /* python namespace */

--- a/src/libtriton/bindings/python/namespaces/initRegNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initRegNamespace.cpp
@@ -74,11 +74,10 @@ namespace triton {
       void initRegNamespace(PyObject* registersDict) {
         PyDict_Clear(registersDict);
 
-        PyObject* x86RegistersDict      = xPyDict_New();
-        PyObject* x86RegistersDictClass = xPyClass_New(nullptr, x86RegistersDict, xPyString_FromString("X86"));
-        xPyDict_SetItemString(registersDict, "X86", x86RegistersDictClass);
+        // Create X86 REG namespace
 
-        // Init X86 REG namespace
+        PyObject* x86RegistersDict      = xPyDict_New();
+
         #define REG_SPEC(UPPER_NAME, _1, _2, _3, _4, _5, _6, _7, X86_AVAIL) \
           if (X86_AVAIL) \
             xPyDict_SetItemString(x86RegistersDict, #UPPER_NAME, PyLong_FromUint32(triton::arch::ID_REG_X86_##UPPER_NAME));
@@ -86,27 +85,34 @@ namespace triton {
         #define REG_SPEC_NO_CAPSTONE REG_SPEC
         #include "triton/x86.spec"
 
-        PyObject* x8664RegistersDict      = xPyDict_New();
-        PyObject* x8664RegistersDictClass = xPyClass_New(nullptr, x8664RegistersDict, xPyString_FromString("X86_64"));
-        xPyDict_SetItemString(registersDict, "X86_64", x8664RegistersDictClass);
+        PyObject* x86RegistersDictClass = xPyClass_New(nullptr, x86RegistersDict, xPyString_FromString("X86"));
+        xPyDict_SetItemString(registersDict, "X86", x86RegistersDictClass);
 
-        // Init X86_64 REG namespace
+        // Create X86_64 REG namespace
+
+        PyObject* x8664RegistersDict      = xPyDict_New();
+
         #define REG_SPEC(UPPER_NAME, _1, _2, _3, _4, _5, _6, _7, _8) \
           xPyDict_SetItemString(x8664RegistersDict, #UPPER_NAME, PyLong_FromUint32(triton::arch::ID_REG_X86_##UPPER_NAME));
         // Use REG not available in capstone as normal register
         #define REG_SPEC_NO_CAPSTONE REG_SPEC
         #include "triton/x86.spec"
 
-        PyObject* aarch64RegistersDict      = xPyDict_New();
-        PyObject* aarch64RegistersDictClass = xPyClass_New(nullptr, aarch64RegistersDict, xPyString_FromString("AARCH64"));
-        xPyDict_SetItemString(registersDict, "AARCH64", aarch64RegistersDictClass);
+        PyObject* x8664RegistersDictClass = xPyClass_New(nullptr, x8664RegistersDict, xPyString_FromString("X86_64"));
+        xPyDict_SetItemString(registersDict, "X86_64", x8664RegistersDictClass);
 
-        // Init AArch64 REG namespace
+        // Create AArch64 REG namespace
+
+        PyObject* aarch64RegistersDict      = xPyDict_New();
+
         #define REG_SPEC(UPPER_NAME, _1, _2, _3, _4, _5) \
           xPyDict_SetItemString(aarch64RegistersDict, #UPPER_NAME, PyLong_FromUint32(triton::arch::ID_REG_AARCH64_##UPPER_NAME));
         // Use REG not available in capstone as normal register
         #define REG_SPEC_NO_CAPSTONE REG_SPEC
         #include "triton/aarch64.spec"
+
+        PyObject* aarch64RegistersDictClass = xPyClass_New(nullptr, aarch64RegistersDict, xPyString_FromString("AARCH64"));
+        xPyDict_SetItemString(registersDict, "AARCH64", aarch64RegistersDictClass);
       }
 
     }; /* python namespace */

--- a/src/libtriton/bindings/python/namespaces/initShiftsNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initShiftsNamespace.cpp
@@ -52,14 +52,15 @@ namespace triton {
         PyDict_Clear(shiftsDict);
 
         PyObject* aarch64ShiftsDict      = xPyDict_New();
-        PyObject* aarch64ShiftsDictClass = xPyClass_New(nullptr, aarch64ShiftsDict, xPyString_FromString("AARCH64"));
-        xPyDict_SetItemString(shiftsDict, "AARCH64", aarch64ShiftsDictClass);
 
         xPyDict_SetItemString(aarch64ShiftsDict, "INVALID", PyLong_FromUint32(triton::arch::aarch64::ID_SHIFT_INVALID));
         xPyDict_SetItemString(aarch64ShiftsDict, "ASR",     PyLong_FromUint32(triton::arch::aarch64::ID_SHIFT_ASR));
         xPyDict_SetItemString(aarch64ShiftsDict, "LSL",     PyLong_FromUint32(triton::arch::aarch64::ID_SHIFT_LSL));
         xPyDict_SetItemString(aarch64ShiftsDict, "LSR",     PyLong_FromUint32(triton::arch::aarch64::ID_SHIFT_LSR));
         xPyDict_SetItemString(aarch64ShiftsDict, "ROR",     PyLong_FromUint32(triton::arch::aarch64::ID_SHIFT_ROR));
+
+        PyObject* aarch64ShiftsDictClass = xPyClass_New(nullptr, aarch64ShiftsDict, xPyString_FromString("AARCH64"));
+        xPyDict_SetItemString(shiftsDict, "AARCH64", aarch64ShiftsDictClass);
       }
 
     }; /* python namespace */

--- a/src/libtriton/bindings/python/objects/pyAstContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyAstContext.cpp
@@ -19,11 +19,12 @@
 
 /* setup doctest context
 
+>>> from __future__ import print_function
 >>> from triton import REG, TritonContext, ARCH, Instruction, AST_REPRESENTATION
 >>> ctxt = TritonContext()
 >>> ctxt.setArchitecture(ARCH.X86_64)
 
->>> opcode = "\x48\x31\xD0"
+>>> opcode = b"\x48\x31\xD0"
 >>> inst = Instruction()
 
 >>> inst.setOpcode(opcode)
@@ -33,7 +34,7 @@
 
 >>> ctxt.processing(inst)
 True
->>> print inst
+>>> print(inst)
 0x400000: xor rax, rdx
 
 */
@@ -1223,7 +1224,7 @@ namespace triton {
         /* Extract arguments */
         PyArg_ParseTuple(args, "|OOO", &op1, &op2, &op3);
 
-        if (op1 == nullptr || !PyString_Check(op1))
+        if (op1 == nullptr || !PyStr_Check(op1))
           return PyErr_Format(PyExc_TypeError, "let(): expected a string as first argument");
 
         if (op2 == nullptr || !PyAstNode_Check(op2))
@@ -1233,7 +1234,7 @@ namespace triton {
           return PyErr_Format(PyExc_TypeError, "let(): expected a AstNode as third argument");
 
         try {
-          return PyAstNode(PyAstContext_AsAstContext(self)->let(PyString_AsString(op1), PyAstNode_AsAstNode(op2), PyAstNode_AsAstNode(op3)));
+          return PyAstNode(PyAstContext_AsAstContext(self)->let(PyStr_AsString(op1), PyAstNode_AsAstNode(op2), PyAstNode_AsAstNode(op3)));
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -1323,11 +1324,11 @@ namespace triton {
 
 
       static PyObject* AstContext_string(PyObject* self, PyObject* expr) {
-        if (!PyString_Check(expr))
+        if (!PyStr_Check(expr))
           return PyErr_Format(PyExc_TypeError, "string(): expected a string as first argument");
 
         try {
-          return PyAstNode(PyAstContext_AsAstContext(self)->string(PyString_AsString(expr)));
+          return PyAstNode(PyAstContext_AsAstContext(self)->string(PyStr_AsString(expr)));
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -1446,7 +1447,7 @@ namespace triton {
         // return z3.ExprRef(ast)
         PyObject* z3ExprRef = PyObject_GetAttrString(z3mod, "ExprRef");
         pyArgs = Py_BuildValue("(O)", retAst);
-        PyObject* retExpr = PyInstance_New(z3ExprRef, pyArgs, nullptr);
+        PyObject* retExpr = PyObject_CallObject(z3ExprRef, pyArgs);
         Py_DECREF(pyArgs);
         Py_DECREF(retAst);
         Py_DECREF(z3ExprRef);
@@ -1523,8 +1524,7 @@ namespace triton {
 
       //! Python description for an ast context.
       PyTypeObject AstContext_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "AstContext",                               /* tp_name */
         sizeof(AstContext_Object),                  /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pyAstNode.cpp
+++ b/src/libtriton/bindings/python/objects/pyAstNode.cpp
@@ -372,10 +372,10 @@ namespace triton {
       }
 
 
-      static int AstNode_print(PyObject* self) {
+      /*static int AstNode_print(PyObject* self) {
         std::cout << PyAstNode_AsAstNode(self);
         return 0;
-      }
+      }*/
 
 
       static int AstNode_cmp(PyObject* a, PyObject* b) {

--- a/src/libtriton/bindings/python/objects/pyAstNode.cpp
+++ b/src/libtriton/bindings/python/objects/pyAstNode.cpp
@@ -378,16 +378,25 @@ namespace triton {
       }
 
 
-      static int AstNode_cmp(AstNode_Object* a, AstNode_Object* b) {
-        return !(a->node->hash(1) == b->node->hash(1));
+      static int AstNode_cmp(PyObject* a, PyObject* b) {
+        if (!PyAstNode_Check(a) || !PyAstNode_Check(b)) {
+          PyErr_Format(
+            PyExc_TypeError,
+            "__cmp__ not supported between instances of '%.100s' and '%.100s'",
+            a->ob_type->tp_name,
+            b->ob_type->tp_name);
+          return -1;
+        }
+        auto ha = PyAstNode_AsAstNode(a)->hash(1);
+        auto hb = PyAstNode_AsAstNode(b)->hash(1);
+        return (ha == hb ? 0 : (ha > hb ? 1 : -1));
       }
-
 
       static PyObject* AstNode_str(PyObject* self) {
         try {
           std::stringstream str;
           str << PyAstNode_AsAstNode(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -635,30 +644,38 @@ namespace triton {
         AstNode_operatorAdd,                        /* nb_add */
         AstNode_operatorSub,                        /* nb_subtract */
         AstNode_operatorMul,                        /* nb_multiply */
+#if !defined(IS_PY3) || !IS_PY3
         AstNode_operatorDiv,                        /* nb_divide */
+#endif
         AstNode_operatorRem,                        /* nb_remainder */
         0,                                          /* nb_divmod */
         0,                                          /* nb_power */
         AstNode_operatorNeg,                        /* nb_negative */
         0,                                          /* nb_positive */
         0,                                          /* nb_absolute */
-        0,                                          /* nb_nonzero */
+        0,                                          /* nb_nonzero/nb_bool */
         AstNode_operatorNot,                        /* nb_invert */
         AstNode_operatorShl,                        /* nb_lshift */
         AstNode_operatorShr,                        /* nb_rshift */
         AstNode_operatorAnd,                        /* nb_and */
         AstNode_operatorXor,                        /* nb_xor */
         AstNode_operatorOr,                         /* nb_or */
+#if !defined(IS_PY3) || !IS_PY3
         AstNode_coerce,                             /* nb_coerce */
+#endif
         0,                                          /* nb_int */
-        0,                                          /* nb_long */
+        0,                                          /* nb_long/nb_reserved */
         0,                                          /* nb_float */
+#if !defined(IS_PY3) || !IS_PY3
         0,                                          /* nb_oct */
         0,                                          /* nb_hex */
+#endif
         AstNode_operatorAdd,                        /* nb_inplace_add */
         AstNode_operatorSub,                        /* nb_inplace_subtract */
         AstNode_operatorMul,                        /* nb_inplace_multiply */
+#if !defined(IS_PY3) || !IS_PY3
         AstNode_operatorDiv,                        /* nb_inplace_divide */
+#endif
         AstNode_operatorRem,                        /* nb_inplace_remainder */
         0,                                          /* nb_inplace_power */
         AstNode_operatorShl,                        /* nb_inplace_lshift */
@@ -666,25 +683,32 @@ namespace triton {
         AstNode_operatorAnd,                        /* nb_inplace_and */
         AstNode_operatorXor,                        /* nb_inplace_xor */
         AstNode_operatorOr,                         /* nb_inplace_or */
-        0,                                          /* nb_floor_divide */
+        AstNode_operatorDiv,                        /* nb_floor_divide */
         0,                                          /* nb_true_divide */
-        0,                                          /* nb_inplace_floor_divide */
+        AstNode_operatorDiv,                        /* nb_inplace_floor_divide */
         0,                                          /* nb_inplace_true_divide */
         0,                                          /* nb_index */
+#if defined(IS_PY3) && IS_PY3
+        0,                                          /* nb_matrix_multiply */
+        0,                                          /* nb_inplace_matrix_multiply */
+#endif
       };
 
 
       PyTypeObject AstNode_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "AstNode",                                  /* tp_name */
         sizeof(AstNode_Object),                     /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)AstNode_dealloc,                /* tp_dealloc */
-        (printfunc)AstNode_print,                   /* tp_print */
+        0,/*(printfunc)AstNode_print,*/             /* tp_print -> int tp_print(PyObject *self, FILE *file, int flags) */
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
+#if defined(IS_PY3) && IS_PY3
+        0,                                          /* tp_as_async */
+#else
         (cmpfunc)AstNode_cmp,                       /* tp_compare */
+#endif
         0,                                          /* tp_repr */
         &AstNode_NumberMethods,                     /* tp_as_number */
         0,                                          /* tp_as_sequence */

--- a/src/libtriton/bindings/python/objects/pyBitsVector.cpp
+++ b/src/libtriton/bindings/python/objects/pyBitsVector.cpp
@@ -126,7 +126,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PyBitsVector_AsBitsVector(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -145,8 +145,7 @@ namespace triton {
 
 
       PyTypeObject BitsVector_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "BitsVector",                               /* tp_name */
         sizeof(BitsVector_Object),                  /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pyImmediate.cpp
+++ b/src/libtriton/bindings/python/objects/pyImmediate.cpp
@@ -21,7 +21,7 @@
 >>> ctxt.setArchitecture(ARCH.X86_64)
 
 >>> inst = Instruction()
->>> inst.setOpcode("\xB8\x14\x00\x00\x00")
+>>> inst.setOpcode(b"\xB8\x14\x00\x00\x00")
 
 */
 
@@ -221,7 +221,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PyImmediate_AsImmediate(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -244,8 +244,7 @@ namespace triton {
 
 
       PyTypeObject Immediate_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "Immediate",                                /* tp_name */
         sizeof(Immediate_Object),                   /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pyInstruction.cpp
+++ b/src/libtriton/bindings/python/objects/pyInstruction.cpp
@@ -255,7 +255,7 @@ namespace triton {
       static PyObject* Instruction_getDisassembly(PyObject* self, PyObject* noarg) {
         try {
           if (!PyInstruction_AsInstruction(self)->getDisassembly().empty())
-            return PyString_FromFormat("%s", PyInstruction_AsInstruction(self)->getDisassembly().c_str());
+            return PyStr_FromFormat("%s", PyInstruction_AsInstruction(self)->getDisassembly().c_str());
           Py_INCREF(Py_None);
           return Py_None;
         }
@@ -683,7 +683,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PyInstruction_AsInstruction(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -727,8 +727,7 @@ namespace triton {
 
 
       PyTypeObject Instruction_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "Instruction",                              /* tp_name */
         sizeof(Instruction_Object),                 /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pyMemoryAccess.cpp
+++ b/src/libtriton/bindings/python/objects/pyMemoryAccess.cpp
@@ -19,7 +19,7 @@
 >>> ctxt = TritonContext()
 >>> ctxt.setArchitecture(ARCH.X86_64)
 
->>> inst = Instruction("\x8A\xA4\x4A\x00\x01\x00\x00")
+>>> inst = Instruction(b"\x8A\xA4\x4A\x00\x01\x00\x00")
 >>> inst.setAddress(0x40000)
 
 */
@@ -395,7 +395,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PyMemoryAccess_AsMemoryAccess(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -427,8 +427,7 @@ namespace triton {
 
 
       PyTypeObject MemoryAccess_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "MemoryAccess",                             /* tp_name */
         sizeof(MemoryAccess_Object),                /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pyPathConstraint.cpp
+++ b/src/libtriton/bindings/python/objects/pyPathConstraint.cpp
@@ -112,10 +112,10 @@ namespace triton {
           ret = xPyList_New(branches.size());
           for (triton::usize index = 0; index != branches.size(); index++) {
             PyObject* dict = xPyDict_New();
-            xPyDict_SetItem(dict, PyString_FromString("isTaken"),    PyBool_FromLong(std::get<0>(branches[index])));
-            xPyDict_SetItem(dict, PyString_FromString("srcAddr"),    PyLong_FromUint64(std::get<1>(branches[index])));
-            xPyDict_SetItem(dict, PyString_FromString("dstAddr"),    PyLong_FromUint64(std::get<2>(branches[index])));
-            xPyDict_SetItem(dict, PyString_FromString("constraint"), PyAstNode(std::get<3>(branches[index])));
+            xPyDict_SetItem(dict, PyStr_FromString("isTaken"),    PyBool_FromLong(std::get<0>(branches[index])));
+            xPyDict_SetItem(dict, PyStr_FromString("srcAddr"),    PyLong_FromUint64(std::get<1>(branches[index])));
+            xPyDict_SetItem(dict, PyStr_FromString("dstAddr"),    PyLong_FromUint64(std::get<2>(branches[index])));
+            xPyDict_SetItem(dict, PyStr_FromString("constraint"), PyAstNode(std::get<3>(branches[index])));
             PyList_SetItem(ret, index, dict);
           }
 
@@ -170,8 +170,7 @@ namespace triton {
 
 
       PyTypeObject PathConstraint_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "PathConstraint",                           /* tp_name */
         sizeof(PathConstraint_Object),              /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pyRegister.cpp
+++ b/src/libtriton/bindings/python/objects/pyRegister.cpp
@@ -19,7 +19,7 @@
 >>> ctxt = TritonContext()
 >>> ctxt.setArchitecture(ARCH.X86_64)
 
->>> inst = Instruction("\x8A\xA4\x4A\x00\x01\x00\x00")
+>>> inst = Instruction(b"\x8A\xA4\x4A\x00\x01\x00\x00")
 >>> inst.setAddress(0x40000)
 
 */
@@ -284,7 +284,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PyRegister_AsRegister(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -351,8 +351,7 @@ namespace triton {
 
 
       PyTypeObject Register_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "Register",                                 /* tp_name */
         sizeof(Register_Object),                    /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pySolverModel.cpp
+++ b/src/libtriton/bindings/python/objects/pySolverModel.cpp
@@ -130,7 +130,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PySolverModel_AsSolverModel(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -148,8 +148,7 @@ namespace triton {
 
 
       PyTypeObject SolverModel_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "SolverModel",                              /* tp_name */
         sizeof(SolverModel_Object),                 /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
+++ b/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
@@ -270,9 +270,9 @@ namespace triton {
 
       static PyObject* SymbolicExpression_setComment(PyObject* self, PyObject* comment) {
         try {
-          if (!PyString_Check(comment))
+          if (!PyStr_Check(comment))
             return PyErr_Format(PyExc_TypeError, "SymbolicExpression::setComment(): Expected a string as argument.");
-          PySymbolicExpression_AsSymbolicExpression(self)->setComment(PyString_AsString(comment));
+          PySymbolicExpression_AsSymbolicExpression(self)->setComment(PyStr_AsString(comment));
           Py_INCREF(Py_None);
           return Py_None;
         }
@@ -292,7 +292,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PySymbolicExpression_AsSymbolicExpression(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -329,8 +329,7 @@ namespace triton {
 
 
       PyTypeObject SymbolicExpression_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "SymbolicExpression",                       /* tp_name */
         sizeof(SymbolicExpression_Object),          /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pySymbolicVariable.cpp
+++ b/src/libtriton/bindings/python/objects/pySymbolicVariable.cpp
@@ -156,9 +156,9 @@ namespace triton {
 
       static PyObject* SymbolicVariable_setAlias(PyObject* self, PyObject* alias) {
         try {
-          if (!PyString_Check(alias))
+          if (!PyStr_Check(alias))
             return PyErr_Format(PyExc_TypeError, "SymbolicVariable::setAlias(): Expected a string as argument.");
-          PySymbolicVariable_AsSymbolicVariable(self)->setAlias(PyString_AsString(alias));
+          PySymbolicVariable_AsSymbolicVariable(self)->setAlias(PyStr_AsString(alias));
           Py_INCREF(Py_None);
           return Py_None;
         }
@@ -170,9 +170,9 @@ namespace triton {
 
       static PyObject* SymbolicVariable_setComment(PyObject* self, PyObject* comment) {
         try {
-          if (!PyString_Check(comment))
+          if (!PyStr_Check(comment))
             return PyErr_Format(PyExc_TypeError, "SymbolicVariable::setComment(): Expected a string as argument.");
-          PySymbolicVariable_AsSymbolicVariable(self)->setComment(PyString_AsString(comment));
+          PySymbolicVariable_AsSymbolicVariable(self)->setComment(PyStr_AsString(comment));
           Py_INCREF(Py_None);
           return Py_None;
         }
@@ -192,7 +192,7 @@ namespace triton {
         try {
           std::stringstream str;
           str << PySymbolicVariable_AsSymbolicVariable(self);
-          return PyString_FromFormat("%s", str.str().c_str());
+          return PyStr_FromFormat("%s", str.str().c_str());
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
@@ -226,8 +226,7 @@ namespace triton {
 
 
       PyTypeObject SymbolicVariable_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "SymbolicVariable",                         /* tp_name */
         sizeof(SymbolicVariable_Object),            /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -409,7 +409,7 @@ namespace triton {
 
         PyObject* registersDict = xPyDict_New();
         for (auto& reg : regs)
-          xPyDict_SetItem(registersDict, PyString_FromString(reg.second.getName().c_str()), PyRegister(reg.second));
+          xPyDict_SetItem(registersDict, xPyString_FromString(reg.second.getName().c_str()), PyRegister(reg.second));
 
         Py_XDECREF(((TritonContext_Object*)(self))->regAttr);
         ((TritonContext_Object*)(self))->regAttr = xPyClass_New(nullptr, registersDict, xPyString_FromString("registers"));
@@ -474,7 +474,7 @@ namespace triton {
                   /* Fetch the last exception */
                   PyErr_Fetch(&type, &value, &traceback);
 
-                  std::string str = PyString_AsString(PyObject_Str(value));
+                  std::string str = PyStr_AsString(PyObject_Str(value));
                   Py_XDECREF(type);
                   Py_XDECREF(value);
                   Py_XDECREF(traceback);
@@ -518,7 +518,7 @@ namespace triton {
                   /* Fetch the last exception */
                   PyErr_Fetch(&type, &value, &traceback);
 
-                  std::string str = PyString_AsString(PyObject_Str(value));
+                  std::string str = PyStr_AsString(PyObject_Str(value));
                   Py_XDECREF(type);
                   Py_XDECREF(value);
                   Py_XDECREF(traceback);
@@ -564,7 +564,7 @@ namespace triton {
                   /* Fetch the last exception */
                   PyErr_Fetch(&type, &value, &traceback);
 
-                  std::string str = PyString_AsString(PyObject_Str(value));
+                  std::string str = PyStr_AsString(PyObject_Str(value));
                   Py_XDECREF(type);
                   Py_XDECREF(value);
                   Py_XDECREF(traceback);
@@ -610,7 +610,7 @@ namespace triton {
                   /* Fetch the last exception */
                   PyErr_Fetch(&type, &value, &traceback);
 
-                  std::string str = PyString_AsString(PyObject_Str(value));
+                  std::string str = PyStr_AsString(PyObject_Str(value));
                   Py_XDECREF(type);
                   Py_XDECREF(value);
                   Py_XDECREF(traceback);
@@ -654,7 +654,7 @@ namespace triton {
                   /* Fetch the last exception */
                   PyErr_Fetch(&type, &value, &traceback);
 
-                  std::string str = PyString_AsString(PyObject_Str(value));
+                  std::string str = PyStr_AsString(PyObject_Str(value));
                   Py_XDECREF(type);
                   Py_XDECREF(value);
                   Py_XDECREF(traceback);
@@ -857,11 +857,11 @@ namespace triton {
         if (symVarSize == nullptr || (!PyLong_Check(symVarSize) && !PyInt_Check(symVarSize)))
           return PyErr_Format(PyExc_TypeError, "convertExpressionToSymbolicVariable(): Expects an integer as second argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "convertExpressionToSymbolicVariable(): Expects a sting as third argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         try {
           return PySymbolicVariable(PyTritonContext_AsTritonContext(self)->convertExpressionToSymbolicVariable(PyLong_AsUsize(exprId), PyLong_AsUint32(symVarSize), ccomment));
@@ -883,11 +883,11 @@ namespace triton {
         if (mem == nullptr || (!PyMemoryAccess_Check(mem)))
           return PyErr_Format(PyExc_TypeError, "convertMemoryToSymbolicVariable(): Expects a MemoryAccess as first argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "convertMemoryToSymbolicVariable(): Expects a sting as second argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         try {
           return PySymbolicVariable(PyTritonContext_AsTritonContext(self)->convertMemoryToSymbolicVariable(*PyMemoryAccess_AsMemoryAccess(mem), ccomment));
@@ -909,11 +909,11 @@ namespace triton {
         if (reg == nullptr || (!PyRegister_Check(reg)))
           return PyErr_Format(PyExc_TypeError, "convertRegisterToSymbolicVariable(): Expects a Register as first argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "convertRegisterToSymbolicVariable(): Expects a sting as second argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         try {
           return PySymbolicVariable(PyTritonContext_AsTritonContext(self)->convertRegisterToSymbolicVariable(*PyRegister_AsRegister(reg), ccomment));
@@ -934,7 +934,7 @@ namespace triton {
         /* Extract arguments */
         PyArg_ParseTuple(args, "|OOOO", &inst, &node, &flag, &comment);
 
-        if (inst == nullptr || (!PyInstance_Check(inst)))
+        if (inst == nullptr || (!PyInstruction_Check(inst)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicFlagExpression(): Expects an Instruction as first argument.");
 
         if (node == nullptr || (!PyAstNode_Check(node)))
@@ -943,11 +943,11 @@ namespace triton {
         if (flag == nullptr || (!PyRegister_Check(flag)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicFlagExpression(): Expects a Register as third argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "createSymbolicFlagExpression(): Expects a sting as fourth argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         triton::arch::Instruction arg1 = *PyInstruction_AsInstruction(inst);
         triton::ast::SharedAbstractNode arg2 = PyAstNode_AsAstNode(node);
@@ -972,7 +972,7 @@ namespace triton {
         /* Extract arguments */
         PyArg_ParseTuple(args, "|OOOO", &inst, &node, &mem, &comment);
 
-        if (inst == nullptr || (!PyInstance_Check(inst)))
+        if (inst == nullptr || (!PyInstruction_Check(inst)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicMemoryExpression(): Expects an Instruction as first argument.");
 
         if (node == nullptr || (!PyAstNode_Check(node)))
@@ -981,11 +981,11 @@ namespace triton {
         if (mem == nullptr || (!PyMemoryAccess_Check(mem)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicMemoryExpression(): Expects a MemoryAccess as third argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "createSymbolicMemoryExpression(): Expects a sting as fourth argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         triton::arch::Instruction arg1 = *PyInstruction_AsInstruction(inst);
         triton::ast::SharedAbstractNode arg2 = PyAstNode_AsAstNode(node);
@@ -1010,7 +1010,7 @@ namespace triton {
         /* Extract arguments */
         PyArg_ParseTuple(args, "|OOOO", &inst, &node, &reg, &comment);
 
-        if (inst == nullptr || (!PyInstance_Check(inst)))
+        if (inst == nullptr || (!PyInstruction_Check(inst)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicRegisterExpression(): Expects an Instruction as first argument.");
 
         if (node == nullptr || (!PyAstNode_Check(node)))
@@ -1019,11 +1019,11 @@ namespace triton {
         if (reg == nullptr || (!PyRegister_Check(reg)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicRegisterExpression(): Expects a Register as third argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "createSymbolicRegisterExpression(): Expects a sting as fourth argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         triton::arch::Instruction arg1 = *PyInstruction_AsInstruction(inst);
         triton::ast::SharedAbstractNode arg2 = PyAstNode_AsAstNode(node);
@@ -1047,17 +1047,17 @@ namespace triton {
         /* Extract arguments */
         PyArg_ParseTuple(args, "|OOO", &inst, &node, &comment);
 
-        if (inst == nullptr || (!PyInstance_Check(inst)))
+        if (inst == nullptr || (!PyInstruction_Check(inst)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicVolatileExpression(): Expects an Instruction as first argument.");
 
         if (node == nullptr || (!PyAstNode_Check(node)))
           return PyErr_Format(PyExc_TypeError, "createSymbolicVolatileExpression(): Expects a AstNode as second argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "createSymbolicVolatileExpression(): Expects a sting as third argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         triton::arch::Instruction arg1 = *PyInstruction_AsInstruction(inst);
         triton::ast::SharedAbstractNode arg2 = PyAstNode_AsAstNode(node);
@@ -1598,11 +1598,11 @@ namespace triton {
 
 
       static PyObject* TritonContext_getSymbolicVariableFromName(PyObject* self, PyObject* symVarName) {
-        if (!PyString_Check(symVarName))
+        if (!PyStr_Check(symVarName))
           return PyErr_Format(PyExc_TypeError, "getSymbolicVariableFromName(): Expects a string as argument.");
 
         try {
-          std::string arg = PyString_AsString(symVarName);
+          std::string arg = PyStr_AsString(symVarName);
           return PySymbolicVariable(PyTritonContext_AsTritonContext(self)->getSymbolicVariableFromName(arg));
         }
         catch (const triton::exceptions::Exception& e) {
@@ -1937,11 +1937,11 @@ namespace triton {
         if (node == nullptr || (!PyAstNode_Check(node)))
           return PyErr_Format(PyExc_TypeError, "newSymbolicExpression(): Expects a AstNode as first argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "newSymbolicExpression(): Expects a sting as second argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         try {
           return PySymbolicExpression(PyTritonContext_AsTritonContext(self)->newSymbolicExpression(PyAstNode_AsAstNode(node), ccomment));
@@ -1963,11 +1963,11 @@ namespace triton {
         if (size == nullptr || (!PyLong_Check(size) && !PyInt_Check(size)))
           return PyErr_Format(PyExc_TypeError, "newSymbolicVariable(): Expects an integer as first argument.");
 
-        if (comment != nullptr && !PyString_Check(comment))
+        if (comment != nullptr && !PyStr_Check(comment))
           return PyErr_Format(PyExc_TypeError, "newSymbolicVariable(): Expects a sting as second  argument.");
 
         if (comment != nullptr)
-          ccomment = PyString_AsString(comment);
+          ccomment = PyStr_AsString(comment);
 
         try {
           return PySymbolicVariable(PyTritonContext_AsTritonContext(self)->newSymbolicVariable(PyLong_AsUint32(size), ccomment));
@@ -2738,7 +2738,7 @@ namespace triton {
       static PyObject* TritonContext_getattro(PyObject* self, PyObject* name) {
         try {
           /* Access to the registers attribute */
-          if (std::string(PyString_AsString(name)) == "registers") {
+          if (std::string(PyStr_AsString(name)) == "registers") {
 
             /* Check if the architecture is defined */
             if (PyTritonContext_AsTritonContext(self)->getArchitecture() == triton::arch::ARCH_INVALID)
@@ -2869,8 +2869,7 @@ namespace triton {
 
       //! Description of the python representation of a TritonContext
       PyTypeObject TritonContext_Type = {
-        PyObject_HEAD_INIT(&PyType_Type)
-        0,                                          /* ob_size */
+        PyVarObject_HEAD_INIT(&PyType_Type, 0)
         "TritonContext",                            /* tp_name */
         sizeof(TritonContext_Object),               /* tp_basicsize */
         0,                                          /* tp_itemsize */

--- a/src/libtriton/bindings/python/pyXFunctions.cpp
+++ b/src/libtriton/bindings/python/pyXFunctions.cpp
@@ -8,8 +8,6 @@
 #include <triton/pythonXFunctions.hpp>
 #include <iostream>
 
-
-
 namespace triton {
   namespace bindings {
     namespace python {
@@ -45,7 +43,7 @@ namespace triton {
 
 
       PyObject* xPyString_FromString(const char *v) {
-        PyObject* s = PyString_FromString(v);
+        PyObject* s = PyStr_FromString(v);
         if (!s)
           notEnoughMemory();
         return s;
@@ -53,7 +51,10 @@ namespace triton {
 
 
       PyObject* xPyClass_New(PyObject* b, PyObject* d, PyObject* n) {
-        PyObject* c = PyClass_New(b, d, n);
+        if (b == NULL)
+          b = PyTuple_New(0);
+
+        PyObject *c = PyObject_CallFunctionObjArgs((PyObject*)&PyType_Type, n, b, d, NULL);
 
         if (!c)
           notEnoughMemory();
@@ -64,6 +65,7 @@ namespace triton {
 
         return c;
       }
+
 
 
       int xPyDict_SetItemString(PyObject* p, const char* key, PyObject* val) {

--- a/src/libtriton/bindings/python/utils.cpp
+++ b/src/libtriton/bindings/python/utils.cpp
@@ -143,96 +143,106 @@ namespace triton {
 
       triton::uint128 PyLong_AsUint128(PyObject* vv) {
         PyLongObject* v;
-        triton::uint128 x, prev;
+        boost::multiprecision::checked_int128_t tmp;
         Py_ssize_t i;
 
         if (vv == NULL || !PyLong_Check(vv)) {
-          if (vv != NULL && PyInt_Check(vv)) {
-              triton::uint128 val = PyInt_AsLong(vv);
-              return val;
-          }
-          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint128(): Bad internal call.");
+          if (vv != NULL && PyInt_Check(vv))
+            return PyInt_AsLong(vv);
+          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): bad internal call.");
         }
 
         v = reinterpret_cast<PyLongObject*>(vv);
         i = Py_SIZE(v);
-        x = 0;
-        if (i < 0)
-          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint128(): Cannot convert negative value to unsigned long.");
 
-        while (--i >= 0) {
-            prev = x;
-            x = (x << PyLong_SHIFT) | v->ob_digit[i];
-            if ((x >> PyLong_SHIFT) != prev)
-                throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint128(): long int too large to convert.");
+        const bool neg = (i <= 0);
+        if (neg) {
+          if (i == 0)
+            return 0;
+          i = -i;
         }
 
-        return x;
+        try {
+          import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+        }
+        catch (std::overflow_error&) {
+          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
+        }
+
+        return static_cast<triton::uint128>(neg ? -tmp : tmp);
       }
 
 
       triton::uint256 PyLong_AsUint256(PyObject* vv) {
         PyLongObject* v;
-        triton::uint256 x, prev;
+        boost::multiprecision::checked_int256_t tmp;
         Py_ssize_t i;
 
         if (vv == NULL || !PyLong_Check(vv)) {
-          if (vv != NULL && PyInt_Check(vv)) {
-              triton::uint256 val = PyInt_AsLong(vv);
-              return val;
-          }
-          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): Bad internal call.");
+          if (vv != NULL && PyInt_Check(vv))
+              return PyInt_AsLong(vv);
+          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): bad internal call.");
         }
 
         v = reinterpret_cast<PyLongObject*>(vv);
         i = Py_SIZE(v);
-        x = 0;
-        if (i < 0)
-          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): Cannot convert negative value to unsigned long.");
 
-        while (--i >= 0) {
-            prev = x;
-            x = (x << PyLong_SHIFT) | v->ob_digit[i];
-            if ((x >> PyLong_SHIFT) != prev)
-                throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long int too large to convert.");
+        const bool neg = (i <= 0);
+        if (neg) {
+          if (i == 0)
+            return 0;
+          i = -i;
         }
 
-        return x;
+        try {
+          import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+        }
+        catch (std::overflow_error&) {
+          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
+        }
+
+        return static_cast<triton::uint256>(neg ? -tmp : tmp);
       }
 
 
       triton::uint512 PyLong_AsUint512(PyObject* vv) {
         PyLongObject* v;
-        triton::uint512 x, prev;
+        boost::multiprecision::checked_int512_t tmp;
         Py_ssize_t i;
 
         if (vv == NULL || !PyLong_Check(vv)) {
-          if (vv != NULL && PyInt_Check(vv)) {
-              triton::uint512 val = PyInt_AsLong(vv);
-              return val;
-          }
-          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint512(): Bad internal call.");
+          if (vv != NULL && PyInt_Check(vv))
+            return PyInt_AsLong(vv);
+          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): bad internal call.");
         }
 
         v = reinterpret_cast<PyLongObject*>(vv);
         i = Py_SIZE(v);
-        x = 0;
-        if (i < 0)
-          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint512(): Cannot convert negative value to unsigned long.");
 
-        while (--i >= 0) {
-            prev = x;
-            x = (x << PyLong_SHIFT) | v->ob_digit[i];
-            if ((x >> PyLong_SHIFT) != prev)
-                throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint512(): long int too large to convert.");
+        const bool neg = (i <= 0);
+        if (neg) {
+          if (i == 0)
+            return 0;
+          i = -i;
         }
 
-        return x;
+        try {
+          import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+        }
+        catch (std::overflow_error&) {
+          throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
+        }
+
+        return static_cast<triton::uint512>(neg ? -tmp : tmp);
       }
 
 
       /* Returns a PyObject from a {32,64}-bits integer */
       PyObject* PyLong_FromUint(triton::__uint value) {
+        // it is mandatory to let Python impl deal with small numbers (static objects)
+        if (value <= std::numeric_limits<unsigned long>::max())
+          return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+
         PyLongObject* v;
         triton::__uint t;
         int ndigits = 0;
@@ -258,9 +268,15 @@ namespace triton {
 
       /* Returns a PyObject from a {32,64}-bits integer */
       PyObject* PyLong_FromUsize(triton::usize value) {
+        // it is mandatory to let Python impl deal with small numbers (static objects)
+        if (value <= std::numeric_limits<unsigned long>::max())
+          return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+
         PyLongObject* v;
         triton::usize t;
         int ndigits = 0;
+
+        
 
         /* Count the number of Python digits. */
         t = value;
@@ -283,6 +299,10 @@ namespace triton {
 
       /* Returns a PyObject from a 32-bits integer */
       PyObject* PyLong_FromUint32(triton::uint32 value) {
+        // it is mandatory to let Python impl deal with small numbers (static objects)
+        if (value <= std::numeric_limits<unsigned long>::max())
+          return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+
         PyLongObject* v;
         triton::uint32 t;
         int ndigits = 0;
@@ -308,6 +328,10 @@ namespace triton {
 
       /* Returns a PyObject from a 64-bits integer */
       PyObject* PyLong_FromUint64(triton::uint64 value) {
+        // it is mandatory to let Python impl deal with small numbers (static objects)
+        if (value <= std::numeric_limits<unsigned long>::max())
+          return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+
         PyLongObject* v;
         triton::uint64 t;
         int ndigits = 0;
@@ -333,24 +357,16 @@ namespace triton {
 
       /* Returns a PyObject from a 128-bits integer */
       PyObject* PyLong_FromUint128(triton::uint128 value) {
+        // it is mandatory to let Python impl deal with small numbers (static objects)
+        if (value <= std::numeric_limits<unsigned long>::max())
+          return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+
         PyLongObject* v;
-        triton::uint128 t;
-        int ndigits = 0;
+        std::vector<digit> digits;
 
-        /* Count the number of Python digits. */
-        t = value;
-        while (t) {
-          ++ndigits;
-          t >>= PyLong_SHIFT;
-        }
-
-        v = _PyLong_New(ndigits);
-        digit* p = v->ob_digit;
-        Py_SIZE(v) = ndigits;
-        while (value) {
-          *p++ = (value & PyLong_MASK).convert_to<digit>();
-          value >>= PyLong_SHIFT;
-        }
+        export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        v = _PyLong_New(digits.size());
+        std::copy(digits.begin(), digits.end(), v->ob_digit);
 
         return (PyObject*)v;
       }
@@ -358,24 +374,16 @@ namespace triton {
 
       /* Returns a PyObject from a 256-bits integer */
       PyObject* PyLong_FromUint256(triton::uint256 value) {
+        // it is mandatory to let Python impl deal with small numbers (static objects)
+        if (value <= std::numeric_limits<unsigned long>::max())
+          return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+
         PyLongObject* v;
-        triton::uint256 t;
-        int ndigits = 0;
+        std::vector<digit> digits;
 
-        /* Count the number of Python digits. */
-        t = value;
-        while (t) {
-          ++ndigits;
-          t >>= PyLong_SHIFT;
-        }
-
-        v = _PyLong_New(ndigits);
-        digit* p = v->ob_digit;
-        Py_SIZE(v) = ndigits;
-        while (value) {
-          *p++ = (value & PyLong_MASK).convert_to<digit>();
-          value >>= PyLong_SHIFT;
-        }
+        export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        v = _PyLong_New(digits.size());
+        std::copy(digits.begin(), digits.end(), v->ob_digit);
 
         return (PyObject*)v;
       }
@@ -383,24 +391,16 @@ namespace triton {
 
       /* Returns a PyObject from a 512-bits integer */
       PyObject* PyLong_FromUint512(triton::uint512 value) {
+        // it is mandatory to let Python impl deal with small numbers (static objects)
+        if (value <= std::numeric_limits<unsigned long>::max())
+          return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+
         PyLongObject* v;
-        triton::uint512 t = 0;
-        int ndigits = 0;
+        std::vector<digit> digits;
 
-        /* Count the number of Python digits. */
-        t = value;
-        while (t) {
-          ++ndigits;
-          t >>= PyLong_SHIFT;
-        }
-
-        v = _PyLong_New(ndigits);
-        digit* p = v->ob_digit;
-        Py_SIZE(v) = ndigits;
-        while (value) {
-          *p++ = (value & PyLong_MASK).convert_to<digit>();
-          value >>= PyLong_SHIFT;
-        }
+        export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        v = _PyLong_New(digits.size());
+        std::copy(digits.begin(), digits.end(), v->ob_digit);
 
         return (PyObject*)v;
       }

--- a/src/libtriton/bindings/python/utils.cpp
+++ b/src/libtriton/bindings/python/utils.cpp
@@ -5,6 +5,8 @@
 **  This program is under the terms of the BSD License.
 */
 
+#include <vector>
+#include <boost/multiprecision/cpp_int/import_export.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/exceptions.hpp>
@@ -163,7 +165,7 @@ namespace triton {
         }
 
         try {
-          import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+          boost::multiprecision::detail::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
         }
         catch (std::overflow_error&) {
           throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
@@ -195,7 +197,7 @@ namespace triton {
         }
 
         try {
-          import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+          boost::multiprecision::detail::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
         }
         catch (std::overflow_error&) {
           throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
@@ -227,7 +229,7 @@ namespace triton {
         }
 
         try {
-          import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+          boost::multiprecision::detail::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
         }
         catch (std::overflow_error&) {
           throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
@@ -364,7 +366,7 @@ namespace triton {
         PyLongObject* v;
         std::vector<digit> digits;
 
-        export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        boost::multiprecision::detail::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
         v = _PyLong_New(digits.size());
         std::copy(digits.begin(), digits.end(), v->ob_digit);
 
@@ -381,7 +383,7 @@ namespace triton {
         PyLongObject* v;
         std::vector<digit> digits;
 
-        export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        boost::multiprecision::detail::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
         v = _PyLong_New(digits.size());
         std::copy(digits.begin(), digits.end(), v->ob_digit);
 
@@ -398,7 +400,7 @@ namespace triton {
         PyLongObject* v;
         std::vector<digit> digits;
 
-        export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        boost::multiprecision::detail::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
         v = _PyLong_New(digits.size());
         std::copy(digits.begin(), digits.end(), v->ob_digit);
 

--- a/src/libtriton/bindings/python/utils.cpp
+++ b/src/libtriton/bindings/python/utils.cpp
@@ -6,7 +6,7 @@
 */
 
 #include <vector>
-#include <boost/multiprecision/cpp_int/import_export.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 #include <triton/pythonBindings.hpp>
 #include <triton/pythonUtils.hpp>
 #include <triton/exceptions.hpp>
@@ -165,7 +165,7 @@ namespace triton {
         }
 
         try {
-          boost::multiprecision::detail::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+          boost::multiprecision::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
         }
         catch (std::overflow_error&) {
           throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
@@ -197,7 +197,7 @@ namespace triton {
         }
 
         try {
-          boost::multiprecision::detail::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+          boost::multiprecision::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
         }
         catch (std::overflow_error&) {
           throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
@@ -229,7 +229,7 @@ namespace triton {
         }
 
         try {
-          boost::multiprecision::detail::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
+          boost::multiprecision::import_bits(tmp, v->ob_digit, v->ob_digit + i, PyLong_SHIFT, false);
         }
         catch (std::overflow_error&) {
           throw triton::exceptions::Bindings("triton::bindings::python::PyLong_AsUint256(): long integer too large to convert.");
@@ -366,7 +366,7 @@ namespace triton {
         PyLongObject* v;
         std::vector<digit> digits;
 
-        boost::multiprecision::detail::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        boost::multiprecision::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
         v = _PyLong_New(digits.size());
         std::copy(digits.begin(), digits.end(), v->ob_digit);
 
@@ -383,7 +383,7 @@ namespace triton {
         PyLongObject* v;
         std::vector<digit> digits;
 
-        boost::multiprecision::detail::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        boost::multiprecision::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
         v = _PyLong_New(digits.size());
         std::copy(digits.begin(), digits.end(), v->ob_digit);
 
@@ -400,7 +400,7 @@ namespace triton {
         PyLongObject* v;
         std::vector<digit> digits;
 
-        boost::multiprecision::detail::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
+        boost::multiprecision::export_bits(value, std::back_inserter(digits), PyLong_SHIFT, false);
         v = _PyLong_New(digits.size());
         std::copy(digits.begin(), digits.end(), v->ob_digit);
 

--- a/src/libtriton/includes/triton/py3c_compat.h
+++ b/src/libtriton/includes/triton/py3c_compat.h
@@ -1,0 +1,139 @@
+/* Copyright (c) 2015, Red Hat, Inc. and/or its affiliates
+ * Licensed under the MIT license; see py3c.h
+ */
+
+#ifndef _PY3C_COMPAT_H_
+#define _PY3C_COMPAT_H_
+#include <Python.h>
+
+#if PY_MAJOR_VERSION >= 3
+
+/***** Python 3 *****/
+
+#define IS_PY3 1
+
+/* Strings */
+
+#define PyStr_Type PyUnicode_Type
+#define PyStr_Check PyUnicode_Check
+#define PyStr_CheckExact PyUnicode_CheckExact
+#define PyStr_FromString PyUnicode_FromString
+#define PyStr_FromStringAndSize PyUnicode_FromStringAndSize
+#define PyStr_FromFormat PyUnicode_FromFormat
+#define PyStr_FromFormatV PyUnicode_FromFormatV
+#define PyStr_AsString PyUnicode_AsUTF8
+#define PyStr_Concat PyUnicode_Concat
+#define PyStr_Format PyUnicode_Format
+#define PyStr_InternInPlace PyUnicode_InternInPlace
+#define PyStr_InternFromString PyUnicode_InternFromString
+#define PyStr_Decode PyUnicode_Decode
+
+#define PyStr_AsUTF8String PyUnicode_AsUTF8String /* returns PyBytes */
+#define PyStr_AsUTF8 PyUnicode_AsUTF8
+#define PyStr_AsUTF8AndSize PyUnicode_AsUTF8AndSize
+
+/* Ints */
+
+#define PyInt_Type PyLong_Type
+#define PyInt_Check PyLong_Check
+#define PyInt_CheckExact PyLong_CheckExact
+#define PyInt_FromString PyLong_FromString
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSsize_t PyLong_FromSsize_t
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_AS_LONG PyLong_AS_LONG
+#define PyInt_AsUnsignedLongLongMask PyLong_AsUnsignedLongLongMask
+#define PyInt_AsSsize_t PyLong_AsSsize_t
+
+/* Module init */
+
+#define MODULE_INIT_FUNC(name) \
+    PyMODINIT_FUNC PyInit_ ## name(void); \
+    PyMODINIT_FUNC PyInit_ ## name(void)
+
+#else
+
+/***** Python 2 *****/
+
+#define IS_PY3 0
+
+/* Strings */
+
+#define PyStr_Type PyString_Type
+#define PyStr_Check PyString_Check
+#define PyStr_CheckExact PyString_CheckExact
+#define PyStr_FromString PyString_FromString
+#define PyStr_FromStringAndSize PyString_FromStringAndSize
+#define PyStr_FromFormat PyString_FromFormat
+#define PyStr_FromFormatV PyString_FromFormatV
+#define PyStr_AsString PyString_AsString
+#define PyStr_Format PyString_Format
+#define PyStr_InternInPlace PyString_InternInPlace
+#define PyStr_InternFromString PyString_InternFromString
+#define PyStr_Decode PyString_Decode
+
+#ifdef __GNUC__
+static PyObject *PyStr_Concat(PyObject *left, PyObject *right) __attribute__ ((unused));
+#endif
+static PyObject *PyStr_Concat(PyObject *left, PyObject *right) {
+    PyObject *str = left;
+    Py_INCREF(left);  /* reference to old left will be stolen */
+    PyString_Concat(&str, right);
+    if (str) {
+        return str;
+    } else {
+        return NULL;
+    }
+}
+
+#define PyStr_AsUTF8String(str) (Py_INCREF(str), (str))
+#define PyStr_AsUTF8 PyString_AsString
+#define PyStr_AsUTF8AndSize(pystr, sizeptr) \
+    ((*sizeptr=PyString_Size(pystr)), PyString_AsString(pystr))
+
+#define PyBytes_Type PyString_Type
+#define PyBytes_Check PyString_Check
+#define PyBytes_CheckExact PyString_CheckExact
+#define PyBytes_FromString PyString_FromString
+#define PyBytes_FromStringAndSize PyString_FromStringAndSize
+#define PyBytes_FromFormat PyString_FromFormat
+#define PyBytes_FromFormatV PyString_FromFormatV
+#define PyBytes_Size PyString_Size
+#define PyBytes_GET_SIZE PyString_GET_SIZE
+#define PyBytes_AsString PyString_AsString
+#define PyBytes_AS_STRING PyString_AS_STRING
+#define PyBytes_AsStringAndSize PyString_AsStringAndSize
+#define PyBytes_Concat PyString_Concat
+#define PyBytes_ConcatAndDel PyString_ConcatAndDel
+#define _PyBytes_Resize _PyString_Resize
+
+/* Floats */
+
+#define PyFloat_FromString(str) PyFloat_FromString(str, NULL)
+
+/* Module init */
+
+#define PyModuleDef_HEAD_INIT 0
+
+typedef struct PyModuleDef {
+    int m_base;
+    const char* m_name;
+    const char* m_doc;
+    Py_ssize_t m_size;
+    PyMethodDef *m_methods;
+} PyModuleDef;
+
+#define PyModule_Create(def) \
+    Py_InitModule3((def)->m_name, (def)->m_methods, (def)->m_doc)
+
+#define MODULE_INIT_FUNC(name) \
+    static PyObject *PyInit_ ## name(void); \
+    PyMODINIT_FUNC init ## name(void); \
+    PyMODINIT_FUNC init ## name(void) { PyInit_ ## name(); } \
+    static PyObject *PyInit_ ## name(void)
+
+
+#endif
+
+#endif

--- a/src/libtriton/includes/triton/pythonBindings.hpp
+++ b/src/libtriton/includes/triton/pythonBindings.hpp
@@ -15,6 +15,7 @@
   #define _hypot hypot
 #endif
 
+#include <triton/py3c_compat.h>
 
 
 //! The Triton namespace
@@ -42,6 +43,9 @@ namespace triton {
 
       //! triton python module.
       extern PyObject* tritonModule;
+
+      //! triton python module definition.
+      extern PyModuleDef tritonModuleDef;
 
       //! triton python methods.
       extern PyMethodDef tritonCallbacks[];
@@ -101,8 +105,12 @@ namespace triton {
       //! Initializes the VERSION python namespace.
       void initVersionNamespace(PyObject* versionDict);
 
-      //! Entry point python bindings.
-      PyMODINIT_FUNC inittriton(void);
+      //! Entry point python bindings (Py2/3).
+#if IS_PY3
+      PyMODINIT_FUNC PyInit_triton(void);
+#else
+      PyObject* PyInit_triton(void);
+#endif
 
     /*! @} End of python namespace */
     };

--- a/src/libtriton/includes/triton/pythonXFunctions.hpp
+++ b/src/libtriton/includes/triton/pythonXFunctions.hpp
@@ -35,7 +35,7 @@ namespace triton {
      *  @{
      */
 
-      //! Creates a PyClass and raises an exception if it fails.
+      //! Creates a PyClass and raises an exception if it fails. __dict__ is copied in Py3 ! All references are decremented.
       PyObject* xPyClass_New(PyObject* b, PyObject* d, PyObject* n);
 
       //! Creates a PyDict and raises an exception if it fails.

--- a/src/testers/unittests/test_ast_conversion.py
+++ b/src/testers/unittests/test_ast_conversion.py
@@ -52,9 +52,13 @@ class TestAstConversion(unittest.TestCase):
             operator.ge,
             operator.lt,
             operator.gt,
-            operator.div,
+            operator.floordiv,
             operator.mod,
         ]
+        operator_div = operator.floordiv
+        if hasattr(operator, "div"):
+            operator_div = operator.div
+            binop.append(operator_div)
 
         for _ in range(100):
             cv1 = random.randint(0, 255)
@@ -63,7 +67,7 @@ class TestAstConversion(unittest.TestCase):
             self.Triton.setConcreteVariableValue(self.sv2, cv2)
             for op in binop:
                 n = op(self.v1, self.v2)
-                if op == operator.div and cv2 == 0:
+                if op in (operator.floordiv, operator_div) and cv2 == 0:
                     ref = 255
                 elif op == operator.mod and cv2 == 0:
                     ref = cv1

--- a/src/testers/unittests/test_ast_duplication.py
+++ b/src/testers/unittests/test_ast_duplication.py
@@ -29,7 +29,7 @@ class TestAstDuplication(unittest.TestCase):
             (self.v1 ^ self.v2),
             (self.v1 | self.v2),
             (self.v1 * self.v2),
-            (self.v1 / self.v2),
+            (self.v1 // self.v2),
             (self.v1 % self.v2),
             (self.v1 << self.v2),
             (self.v1 >> self.v2),

--- a/src/testers/unittests/test_examples.py
+++ b/src/testers/unittests/test_examples.py
@@ -38,7 +38,7 @@ for i, example in enumerate(itertools.chain(glob.iglob(os.path.join(EXAMPLE_DIR,
 
         p = subprocess.Popen([sys.executable, example_name] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
-        self.assertEqual(p.returncode, 0, "\n".join((out, err, str(p.returncode))))
+        self.assertEqual(p.returncode, 0, "\n".join((str(out), str(err), str(p.returncode))))
 
     # Define an arguments with a default value as default value is capture at
     # lambda creation so that example_name is not in the closure of the lambda


### PR DESCRIPTION
- PyClass_New replaced (dict is now copied)
- Compilation fix (import print_function)
- PyStr compatible methods (Py3 strings are true bytes)
- Fix: PyInstance_Check typo (PyInstr.. intended)
- Fix: safe conversion of unsigned types to PyLong