### PR TITLE
added pslld/psllq and vpmovmskb semantics

### DIFF
--- a/src/libtriton/includes/triton/x86Semantics.hpp
+++ b/src/libtriton/includes/triton/x86Semantics.hpp
@@ -1001,6 +1001,12 @@ namespace triton {
           //! The PSLLDQ semantics.
           void pslldq_s(triton::arch::Instruction& inst);
 
+          //! The PSLLD semantics.
+          void pslld_s(triton::arch::Instruction& inst);
+
+          //! The PSLLQ semantics.
+          void psllq_s(triton::arch::Instruction& inst);
+
           //! The PSRLDQ semantics.
           void psrldq_s(triton::arch::Instruction& inst);
 
@@ -1231,6 +1237,9 @@ namespace triton {
 
           //! The VPAND semantics.
           void vpand_s(triton::arch::Instruction& inst);
+
+          //! The VPMOVMSKB semantics.
+          void vpmovmskb_s(triton::arch::Instruction& inst);
 
           //! The VPANDN semantics.
           void vpandn_s(triton::arch::Instruction& inst);

--- a/src/samples/ir_test_suite/ir.c
+++ b/src/samples/ir_test_suite/ir.c
@@ -3658,6 +3658,46 @@ void check(void)
   asm("vpor xmm1, xmm2, xmm3");
   asm("vpor xmm1, xmm1, xmm2");
   asm("vpor xmm1, xmm3, xmm4");
+
+
+  asm("vpmovmskb eax, xmm0");
+  asm("vpmovmskb eax, xmm1");
+  asm("vpmovmskb ecx, ymm0");
+  asm("vpmovmskb ecx, ymm1");
+
+
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("pslld xmm1, 0");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("pslld xmm1, 8");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("pslld xmm1, 31");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("pslld xmm1, 32");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("pslld xmm1, 33");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("pslld xmm1, 120");
+
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 0");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 8");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 31");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 32");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 33");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 63");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 64");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 65");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("psllq xmm1, 120");
+
 }
 
 int main(){


### PR DESCRIPTION
I have added the pslld/psllq and vpmovmskb instruction semantics which I came across in glibc. I am not sure whether my implementation is correct, so please have a look.

I have checked for the correct end result with [this script](https://gist.github.com/Toizi/36f6d0d8a3c2a6e78d43c6055ac6e757), which generates the following output

```
before
ymm1: 0xffffff00ff000000ffffffffffffff00ffffffffffffffffffffff0000000000
eax: 0x0

executing 0x10000:  (vpmovmskb eax, ymm1)

after
ymm1: 0xffffff00ff000000ffffffffffffff00ffffffffffffffffffffff0000000000
eax: 0xe8feffe0

=============================================================
before
xmm1 = 0x0102030405060708090a0b0c0d0e0f10

executing 0x10000:  (pslld xmm1, 8)

after
xmm1 = 0x02030400060708000a0b0c000e0f1000

=============================================================
before
xmm1 = 0x0102030405060708090a0b0c0d0e0f10

executing 0x10000:  (pslld xmm1, 130)

after
xmm1 = 0x00000000000000000000000000000000

=============================================================
before
xmm1 = 0x0102030405060708090a0b0c0d0e0f10

executing 0x10000:  (psllq xmm1, 16)

after
xmm1 = 0x03040506070800000b0c0d0e0f100000

=============================================================
before
xmm1 = 0x0102030405060708090a0b0c0d0e0f10

executing 0x10000:  (psllq xmm1, 70)

after
xmm1 = 0x00000000000000000000000000000000

=============================================================
```