### PR TITLE
Increase speed of nodes nodesExtraction algorithm and apply it in newInstance

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -23,7 +23,6 @@
 
 namespace triton {
   namespace ast {
-
     /* ====== Abstract node */
 
     AbstractNode::AbstractNode(triton::ast::ast_e type, const SharedAstContext& ctxt) {
@@ -116,7 +115,8 @@ namespace triton {
 
 
     void AbstractNode::initParents(void) {
-      for (auto& sp : this->getParents())
+      auto ancestors = parentsExtraction(this->shared_from_this(), false);
+      for (auto& sp : ancestors)
         sp->init();
     }
 
@@ -244,9 +244,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -284,9 +281,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -324,9 +318,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -397,9 +388,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -437,9 +425,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -477,9 +462,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -517,9 +499,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -553,9 +532,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -593,9 +569,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -629,9 +602,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -669,9 +639,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -720,9 +687,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -771,9 +735,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -824,9 +785,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -871,9 +829,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -918,9 +873,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -958,9 +910,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1005,9 +954,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1052,9 +998,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1103,9 +1046,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1154,9 +1094,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1194,9 +1131,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1238,9 +1172,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1278,9 +1209,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1318,9 +1246,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1358,9 +1283,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1398,9 +1320,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1442,9 +1361,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1482,9 +1398,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1522,9 +1435,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1574,9 +1484,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1605,9 +1512,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1651,9 +1555,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1690,9 +1591,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1730,9 +1628,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1770,9 +1665,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1823,9 +1715,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1869,9 +1758,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1897,9 +1783,6 @@ namespace triton {
       this->eval        = 0;
       this->size        = 0;
       this->symbolized  = false;
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1943,9 +1826,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -1984,9 +1864,6 @@ namespace triton {
         if (this->children[index]->isLogical() == false)
           throw triton::exceptions::Ast("LandNode::init(): Must take logical nodes as arguments.");
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2025,9 +1902,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2064,10 +1938,6 @@ namespace triton {
         if (this->children[index]->isLogical() == false)
           throw triton::exceptions::Ast("LnotNode::init(): Must take logical nodes arguments.");
       }
-
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2106,9 +1976,6 @@ namespace triton {
         if (this->children[index]->isLogical() == false)
           throw triton::exceptions::Ast("LorNode::init(): Must take logical nodes as arguments.");
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2138,9 +2005,6 @@ namespace triton {
       this->symbolized  = this->expr->getAst()->isSymbolized();
 
       this->expr->getAst()->setParent(this);
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2168,9 +2032,6 @@ namespace triton {
       this->eval        = 0;
       this->size        = 0;
       this->symbolized  = false;
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2223,9 +2084,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2251,9 +2109,6 @@ namespace triton {
       this->size        = this->symVar->getSize();
       this->eval        = this->ctxt->getVariableValue(this->symVar->getName()) & this->getBitvectorMask();
       this->symbolized  = true;
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2307,9 +2162,6 @@ namespace triton {
         this->children[index]->setParent(this);
         this->symbolized |= this->children[index]->isSymbolized();
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 
@@ -2486,7 +2338,7 @@ namespace triton {
 
     SharedAbstractNode newInstance(AbstractNode* node, bool unroll) {
       std::map<AbstractNode *, SharedAbstractNode> exprs;
-      auto nodes = nodesExtraction(node->shared_from_this(), unroll, true);
+      auto nodes = childrenExtraction(node->shared_from_this(), unroll, true);
 
       for (auto&& n : nodes) {
         auto newNode = shallowCopy(n.get(), unroll);
@@ -2506,11 +2358,15 @@ namespace triton {
 
     /* Returns a vector of unique AST-nodes sorted topologically
      *
-     * The result has property that any parent has smaller index than its children.
+     * Depending on @descent argument this function produces topologically sorted vector of nodes from DAG consisting of
+     * either parents or children of given @node. This helps to prevent exponential complexity when complex AST are
+     * parsed during z3 conversion, copying and parents reinitialization.
+     *
      * @unroll - traverses through ReferenceNodes
      * @revert - reverses the result
+     * @descent - if true we traverse through children of nodes, otherwise parents
      */
-    std::vector<SharedAbstractNode> nodesExtraction(const SharedAbstractNode& node, bool unroll, bool revert) {
+    static std::vector<SharedAbstractNode> nodesExtraction(const SharedAbstractNode& node, bool unroll, bool revert, bool descend) {
       std::vector<SharedAbstractNode> result;
       std::set<AbstractNode *> visited;
       std::stack<std::pair<SharedAbstractNode, bool>> worklist;
@@ -2540,10 +2396,12 @@ namespace triton {
           continue;
         worklist.push({ast, true});
 
-        /* Proceed children */
-        for (const auto& child : ast->getChildren()) {
-          if (visited.find(child.get()) == visited.end()) {
-            worklist.push({child, false});
+        const auto &relatives = descend ? ast->getChildren() : ast->getParents();
+
+        /* Proceed relatives */
+        for (const auto& r : relatives) {
+          if (visited.find(r.get()) == visited.end()) {
+            worklist.push({r, false});
           }
         }
 
@@ -2563,6 +2421,13 @@ namespace triton {
       return result;
     }
 
+    std::vector<SharedAbstractNode> childrenExtraction(const SharedAbstractNode& node, bool unroll, bool revert) {
+      return nodesExtraction(node, unroll, revert, true);
+    }
+
+    std::vector<SharedAbstractNode> parentsExtraction(const SharedAbstractNode& node, bool revert) {
+      return nodesExtraction(node, false, revert, false);
+    }
 
     std::deque<SharedAbstractNode> lookingForNodes(const SharedAbstractNode& node, triton::ast::ast_e match) {
       std::stack<triton::ast::AbstractNode*>      worklist;

--- a/src/libtriton/ast/astContext.cpp
+++ b/src/libtriton/ast/astContext.cpp
@@ -774,7 +774,7 @@ namespace triton {
       if (it != this->valueMapping.end()) {
         if (auto node = it->second.first.lock()) {
           it->second.second = value;
-          node->init();
+          node->initParents();
         }
         else {
           throw triton::exceptions::Ast("AstContext::updateVariable(): This symbolic variable is dead.");

--- a/src/libtriton/ast/z3/tritonToZ3Ast.cpp
+++ b/src/libtriton/ast/z3/tritonToZ3Ast.cpp
@@ -43,10 +43,8 @@ namespace triton {
 
 
     z3::expr TritonToZ3Ast::convert(const triton::ast::SharedAbstractNode& node) {
-      std::unordered_map<triton::ast::SharedAbstractNode, z3::expr> results;
-      std::deque<triton::ast::SharedAbstractNode> nodes;
-
-      triton::ast::nodesExtraction(&nodes, node, true /* unroll*/, true /* revert */);
+      std::unordered_map<triton::ast::SharedAbstractNode, z3::expr> results;;
+      auto nodes = triton::ast::nodesExtraction(node, true /* unroll*/, true /* revert */);
 
       for (auto&& n : nodes) {
         results.insert(std::make_pair(n, this->do_convert(n, &results)));

--- a/src/libtriton/ast/z3/tritonToZ3Ast.cpp
+++ b/src/libtriton/ast/z3/tritonToZ3Ast.cpp
@@ -44,7 +44,7 @@ namespace triton {
 
     z3::expr TritonToZ3Ast::convert(const triton::ast::SharedAbstractNode& node) {
       std::unordered_map<triton::ast::SharedAbstractNode, z3::expr> results;;
-      auto nodes = triton::ast::nodesExtraction(node, true /* unroll*/, true /* revert */);
+      auto nodes = triton::ast::childrenExtraction(node, true /* unroll*/, true /* revert */);
 
       for (auto&& n : nodes) {
         results.insert(std::make_pair(n, this->do_convert(n, &results)));

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -400,13 +400,12 @@ namespace triton {
       /* Slices all expressions from a given one */
       std::map<triton::usize, SharedSymbolicExpression> SymbolicEngine::sliceExpressions(const SharedSymbolicExpression& expr) {
         std::map<triton::usize, SharedSymbolicExpression> exprs;
-        std::deque<triton::ast::SharedAbstractNode> worklist;
 
         if (expr == nullptr)
           throw triton::exceptions::SymbolicEngine("SymbolicEngine::sliceExpressions(): expr cannot be null.");
 
         exprs[expr->getId()] = expr;
-        triton::ast::nodesExtraction(&worklist, expr->getAst(), true /* unroll */, false /* revert */);
+        auto worklist = triton::ast::nodesExtraction(expr->getAst(), true /* unroll */, false /* revert */);
 
         for (auto&& n : worklist) {
           if (n->getType() == triton::ast::REFERENCE_NODE) {

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -405,7 +405,7 @@ namespace triton {
           throw triton::exceptions::SymbolicEngine("SymbolicEngine::sliceExpressions(): expr cannot be null.");
 
         exprs[expr->getId()] = expr;
-        auto worklist = triton::ast::nodesExtraction(expr->getAst(), true /* unroll */, false /* revert */);
+        auto worklist = triton::ast::childrenExtraction(expr->getAst(), true /* unroll */, false /* revert */);
 
         for (auto&& n : worklist) {
           if (n->getType() == triton::ast::REFERENCE_NODE) {

--- a/src/libtriton/includes/triton/ast.hpp
+++ b/src/libtriton/includes/triton/ast.hpp
@@ -663,8 +663,11 @@ namespace triton {
     //! AST C++ API - Unrolls the SSA form of a given AST.
     TRITON_EXPORT SharedAbstractNode unrollAst(const SharedAbstractNode& node);
 
-    //! Returns all nodes of an AST. If `unroll` is true, references are unrolled. If `revert` is true, children are on top of list.
-    TRITON_EXPORT std::vector<SharedAbstractNode> nodesExtraction(const SharedAbstractNode& node, bool unroll, bool revert);
+    //! Returns node and all its children of an AST sorted topologically. If `unroll` is true, references are unrolled. If `revert` is true, children are on top of list.
+    TRITON_EXPORT std::vector<SharedAbstractNode> childrenExtraction(const SharedAbstractNode& node, bool unroll, bool revert);
+
+    //! Returns node and all its parents of an AST sorted topologically. If `revert` is true, oldest parents are on top of list.
+    TRITON_EXPORT std::vector<SharedAbstractNode> parentsExtraction(const SharedAbstractNode& node, bool revert);
 
     //! Returns a deque of collected matched nodes via a depth-first pre order traversal.
     TRITON_EXPORT std::deque<SharedAbstractNode> lookingForNodes(const SharedAbstractNode& node, triton::ast::ast_e match=ANY_NODE);

--- a/src/libtriton/includes/triton/ast.hpp
+++ b/src/libtriton/includes/triton/ast.hpp
@@ -664,7 +664,7 @@ namespace triton {
     TRITON_EXPORT SharedAbstractNode unrollAst(const SharedAbstractNode& node);
 
     //! Returns all nodes of an AST. If `unroll` is true, references are unrolled. If `revert` is true, children are on top of list.
-    TRITON_EXPORT void nodesExtraction(std::deque<SharedAbstractNode>* output, const SharedAbstractNode& node, bool unroll, bool revert);
+    TRITON_EXPORT std::vector<SharedAbstractNode> nodesExtraction(const SharedAbstractNode& node, bool unroll, bool revert);
 
     //! Returns a deque of collected matched nodes via a depth-first pre order traversal.
     TRITON_EXPORT std::deque<SharedAbstractNode> lookingForNodes(const SharedAbstractNode& node, triton::ast::ast_e match=ANY_NODE);

--- a/src/testers/unittests/test_ast_deep.py
+++ b/src/testers/unittests/test_ast_deep.py
@@ -12,27 +12,37 @@ class TestDeep(unittest.TestCase):
         self.triton.setArchitecture(ARCH.X86_64)
         self.ctx = self.triton.getAstContext()
 
-        sym_var = self.ctx.variable(self.triton.convertRegisterToSymbolicVariable(self.triton.registers.rax))
+        self.sym_var = self.ctx.variable(self.triton.convertRegisterToSymbolicVariable(self.triton.registers.rax))
+        self.triton.setConcreteRegisterValue(self.triton.registers.rbx, 0)
 
         add_inst = Instruction()
         add_inst.setAddress(0x100)
-        add_inst.setOpcode("\x48\x01\xc0")      # add   rax, rax
+        add_inst.setOpcode("\x48\x01\xC3")      # add   rbx, rax
 
         sub_inst = Instruction()
-        sub_inst.setOpcode("\x48\x29\xC0")      # sub   rax, rax
+        sub_inst.setOpcode("\x48\x29\xC3")      # sub   rbx, rax
 
+        # We subtract and add the same symbolic value from rbx N times
         for _ in range(DEPTH):
             self.triton.processing(add_inst)
             sub_inst.setAddress(add_inst.getAddress() + add_inst.getSize())
             self.triton.processing(sub_inst)
             add_inst.setAddress(sub_inst.getAddress() + sub_inst.getSize())
 
-        self.complex_ast_tree = self.triton.getSymbolicRegister(self.triton.registers.rax).getAst()
+        # And finally add symbolic variable ones
+        add_inst.setAddress(add_inst.getAddress() + add_inst.getSize())
+        self.triton.processing(add_inst)
+
+        # Now rbx has `SymVar_0` value
+        self.complex_ast_tree = self.triton.getSymbolicRegister(self.triton.registers.rbx).getAst()
 
     def test_z3_conversion(self):
         result = self.triton.simplify(self.complex_ast_tree, True)
-        answer = self.ctx.bv(0, 64)
-        self.assertEqual(str(result), str(answer))
+        self.assertEqual(str(result), str(self.sym_var))
 
     def test_duplication(self):
         s = self.ctx.duplicate(self.complex_ast_tree)
+
+    def test_symbolic_variable_update(self):
+        self.triton.setConcreteVariableValue(self.sym_var.getSymbolicVariable(), 0xdeadbeaf)
+        self.assertEqual(self.complex_ast_tree.evaluate(), 0xdeadbeaf)

--- a/src/testers/unittests/test_ast_deep.py
+++ b/src/testers/unittests/test_ast_deep.py
@@ -1,0 +1,38 @@
+import unittest
+from triton import *
+
+DEPTH = 10000
+
+
+class TestDeep(unittest.TestCase):
+
+    def setUp(self):
+        """Define the arch."""
+        self.triton = TritonContext()
+        self.triton.setArchitecture(ARCH.X86_64)
+        self.ctx = self.triton.getAstContext()
+
+        sym_var = self.ctx.variable(self.triton.convertRegisterToSymbolicVariable(self.triton.registers.rax))
+
+        add_inst = Instruction()
+        add_inst.setAddress(0x100)
+        add_inst.setOpcode("\x48\x01\xc0")      # add   rax, rax
+
+        sub_inst = Instruction()
+        sub_inst.setOpcode("\x48\x29\xC0")      # sub   rax, rax
+
+        for _ in range(DEPTH):
+            self.triton.processing(add_inst)
+            sub_inst.setAddress(add_inst.getAddress() + add_inst.getSize())
+            self.triton.processing(sub_inst)
+            add_inst.setAddress(sub_inst.getAddress() + sub_inst.getSize())
+
+        self.complex_ast_tree = self.triton.getSymbolicRegister(self.triton.registers.rax).getAst()
+
+    def test_z3_conversion(self):
+        result = self.triton.simplify(self.complex_ast_tree, True)
+        answer = self.ctx.bv(0, 64)
+        self.assertEqual(str(result), str(answer))
+
+    def test_duplication(self):
+        s = self.ctx.duplicate(self.complex_ast_tree)


### PR DESCRIPTION
This version of `nodesExtraction` works 10 times faster than current implementation (See N=20000 at test_ast_deep.py). Also I incorporated the usage of this function in `newInstance` that makes a deep copy of AST node.

I don't see a nice way to make added test fail with specified timeout. Seems like unittests doesn't support it. So this test probably doesn't test a lot (just works for very long time if speed degrades) so may be it should be deleted.

There's still exists the same problem when ascending AST(which is actually a DAG) traversal is happening in `AbstractNode::init` and `AbstractNode::initParents` functions. Current version will be calling the same methods several times for already processed elements and it never finishes when applying triton to real-live obfuscators. In my private version I comment them out but I would like to make the similar to nodesExtraction mechanism. So is it okey if I remove calling `initParent` from all `init` methods and make `initParent` first collecting all depending nodes and applying `init` to them?