### PR TITLE
Remove parent initialization in LxorNode::init

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -2068,9 +2068,6 @@ namespace triton {
         if (this->children[index]->isLogical() == false)
           throw triton::exceptions::Ast("LxorNode::init(): Must take logical nodes as arguments.");
       }
-
-      /* Init parents */
-      this->initParents();
     }
 
 


### PR DESCRIPTION
Actually it was because I didn't have `LxorNode` in my branch and for this class initialization leads to infinite recursion