### PR TITLE
Push simple expressions to path constraints

### DIFF
--- a/src/libtriton/engines/symbolic/pathManager.cpp
+++ b/src/libtriton/engines/symbolic/pathManager.cpp
@@ -140,14 +140,17 @@ namespace triton {
 
         /* Multiple branches */
         if (pc->getType() == triton::ast::ITE_NODE) {
+          /* Condition */
+          triton::ast::SharedAbstractNode cond = pc->getChildren()[0];
+
+          /* Then */
           triton::uint64 bb1 = pc->getChildren()[1]->evaluate().convert_to<triton::uint64>();
+          triton::ast::SharedAbstractNode bb1pc = cond;
+
+          /* Else */
           triton::uint64 bb2 = pc->getChildren()[2]->evaluate().convert_to<triton::uint64>();
+          triton::ast::SharedAbstractNode bb2pc = this->astCtxt->lnot(cond);
 
-          triton::ast::SharedAbstractNode bb1pc = (bb1 == dstAddr) ? this->astCtxt->equal(pc, this->astCtxt->bv(dstAddr, size)) :
-                                                                     this->astCtxt->lnot(this->astCtxt->equal(pc, this->astCtxt->bv(dstAddr, size)));
-
-          triton::ast::SharedAbstractNode bb2pc = (bb2 == dstAddr) ? this->astCtxt->equal(pc, this->astCtxt->bv(dstAddr, size)) :
-                                                                     this->astCtxt->lnot(this->astCtxt->equal(pc, this->astCtxt->bv(dstAddr, size)));
           /* Branch A */
           pco.addBranchConstraint(
             bb1 == dstAddr, /* is taken ? */

--- a/src/testers/unittests/test_path_constraint.py
+++ b/src/testers/unittests/test_path_constraint.py
@@ -70,11 +70,11 @@ class TestPathConstraint(unittest.TestCase):
         pc  = self.ctx.getPathPredicate()
         opc = pc
 
-        self.assertEqual(str(pc), "(and (= (_ bv1 1) (_ bv1 1)) (= (ite (= ref!35 (_ bv1 1)) (_ bv91 32) (_ bv23 32)) (_ bv91 32)))")
+        self.assertEqual(str(pc), "(and (= (_ bv1 1) (_ bv1 1)) (= ref!35 (_ bv1 1)))")
         self.ctx.pushPathConstraint(ast.equal(ast.bvtrue(), ast.bvtrue()))
 
         pc  = self.ctx.getPathPredicate()
-        self.assertEqual(str(pc), "(and (and (= (_ bv1 1) (_ bv1 1)) (= (ite (= ref!35 (_ bv1 1)) (_ bv91 32) (_ bv23 32)) (_ bv91 32))) (= (_ bv1 1) (_ bv1 1)))")
+        self.assertEqual(str(pc), "(and (and (= (_ bv1 1) (_ bv1 1)) (= ref!35 (_ bv1 1))) (= (_ bv1 1) (_ bv1 1)))")
 
         self.ctx.popPathConstraint()
         pc  = self.ctx.getPathPredicate()


### PR DESCRIPTION
Previously `ite` formulas were pushed. We can just push a corresponding condition from them. Motivating example:
```
< (and (and (and (= (_ bv1 1) (_ bv1 1)) (not (= ref!10453 (_ bv0 8)))) (not (= ref!10458 (_ bv0 8)))) (not (= (ite (= ref!11694 (_ bv0 1)) (_ bv139860530526313 64) (_ bv139860530526257 64)) (_ bv139860530526257 64))))
---
> (and (and (and (= (_ bv1 1) (_ bv1 1)) (not (= ref!10453 (_ bv0 8)))) (not (= ref!10458 (_ bv0 8)))) (= ref!11694 (_ bv0 1)))
```