### PR TITLE
Fix #900 - Python 3.8 compatibility

### DIFF
--- a/src/libtriton/bindings/python/objects/pyAstContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyAstContext.cpp
@@ -1724,7 +1724,7 @@ namespace triton {
         sizeof(AstContext_Object),                  /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)AstContext_dealloc,             /* tp_dealloc */
-        0,                                          /* tp_print */
+        0,                                          /* tp_print or tp_vectorcall_offset */
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -1768,6 +1768,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyAstNode.cpp
+++ b/src/libtriton/bindings/python/objects/pyAstNode.cpp
@@ -369,11 +369,12 @@ namespace triton {
         }
       }
 
-
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int AstNode_print(PyObject* self, void* io, int s) {
         std::cout << PyAstNode_AsAstNode(self);
         return 0;
       }
+      #endif
 
 
       #if !defined(IS_PY3) || !IS_PY3
@@ -879,7 +880,11 @@ namespace triton {
         sizeof(AstNode_Object),                     /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)AstNode_dealloc,                /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)AstNode_print,                   /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         #if defined(IS_PY3) && IS_PY3
@@ -927,6 +932,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyBitsVector.cpp
+++ b/src/libtriton/bindings/python/objects/pyBitsVector.cpp
@@ -115,11 +115,12 @@ namespace triton {
         }
       }
 
-
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int BitsVector_print(PyObject* self, void* io, int s) {
         std::cout << PyBitsVector_AsBitsVector(self);
         return 0;
       }
+      #endif
 
 
       static PyObject* BitsVector_str(PyObject* self) {
@@ -150,7 +151,11 @@ namespace triton {
         sizeof(BitsVector_Object),                  /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)BitsVector_dealloc,             /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)BitsVector_print,                /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -194,6 +199,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyImmediate.cpp
+++ b/src/libtriton/bindings/python/objects/pyImmediate.cpp
@@ -228,10 +228,12 @@ namespace triton {
       }
 
 
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int Immediate_print(PyObject* self, void* io, int s) {
         std::cout << PyImmediate_AsImmediate(self);
         return 0;
       }
+      #endif
 
 
       static PyObject* Immediate_str(PyObject* self) {
@@ -267,7 +269,11 @@ namespace triton {
         sizeof(Immediate_Object),                   /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)Immediate_dealloc,              /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)Immediate_print,                 /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -311,6 +317,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyInstruction.cpp
+++ b/src/libtriton/bindings/python/objects/pyInstruction.cpp
@@ -698,10 +698,12 @@ namespace triton {
       }
 
 
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int Instruction_print(PyObject* self, void* io, int s) {
         std::cout << PyInstruction_AsInstruction(self);
         return 0;
       }
+      #endif
 
 
       static PyObject* Instruction_str(PyObject* self) {
@@ -758,7 +760,11 @@ namespace triton {
         sizeof(Instruction_Object),                 /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)Instruction_dealloc,            /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)Instruction_print,               /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -802,6 +808,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyMemoryAccess.cpp
+++ b/src/libtriton/bindings/python/objects/pyMemoryAccess.cpp
@@ -386,10 +386,12 @@ namespace triton {
       }
 
 
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int MemoryAccess_print(PyObject* self, void* io, int s) {
         std::cout << PyMemoryAccess_AsMemoryAccess(self);
         return 0;
       }
+      #endif
 
 
       static PyObject* MemoryAccess_str(PyObject* self) {
@@ -433,7 +435,11 @@ namespace triton {
         sizeof(MemoryAccess_Object),                /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)MemoryAccess_dealloc,           /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)MemoryAccess_print,              /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -477,6 +483,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyPathConstraint.cpp
+++ b/src/libtriton/bindings/python/objects/pyPathConstraint.cpp
@@ -174,7 +174,7 @@ namespace triton {
         sizeof(PathConstraint_Object),              /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)PathConstraint_dealloc,         /* tp_dealloc */
-        0,                                          /* tp_print */
+        0,                                          /* tp_print or tp_vectorcall_offset */
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -218,6 +218,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyRegister.cpp
+++ b/src/libtriton/bindings/python/objects/pyRegister.cpp
@@ -284,10 +284,12 @@ namespace triton {
       }
 
 
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int Register_print(PyObject* self, void* io, int s) {
         std::cout << PyRegister_AsRegister(self);
         return 0;
       }
+      #endif
 
 
       static long Register_hash(PyObject* self) {
@@ -372,7 +374,11 @@ namespace triton {
         sizeof(Register_Object),                    /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)Register_dealloc,               /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)Register_print,                  /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -416,6 +422,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pySolverModel.cpp
+++ b/src/libtriton/bindings/python/objects/pySolverModel.cpp
@@ -121,10 +121,12 @@ namespace triton {
       }
 
 
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int SolverModel_print(PyObject* self, void* io, int s) {
         std::cout << PySolverModel_AsSolverModel(self);
         return 0;
       }
