### PR TITLE
Fix to issue #828.

### DIFF
--- a/src/libtriton/arch/instruction.cpp
+++ b/src/libtriton/arch/instruction.cpp
@@ -78,6 +78,8 @@ namespace triton {
       this->disassembly.str(other.disassembly.str());
     }
 
+    Instruction::~Instruction() {
+    }
 
     triton::uint32 Instruction::getThreadId(void) const {
       return this->tid;

--- a/src/libtriton/includes/triton/instruction.hpp
+++ b/src/libtriton/includes/triton/instruction.hpp
@@ -128,6 +128,9 @@ namespace triton {
 
         //! Copies an Instruction.
         TRITON_EXPORT Instruction& operator=(const Instruction& other);
+        
+        //! Destructor.
+        TRITON_EXPORT ~Instruction();
 
         //! Returns the thread id of the instruction.
         TRITON_EXPORT triton::uint32 getThreadId(void) const;


### PR DESCRIPTION
This PR fixes issue. Works for examples/ir.cpp. 
Destructor wasn't visible from dll.