### PR TITLE
Add LGTM (Semmle) C++ analysis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Full documentation is available on our [doxygen page](http://triton.quarkslab.co
   <a href="https://codecov.io/gh/JonathanSalwan/Triton">
     <img src="https://codecov.io/gh/JonathanSalwan/Triton/branch/dev-v0.7/graph/badge.svg" alt="Codecov" />
   </a>
+  &nbsp;
+  <a href="https://lgtm.com/projects/g/JonathanSalwan/Triton/alerts/">
+    <img src="https://img.shields.io/lgtm/alerts/g/JonathanSalwan/Triton.svg?logo=lgtm&logoWidth=18"/>
+  </a>
 </p>
 
 ### Quick start

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,9 @@
+extraction:
+  cpp:
+    prepare:
+      script:
+      - "curl -o cap.tgz -L https://github.com/aquynh/capstone/archive/4.0.1.tar.gz"
+      - "tar xf cap.tgz && cd capstone-4.0.1/ && ./make.sh"
+    after_prepare:
+    - "export CAPSTONE_INCLUDE_DIRS=$LGTM_SRC/capstone-4.0.1/include"
+    - "export CAPSTONE_LIBRARIES=$LGTM_SRC/capstone-4.0.1/libcapstone.so.4"


### PR DESCRIPTION
Since libcapstone-dev is only v3.0.5 in Ubuntu 19.10, which is used by
LGTM to build Triton, we need to build Capstone v4.0.1 from source and
use it during the build.

Here are logs from this config to show that it works: https://lgtm.com/logs/47a1058f52b16ef96dbe50ca638d5e8bd9921d12/lang:cpp