+      #endif
 
 
       static PyObject* SolverModel_str(PyObject* self) {
@@ -154,7 +156,11 @@ namespace triton {
         sizeof(SolverModel_Object),                 /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)SolverModel_dealloc,            /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)SolverModel_print,               /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -198,6 +204,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
+++ b/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
@@ -279,10 +279,12 @@ namespace triton {
       }
 
 
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int SymbolicExpression_print(PyObject* self, void* io, int s) {
         std::cout << PySymbolicExpression_AsSymbolicExpression(self);
         return 0;
       }
+      #endif
 
 
       static PyObject* SymbolicExpression_str(PyObject* self) {
@@ -331,7 +333,11 @@ namespace triton {
         sizeof(SymbolicExpression_Object),          /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)SymbolicExpression_dealloc,     /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)SymbolicExpression_print,        /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -375,6 +381,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pySymbolicVariable.cpp
+++ b/src/libtriton/bindings/python/objects/pySymbolicVariable.cpp
@@ -188,10 +188,12 @@ namespace triton {
       }
 
 
+      #if !defined(IS_PY3_8) || !IS_PY3_8
       static int SymbolicVariable_print(PyObject* self, void* io, int s) {
         std::cout << PySymbolicVariable_AsSymbolicVariable(self);
         return 0;
       }
+      #endif
 
 
       static PyObject* SymbolicVariable_str(PyObject* self) {
@@ -281,7 +283,11 @@ namespace triton {
         sizeof(SymbolicVariable_Object),            /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)SymbolicVariable_dealloc,       /* tp_dealloc */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall_offset */
+        #else
         (printfunc)SymbolicVariable_print,          /* tp_print */
+        #endif
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -325,6 +331,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -3058,7 +3058,7 @@ namespace triton {
         sizeof(TritonContext_Object),               /* tp_basicsize */
         0,                                          /* tp_itemsize */
         (destructor)TritonContext_dealloc,          /* tp_dealloc */
-        0,                                          /* tp_print */
+        0,                                          /* tp_print or tp_vectorcall_offset */
         0,                                          /* tp_getattr */
         0,                                          /* tp_setattr */
         0,                                          /* tp_compare */
@@ -3102,6 +3102,9 @@ namespace triton {
         #if IS_PY3
         0,                                          /* tp_version_tag */
         0,                                          /* tp_finalize */
+        #if IS_PY3_8
+        0,                                          /* tp_vectorcall */
+        #endif
         #else
         0                                           /* tp_version_tag */
         #endif

--- a/src/libtriton/includes/triton/py3c_compat.h
+++ b/src/libtriton/includes/triton/py3c_compat.h
@@ -12,6 +12,12 @@
 
 #define IS_PY3 1
 
+#if PY_MINOR_VERSION >= 8
+#define IS_PY3_8 1
+#else
+#define IS_PY3_8 0
+#endif
+
 /* Strings */
 
 #define PyStr_Type PyUnicode_Type


### PR DESCRIPTION
Fixed some of the warnings since it's turned out that Python 3.8 added new field - `tp_vectorcall` in the object structure. And `tp_print` is now became `tp_vectorcall_offset`:
- https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_vectorcall_offset
- https://github.com/python/cpython/blob/master/Objects/typeobject.c#L5014
- https://renenyffenegger.ch/notes/development/languages/Python/CPython/sources/Include/cpython/object_h

Sadly, some warnings remain and I have no idea where they come from (`tp_print` was removed as documentation mentions):
```
/home/Triton/src/libtriton/bindings/python/objects/pyAstContext.cpp:1777:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
 1777 |       };
      |       ^
[ 70%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyAstNode.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyAstNode.cpp:941:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  941 |       };
      |       ^
[ 71%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyBitsVector.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyBitsVector.cpp:208:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  208 |       };
      |       ^
[ 72%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyImmediate.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyImmediate.cpp:326:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  326 |       };
      |       ^
[ 73%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyInstruction.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyInstruction.cpp:817:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  817 |       };
      |       ^
[ 75%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyMemoryAccess.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyMemoryAccess.cpp:492:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  492 |       };
      |       ^
[ 76%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyPathConstraint.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyPathConstraint.cpp:227:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  227 |       };
      |       ^
[ 77%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyRegister.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyRegister.cpp:431:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  431 |       };
      |       ^
[ 78%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pySolverModel.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pySolverModel.cpp:213:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  213 |       };
      |       ^
[ 79%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pySymbolicExpression.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp:390:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  390 |       };
      |       ^
[ 80%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pySymbolicVariable.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pySymbolicVariable.cpp:340:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
  340 |       };
      |       ^
[ 81%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyTritonContext.cpp.o
/home/Triton/src/libtriton/bindings/python/objects/pyTritonContext.cpp:3111:7: warning: missing initializer for member ‘_typeobject::tp_print’ [-Wmissing-field-initializers]
 3111 |       };
      |       ^

```
