### PR TITLE
Fix linking 32-bit Triton on a 64-bit machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,8 +109,17 @@ else()
     set(ARCHITECTURE i386)
 endif()
 
-if(${TARGET} MATCHES "ia32")
+if(NOT ${ARCHITECTURE} STREQUAL "i386" AND "${TARGET}" MATCHES "ia32")
     set(ARCHITECTURE i386)
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        # Set appropriate compile and linker flags
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+        if(NOT STATICLIB)
+            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m32")
+        endif()
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32")
+    endif()
 endif()
 
 # Read the build version

--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -49,13 +49,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     endif()
 endif()
 
-# 32-bits
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    if(${ARCHITECTURE} STREQUAL "i386")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
-    endif()
-endif()
-
 # Add Triton includes
 include_directories("${CMAKE_CURRENT_LIST_DIR}/includes")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/includes")


### PR DESCRIPTION
This merge fixes linking and compile flags (adds `-m32`) for cross compilation. Previously linker was not getting `-m32` flag.