### PR TITLE
Export fromUintToBuffer and fromBufferToUintfunctions

### DIFF
--- a/src/libtriton/includes/triton/coreUtils.hpp
+++ b/src/libtriton/includes/triton/coreUtils.hpp
@@ -9,7 +9,7 @@
 #define TRITON_CORE_UTIL_H
 
 #include <triton/tritonTypes.hpp>
-
+#include <triton/dllexport.hpp>
 
 
 //! The Triton namespace
@@ -28,13 +28,13 @@ namespace triton {
    */
 
     //! Inject the value into the buffer. Make sure that the `buffer` contains at least 16 allocated bytes.
-    void fromUintToBuffer(triton::uint128 value, triton::uint8* buffer);
+    TRITON_EXPORT void fromUintToBuffer(triton::uint128 value, triton::uint8* buffer);
 
     //! Inject the value into the buffer. Make sure that the `buffer` contains at least 32 allocated bytes.
-    void fromUintToBuffer(triton::uint256 value, triton::uint8* buffer);
+    TRITON_EXPORT void fromUintToBuffer(triton::uint256 value, triton::uint8* buffer);
 
     //! Inject the value into the buffer. Make sure that the `buffer` contains at least 64 allocated bytes.
-    void fromUintToBuffer(triton::uint512 value, triton::uint8* buffer);
+    TRITON_EXPORT void fromUintToBuffer(triton::uint512 value, triton::uint8* buffer);
 
     //! Returns the value located into the buffer.
     template <typename T> T fromBufferToUint(const triton::uint8* buffer) {
@@ -44,9 +44,9 @@ namespace triton {
       return {};
     }
 
-    template <> triton::uint128 fromBufferToUint(const triton::uint8* buffer);
-    template <> triton::uint256 fromBufferToUint(const triton::uint8* buffer);
-    template <> triton::uint512 fromBufferToUint(const triton::uint8* buffer);
+    template <> TRITON_EXPORT triton::uint128 fromBufferToUint(const triton::uint8* buffer);
+    template <> TRITON_EXPORT triton::uint256 fromBufferToUint(const triton::uint8* buffer);
+    template <> TRITON_EXPORT triton::uint512 fromBufferToUint(const triton::uint8* buffer);
 
   /*! @} End of triton namespace */
   };


### PR DESCRIPTION
This will probably only affect Windows build since AFAIK Linux builds export all the functions by default