### PR TITLE
Add semantics for bfi and bic AArch64 instructions

### DIFF
--- a/src/libtriton/includes/triton/aarch64Semantics.hpp
+++ b/src/libtriton/includes/triton/aarch64Semantics.hpp
@@ -177,6 +177,12 @@ namespace triton {
           //! The B and B.cond semantics.
           void b_s(triton::arch::Instruction& inst);
 
+          //! The BFI semantics.
+          void bfi_s(triton::arch::Instruction& inst);
+
+          //! The BIC semantics.
+          void bic_s(triton::arch::Instruction& inst);
+
           //! The BL semantics.
           void bl_s(triton::arch::Instruction& inst);
 


### PR DESCRIPTION
Examples:

```asm
bfi  w12, w11, #24, #8
bic  w10, w10, w9
```