### PR TITLE
Fixed parent cleaning in ast::newInstance

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -2470,7 +2470,13 @@ namespace triton {
         throw triton::exceptions::Ast("triton::ast::newInstance(): No enough memory.");
 
       /* Remove parents as this is a new node which has no connections with original AST */
-      newNode->getParents().clear();
+      if (node->getType() != VARIABLE_NODE) {
+        /* VARIABLE_NODE are not duplicated (see #792), so don't remove their parents */
+        auto parents = newNode->getParents();
+        for (auto & p : parents) {
+          newNode->removeParent(p.get());
+        }
+      }
 
       /* Create new instances of children and set their new parents */
       auto& children = newNode->getChildren();


### PR DESCRIPTION
Before this patch, it was clearing a local copy of the parents vector, so it had no effect.

I don't know if it's the best patch, but now calling `removeParent` on the node results in the parents being effectively removed from the node's parents vector.