### PR TITLE
Implement extract AST simplifications

### DIFF
--- a/src/libtriton/ast/astContext.cpp
+++ b/src/libtriton/ast/astContext.cpp
@@ -788,7 +788,7 @@ namespace triton {
           high > low && high < size) {
         while (true) {
           auto n = node;
-          if (n->getType() == REFERENCE_NODE) {
+          while (n->getType() == REFERENCE_NODE) {
             auto ref = reinterpret_cast<ReferenceNode*>(n.get());
             n = ref->getSymbolicExpression()->getAst();
           }
@@ -837,7 +837,7 @@ namespace triton {
 
         /* Optimization: extract from extract is one extract */
         auto n = node;
-        if (n->getType() == REFERENCE_NODE) {
+        while (n->getType() == REFERENCE_NODE) {
           auto ref = reinterpret_cast<ReferenceNode*>(n.get());
           n = ref->getSymbolicExpression()->getAst();
         }

--- a/src/libtriton/ast/astContext.cpp
+++ b/src/libtriton/ast/astContext.cpp
@@ -227,6 +227,14 @@ namespace triton {
         /* Optimization: A * 0 = 0 */
         if (!expr2->isSymbolized() && expr2->evaluate() == 0)
           return this->bv(0, expr1->getBitvectorSize());
+
+        /* Optimization: 1 * A = A */
+        if (!expr1->isSymbolized() && expr1->evaluate() == 1)
+          return expr2;
+
+        /* Optimization: A * 1 = A */
+        if (!expr2->isSymbolized() && expr2->evaluate() == 1)
+          return expr1;
       }
 
       SharedAbstractNode node = std::make_shared<BvmulNode>(expr1, expr2);

--- a/src/libtriton/ast/astContext.cpp
+++ b/src/libtriton/ast/astContext.cpp
@@ -777,11 +777,83 @@ namespace triton {
 
 
     SharedAbstractNode AstContext::extract(triton::uint32 high, triton::uint32 low, const SharedAbstractNode& expr) {
+      auto node = expr;
+      auto size = expr->getBitvectorSize();
+
       /* Optimization: If we extract the full size of expr, just return expr */
-      if (low == 0 && (high + 1) == expr->getBitvectorSize())
+      if (low == 0 && (high + 1) == size)
         return expr;
 
-      SharedAbstractNode node = std::make_shared<ExtractNode>(high, low, expr);
+      if (this->modes->isModeEnabled(triton::modes::AST_OPTIMIZATIONS) &&
+          high > low && high < size) {
+        while (true) {
+          auto n = node;
+          if (n->getType() == REFERENCE_NODE) {
+            auto ref = reinterpret_cast<ReferenceNode*>(n.get());
+            n = ref->getSymbolicExpression()->getAst();
+          }
+          if (n->getType() == CONCAT_NODE) {
+            /* Optimization: If we extract the full part of concatenation, just
+             * return the part */
+            auto hi = n->getBitvectorSize() - 1;
+            bool found = false;
+            for (const auto& part : n->getChildren()) {
+              if (hi < high) {
+                break;
+              }
+              auto sz = part->getBitvectorSize();
+              auto lo = hi + 1 - sz;
+              if (hi == high && lo == low) {
+                return part;
+              }
+              if (hi >= high && lo <= low) {
+                node = part;
+                high -= lo;
+                low -= lo;
+                found = true;
+                break;
+              }
+              hi -= sz;
+            }
+            if (found) {
+              continue;
+            }
+          }
+          else if (n->getType() == ZX_NODE || n->getType() == SX_NODE) {
+            /* Optimization: If we extract from the node being extended, just
+             * return the node */
+            n = n->getChildren()[1];
+            auto sz = n->getBitvectorSize();
+            if (low == 0 && high + 1 == sz) {
+              return n;
+            }
+            if (high < sz) {
+              node = n;
+              continue;
+            }
+          }
+          break;
+        }
+
+        /* Optimization: extract from extract is one extract */
+        auto n = node;
+        if (n->getType() == REFERENCE_NODE) {
+          auto ref = reinterpret_cast<ReferenceNode*>(n.get());
+          n = ref->getSymbolicExpression()->getAst();
+        }
+        if (n->getType() == EXTRACT_NODE) {
+          const auto& childs = n->getChildren();
+          auto hi = reinterpret_cast<IntegerNode*>(childs[0].get())->getInteger().convert_to<triton::uint32>();
+          auto lo = reinterpret_cast<IntegerNode*>(childs[1].get())->getInteger().convert_to<triton::uint32>();
+          if (lo + high <= hi) {
+            node = childs[2];
+            high += lo;
+            low += lo;
+          }
+        }
+      }
+
+      node = std::make_shared<ExtractNode>(high, low, node);
       if (node == nullptr)
         throw triton::exceptions::Ast("AstContext::extract(): Not enough memory.");
       node->init();

--- a/src/libtriton/includes/triton/astContext.hpp
+++ b/src/libtriton/includes/triton/astContext.hpp
@@ -210,6 +210,15 @@ namespace triton {
             }
           }
 
+          if (this->modes->isModeEnabled(triton::modes::AST_OPTIMIZATIONS) &&
+              node->getBitvectorSize() <= 512) {
+            /* Optimization: concatenate extractions in one if possible */
+            auto n = this->simplify_concat(std::vector<SharedAbstractNode>(exprs.begin(), exprs.end()));
+            if (n) {
+              node = n;
+            }
+          }
+
           return this->collect(node);
         }
 
@@ -320,6 +329,10 @@ namespace triton {
 
         //! Prints the given node with this context representation
         TRITON_EXPORT std::ostream& print(std::ostream& stream, AbstractNode* node);
+
+      private:
+        //! Return simplified concatenation.
+        SharedAbstractNode simplify_concat(std::vector<SharedAbstractNode> exprs) const;
     };
 
     //! Shared AST context

--- a/src/testers/unittests/test_ast_simplification.py
+++ b/src/testers/unittests/test_ast_simplification.py
@@ -621,14 +621,21 @@ class TestAstSimplification4(unittest.TestCase):
         n = self.ast.concat([self.ast.extract(23, 16, a), self.ast.extract(15, 8, a)])
         self.assertEqual(str(n), "((_ extract 23 8) SymVar_0)")
 
-    def test_concat_extract_5(self):
+    def test_concat_extract_intersection(self):
         a = self.ast.variable(self.ctx.newSymbolicVariable(32))
-        e = self.ast.extract(15, 8, a)
-        r = self.ast.reference(self.ctx.newSymbolicExpression(e, "r"))
-        c1 = self.ast.concat([self.ast.extract(31, 24, a), r])
-        c2 = self.ast.concat([self.ast.extract(17, 16, a), self.ast.extract(23, 17, a)])
-        n = self.ast.concat([c1, c2])
-        self.assertEqual(str(n), "((_ extract 31 8) SymVar_0)")
+        n = self.ast.concat([self.ast.extract(31, 24, a), self.ast.extract(27, 26, a),
+                             self.ast.extract(23, 16, a), self.ast.extract(15, 8, a),
+                             self.ast.extract(7, 0, a)])
+        self.assertEqual(str(n), ("(concat ((_ extract 31 24) SymVar_0) "
+                                  "((_ extract 27 26) SymVar_0) "
+                                  "((_ extract 23 16) SymVar_0) "
+                                  "((_ extract 15 8) SymVar_0) "
+                                  "((_ extract 7 0) SymVar_0))"))
+
+    def test_concat_extract_order(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        n = self.ast.concat([self.ast.extract(15, 0, a), self.ast.extract(31, 16, a)])
+        self.assertEqual(str(n), "(concat ((_ extract 15 0) SymVar_0) ((_ extract 31 16) SymVar_0))")
 
 
 class TestAstSimplification5(unittest.TestCase):

--- a/src/testers/unittests/test_ast_simplification.py
+++ b/src/testers/unittests/test_ast_simplification.py
@@ -593,6 +593,43 @@ class TestAstSimplification4(unittest.TestCase):
         n = self.ast.extract(7, 0, r2)
         self.assertEqual(str(n), "SymVar_0")
 
+    def test_concat_extract(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        n = self.ast.concat([self.ast.extract(31, 24, a), self.ast.extract(23, 16, a),
+                             self.ast.extract(15, 8, a), self.ast.extract(7, 0, a)])
+        self.assertEqual(str(n), "SymVar_0")
+
+    def test_concat_extract_2(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        e = self.ast.extract(15, 8, a)
+        r = self.ast.reference(self.ctx.newSymbolicExpression(e, "r"))
+        n = self.ast.concat([self.ast.extract(31, 24, a), self.ast.extract(23, 16, a),
+                             r, self.ast.extract(7, 0, a)])
+        self.assertEqual(str(n), "SymVar_0")
+
+    def test_concat_extract_3(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        e = self.ast.extract(15, 8, a)
+        r = self.ast.reference(self.ctx.newSymbolicExpression(e, "r"))
+        c1 = self.ast.concat([self.ast.extract(31, 24, a), self.ast.extract(23, 16, a)])
+        c2 = self.ast.concat([r, self.ast.extract(7, 0, a)])
+        n = self.ast.concat([c1, c2])
+        self.assertEqual(str(n), "SymVar_0")
+
+    def test_concat_extract_4(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        n = self.ast.concat([self.ast.extract(23, 16, a), self.ast.extract(15, 8, a)])
+        self.assertEqual(str(n), "((_ extract 23 8) SymVar_0)")
+
+    def test_concat_extract_5(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        e = self.ast.extract(15, 8, a)
+        r = self.ast.reference(self.ctx.newSymbolicExpression(e, "r"))
+        c1 = self.ast.concat([self.ast.extract(31, 24, a), r])
+        c2 = self.ast.concat([self.ast.extract(17, 16, a), self.ast.extract(23, 17, a)])
+        n = self.ast.concat([c1, c2])
+        self.assertEqual(str(n), "((_ extract 31 8) SymVar_0)")
+
 
 class TestAstSimplification5(unittest.TestCase):
 

--- a/src/testers/unittests/test_ast_simplification.py
+++ b/src/testers/unittests/test_ast_simplification.py
@@ -432,6 +432,14 @@ class TestAstSimplification4(unittest.TestCase):
         n = self.ast.bvmul(b, a)
         self.assertTrue(self.proof(n == 0))
 
+    def test_mul3(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        b = self.ast.bv(1, 32)
+        n = self.ast.bvmul(b, a)
+        self.assertEqual(str(n), "SymVar_0")
+        n = self.ast.bvmul(a, b)
+        self.assertEqual(str(n), "SymVar_0")
+
     def test_or1(self):
         a = self.ast.variable(self.ctx.newSymbolicVariable(32))
         b = self.ast.bv(0, 32)

--- a/src/testers/unittests/test_ast_simplification.py
+++ b/src/testers/unittests/test_ast_simplification.py
@@ -524,3 +524,101 @@ class TestAstSimplification4(unittest.TestCase):
         a = self.ast.variable(self.ctx.newSymbolicVariable(32))
         n = self.ast.bvxor(a, a)
         self.assertTrue(self.proof(n == 0))
+
+    def test_extract_concat(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(8))
+        n = self.ast.extract(7, 0, self.ast.concat([self.ast.bv(0, 24), a]))
+        self.assertEqual(str(n), "SymVar_0")
+
+    def test_extract_concat_2(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(8))
+        c = [self.ast.bv(1, 8), self.ast.bv(2, 8), self.ast.bv(3, 8), a]
+        n = self.ast.extract(7, 0, self.ast.concat(c))
+        self.assertEqual(str(n), "SymVar_0")
+        n = self.ast.extract(15, 8, self.ast.concat(c))
+        self.assertEqual(str(n), "(_ bv3 8)")
+        n = self.ast.extract(23, 16, self.ast.concat(c))
+        self.assertEqual(str(n), "(_ bv2 8)")
+        n = self.ast.extract(31, 24, self.ast.concat(c))
+        self.assertEqual(str(n), "(_ bv1 8)")
+        n = self.ast.extract(8, 0, self.ast.concat(c))
+        self.assertEqual(str(n), "((_ extract 8 0) (concat (_ bv1 8) (_ bv2 8) (_ bv3 8) SymVar_0))")
+        n = self.ast.extract(12, 9, self.ast.concat(c))
+        self.assertEqual(str(n), "((_ extract 4 1) (_ bv3 8))")
+        n = self.ast.extract(17, 16, self.ast.concat(c))
+        self.assertEqual(str(n), "((_ extract 1 0) (_ bv2 8))")
+        n = self.ast.extract(31, 30, self.ast.concat(c))
+        self.assertEqual(str(n), "((_ extract 7 6) (_ bv1 8))")
+
+    def test_extract_concat_3(self):
+        c1 = self.ast.concat([self.ast.bv(1, 8), self.ast.bv(2, 24)])
+        c2 = self.ast.concat([c1, self.ast.bv(3, 32)])
+        c = [self.ast.bv(4, 8), c2, self.ast.bv(5, 8)]
+        n = self.ast.extract(43, 41, self.ast.concat(c))
+        self.assertEqual(str(n), "((_ extract 3 1) (_ bv2 24))")
+
+    def test_extract_concat_real(self):
+        self.ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+        self.ctx.symbolizeRegister(self.ctx.getRegister(REG.X86.EAX), "eax")
+        code = [
+            b"\xb0\x00",                  # mov al, 0x00
+            b"\x84\xc0",                  # test al, al
+            b"\x0f\x84\xe9\xbe\xad\xde",  # jz 0xdeadbeef
+        ]
+        addr = 0x400000
+        for opcode in code:
+            inst = Instruction(addr, opcode)
+            self.ctx.processing(inst)
+            addr += len(opcode)
+        self.assertEqual(len(self.ctx.getPathConstraints()), 0)
+
+    def test_extract_extract(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        n = self.ast.extract(4, 2, self.ast.extract(18, 5, a))
+        self.assertEqual(str(n), "((_ extract 9 7) SymVar_0)")
+
+
+class TestAstSimplification5(unittest.TestCase):
+
+    """Testing AST simplification"""
+
+    def setUp(self):
+        self.ctx = TritonContext()
+        self.ctx.setArchitecture(ARCH.X86_64)
+        self.ast = self.ctx.getAstContext()
+        self.ctx.setMode(MODE.AST_OPTIMIZATIONS, True)
+
+    def proof(self, n):
+        if self.ctx.isSat(self.ast.lnot(n)) == True:
+            return False
+        return True
+
+    def test_extract_zx(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        zx = self.ast.zx(32, a)
+        n = self.ast.extract(31, 0, zx)
+        self.assertEqual(str(n), "SymVar_0")
+        n = self.ast.extract(30, 0, zx)
+        self.assertEqual(str(n), "((_ extract 30 0) SymVar_0)")
+
+    def test_extract_zx_real(self):
+        self.ctx.symbolizeRegister(self.ctx.getRegister(REG.X86_64.EAX), "eax")
+        addr = 0x400000
+        code = [
+            b"\x89\xc3",  # mov ebx, eax
+            b"\x89\xd9",  # mov ecx, ebx
+        ]
+        for opcode in code:
+            inst = Instruction(addr, opcode)
+            self.ctx.processing(inst)
+            addr += len(opcode)
+        ecx = self.ctx.getRegister(REG.X86_64.ECX)
+        self.assertEqual(str(self.ctx.getRegisterAst(ecx)), "eax")
+
+    def test_extract_sx(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(32))
+        sx = self.ast.sx(32, a)
+        n = self.ast.extract(31, 0, sx)
+        self.assertEqual(str(n), "SymVar_0")
+        n = self.ast.extract(30, 0, sx)
+        self.assertEqual(str(n), "((_ extract 30 0) SymVar_0)")

--- a/src/testers/unittests/test_ast_simplification.py
+++ b/src/testers/unittests/test_ast_simplification.py
@@ -577,6 +577,14 @@ class TestAstSimplification4(unittest.TestCase):
         n = self.ast.extract(4, 2, self.ast.extract(18, 5, a))
         self.assertEqual(str(n), "((_ extract 9 7) SymVar_0)")
 
+    def test_extract_ref(self):
+        a = self.ast.variable(self.ctx.newSymbolicVariable(8))
+        c = self.ast.concat([self.ast.bv(0, 24), a])
+        r1 = self.ast.reference(self.ctx.newSymbolicExpression(c, "r1"))
+        r2 = self.ast.reference(self.ctx.newSymbolicExpression(r1, "r2"))
+        n = self.ast.extract(7, 0, r2)
+        self.assertEqual(str(n), "SymVar_0")
+
 
 class TestAstSimplification5(unittest.TestCase):
 


### PR DESCRIPTION
Hi!

I implemented a few cool AST simplifications for extract node. Like:

1) extract from extract
2) extract from one of concatenated nodes
3) extract from actually not extended value

This solves the following real life case:

```
    def test_extract_concat_real(self):
        self.ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
        self.ctx.symbolizeRegister(self.ctx.getRegister(REG.X86.EAX), "eax")
        code = [
            b"\xb0\x00",                  # mov al, 0x00
            b"\x84\xc0",                  # test al, al
            b"\x0f\x84\xe9\xbe\xad\xde",  # jz 0xdeadbeef
        ]
        addr = 0x400000
        for opcode in code:
            inst = Instruction(addr, opcode)
            self.ctx.processing(inst)
            addr += len(opcode)
        self.assertEqual(len(self.ctx.getPathConstraints()), 0)
```

So, this pull request kind of increases symbolic registers granularity. Without my patch there would be one path constraint, because eax is symbolized. But actually we use only constant al.