### PR TITLE
Force to use python3 binary

### DIFF
--- a/src/examples/python/backward_slicing.py
+++ b/src/examples/python/backward_slicing.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
-## $ python ./backward_slicing.py
+## $ python3 ./backward_slicing.py
 ## [slicing] 0x40058b: movzx eax, byte ptr [rax]
 ## [slicing] 0x40058e: movsx eax, al
 ## [slicing] 0x400591: sub eax, 1

--- a/src/examples/python/code_coverage_crackme_xor.py
+++ b/src/examples/python/code_coverage_crackme_xor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Output:

--- a/src/examples/python/constraints.py
+++ b/src/examples/python/constraints.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/alexctf-2017-re2-cpp-is-awesome/solve.py
+++ b/src/examples/python/ctf-writeups/alexctf-2017-re2-cpp-is-awesome/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2020-05-01
@@ -8,9 +8,9 @@
 ##
 ##  Output:
 ##
-##  $ time python solve2.py
+##  $ time python3 solve2.py
 ##  [+] Good flag: ALEXCTF{W3_L0v3_C_W1th_CL45535}
-##  python solve2.py  0.32s user 0.00s system 99% cpu 0.322 total
+##  python3 solve2.py  0.32s user 0.00s system 99% cpu 0.322 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/alexctf-2017-re3-catalyst-system/solve.py
+++ b/src/examples/python/ctf-writeups/alexctf-2017-re3-catalyst-system/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2020-05-03
@@ -14,7 +14,7 @@
 ##
 ##  Output:
 ##
-##  $ time python ./solve.py
+##  $ time python3 ./solve.py
 ##  Loading..............................
 ##  Username: Password: Logging in..............................
 ##  your flag is: ALEXCTF{1_t41d_y0u_y0u_ar3__gr34t__reverser__s33
@@ -22,7 +22,7 @@
 ##  [+] The password is : sLSVpQ4vK3cGWyW86AiZhggwLHBjmx9CRspVGggj
 ##  [+] The flag is : 1_t41d_y0u_y0u_ar3__gr34t__reverser__s33
 ##  Success!
-##  python ./solve.py  2.68s user 0.02s system 99% cpu 2.709 total
+##  python3 ./solve.py  2.68s user 0.02s system 99% cpu 2.709 total
 ##  $
 ##
 

--- a/src/examples/python/ctf-writeups/custom-crackmes/aarch64-hash/solve.py
+++ b/src/examples/python/ctf-writeups/custom-crackmes/aarch64-hash/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2018-12-26

--- a/src/examples/python/ctf-writeups/custom-crackmes/arm32-hash/solve-arm.py
+++ b/src/examples/python/ctf-writeups/custom-crackmes/arm32-hash/solve-arm.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/custom-crackmes/arm32-hash/solve-thumb.py
+++ b/src/examples/python/ctf-writeups/custom-crackmes/arm32-hash/solve-thumb.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/defcamp-2015-r100/solve.py
+++ b/src/examples/python/ctf-writeups/defcamp-2015-r100/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2016-08-02
@@ -9,7 +9,7 @@
 ##
 ##  Output:
 ##
-##  $ time python ./solve.py
+##  $ time python3 ./solve.py
 ##  [...]
 ##  400784: movsx eax, al
 ##  400787: sub edx, eax
@@ -37,7 +37,7 @@
 ##  4007a7: ret
 ##  [+] Emulation done.
 ##  [+] Flag found: bytearray(b'Code_Talkers')
-##  python solve.py  0.27s user 0.01s system 99% cpu 0.276 total
+##  python3 solve.py  0.27s user 0.01s system 99% cpu 0.276 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/defcon-2016-baby-re/solve.py
+++ b/src/examples/python/ctf-writeups/defcon-2016-baby-re/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2016-08-01
@@ -11,7 +11,7 @@
 ##
 ##  Output:
 ##
-##   $ time python ./solve.py
+##   $ time python3 ./solve.py
 ##   [...]
 ##   0x4025a0: imul eax, edx
 ##   0x4025a3: add ecx, eax
@@ -27,7 +27,7 @@
 ##   [+] Win
 ##   [+] Emulation done.
 ##   [+] Final solution: bytearray(b'Math is hard!')
-##   python solve.py  310.81s user 0.19s system 99% cpu 5:11.46 total
+##   python3 solve.py  310.81s user 0.19s system 99% cpu 5:11.46 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/ekopartyctf2016_rev250/solve.py
+++ b/src/examples/python/ctf-writeups/ekopartyctf2016_rev250/solve.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2020-04-26
 ##
 ##  Output:
 ##
-##  $ time python ./solve.py
+##  $ time python3 ./solve.py
 ##  [+] Loading 0x400040 - 0x400238
 ##  [+] Loading 0x400238 - 0x400254
 ##  [+] Loading 0x400000 - 0x405804
@@ -30,7 +30,7 @@
 ##  Valid input is: ''@ (G @@ ^@v@  @/5vC\p D AC`P `  $  @#@   X  @@@P h@?@  WAU" A( Lq@ @p@ F$tH w60 * B k[Qn @@NCp@0I@@'
 ##  [+] Instruction executed: 2220
 ##  [+] Emulation done.
-##  python solve.py  2.60s user 0.02s system 99% cpu 2.626 total
+##  python3 solve.py  2.60s user 0.02s system 99% cpu 2.626 total
 ##
 ##  $ ./FUck_binary
 ##  Hello, what's your team name? '@ (G @@ ^@v@  @/5vC\p D AC`P `  $  @#@   X  @@@P h@?@  WAU" A( Lq@ @p@ F$tH w60 * B k[Qn @@NCp@0I@@

--- a/src/examples/python/ctf-writeups/google2016-unbreakable/solve.py
+++ b/src/examples/python/ctf-writeups/google2016-unbreakable/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2018-10-26
@@ -9,7 +9,7 @@
 ##
 ##  Output:
 ##
-##  $ time python ./solve.py
+##  $ time python3 ./solve.py
 ##  [+] Loading 0x400040 - 0x400200
 ##  [+] Loading 0x400200 - 0x40021c
 ##  [+] Loading 0x400000 - 0x403df4
@@ -32,7 +32,7 @@
 ##  Thank you - product activated!
 ##  [+] exit hooked
 ##  Flag: CTF{0The1Quick2Brown3Fox4Jumped5Over6The7Lazy8Fox9}
-##  python solve.py  8.04s user 0.02s system 99% cpu 8.060 total
+##  python3 solve.py  8.04s user 0.02s system 99% cpu 8.060 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/hackcon-2016-angry-reverser/solve.py
+++ b/src/examples/python/ctf-writeups/hackcon-2016-angry-reverser/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2018-11-02
@@ -13,7 +13,7 @@
 ##
 ##  Output:
 ##
-##  $ time python solve.py
+##  $ time python3 solve.py
 ##  [+] Loading 0x400040 - 0x400200
 ##  [+] Loading 0x400200 - 0x40021c
 ##  [+] Loading 0x400000 - 0x405d04
@@ -62,7 +62,7 @@
 ##  [+] Instruction executed: 4453
 ##  [+] Emulation done.
 ##
-##  python solve.py  113.53s user 0.09s system 99% cpu 1:53.79 total
+##  python3 solve.py  113.53s user 0.09s system 99% cpu 1:53.79 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/hackover-ctf-2015-r150/solve.py
+++ b/src/examples/python/ctf-writeups/hackover-ctf-2015-r150/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2017-02-06
@@ -13,7 +13,7 @@
 ##
 ##   $ time ./solve.py
 ##   PASSWORD:hackover15{I_USE_GOTO_WHEREEVER_I_W4NT}
-##   python ./solve.py  0.11s user 0.00s system 99% cpu 0.111 total
+##   python3 ./solve.py  0.11s user 0.00s system 99% cpu 0.111 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/mma-2015-howtouse/solve.py
+++ b/src/examples/python/ctf-writeups/mma-2015-howtouse/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2018-11-03
@@ -10,7 +10,7 @@
 ##
 ##  Output:
 ##
-##  $ time python solve.py
+##  $ time python3 solve.py
 ##  [+] Loading 0x10001000 - 0x10001b10
 ##  [+] Loading 0x10002000 - 0x10002573
 ##  [+] Loading 0x10003000 - 0x10003364
@@ -62,7 +62,7 @@
 ##  [+] Starting emulation of the function howtouse(43)
 ##  [+] Starting emulation of the function howtouse(44)
 ##  Flag is: MMA{fc7d90ca001fc8712497d88d9ee7efa9e9b32ed8}
-##  python solve.py  0.18s user 0.02s system 99% cpu 0.200 total
+##  python3 solve.py  0.18s user 0.02s system 99% cpu 0.200 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/ctf-writeups/securityfest-2016-fairlight/solve.py
+++ b/src/examples/python/ctf-writeups/securityfest-2016-fairlight/solve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2020-04-26
@@ -6,7 +6,7 @@
 ##
 ##  Output:
 ##
-##  $ time python ./solve.py
+##  $ time python3 ./solve.py
 ##  [+] Loading 0x400040 - 0x400238
 ##  [+] Loading 0x400238 - 0x400254
 ##  [+] Loading 0x400000 - 0x401ecc
@@ -69,7 +69,7 @@
 ##  [+] rand hooked
 ##  [+] Solve constraint at 4018f3
 ##  [+] OK - ACCESS GRANTED: CODE{b'4ngrman4gem3nt'}
-##  python solve.py  21.63s user 0.03s system 99% cpu 21.690 total
+##  python3 solve.py  21.63s user 0.03s system 99% cpu 21.690 total
 ##
 
 from __future__ import print_function

--- a/src/examples/python/disass.py
+++ b/src/examples/python/disass.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Output:
 ##
-##  $ python src/examples/python/disass.py
+##  $ python3 src/examples/python/disass.py
 ##  40000: imul sil
 ##      ---------------
 ##      Is memory read : False

--- a/src/examples/python/forward_tainting.py
+++ b/src/examples/python/forward_tainting.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
-## $ python forward_tainting.py
+## $ python3 forward_tainting.py
 ## [tainted] 0x40058e: movsx eax, al
 ## [tainted] 0x400591: sub eax, 1
 ## [tainted] 0x400594: xor eax, 0x55

--- a/src/examples/python/hooking_libc.py
+++ b/src/examples/python/hooking_libc.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Output:
 ##
-##  $ python ./src/examples/python/hooking_libc.py
+##  $ python3 ./src/examples/python/hooking_libc.py
 ##  [+] Loading 0x400040 - 0x400270
 ##  [+] Loading 0x400270 - 0x40028c
 ##  [+] Loading 0x400000 - 0x4007a4

--- a/src/examples/python/ir.py
+++ b/src/examples/python/ir.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Output
 ##
-##  $ python ir.py
+##  $ python3 ir.py
 ##  400000: mov rax, qword ptr [rip + 0x13b8]
 ##          ref!0 = (concat ((_ extract 7 0) (_ bv0 8)) ((_ extract 7 0) (_ bv49 8)) ((_ extract 7 0) (_ bv0 8)) ((_ extract 7 0) (_ bv50 8)) ((_ extract 7 0) (_ bv0 8)) ((_ extract 7 0) (_ bv51 8)) ((_ extract 7 0) (_ bv0 8)) ((_ extract 7 0) (_ bv52 8))) ; MOV operation
 ##          ref!1 = (_ bv4194311 64) ; Program Counter

--- a/src/examples/python/proving_opaque_predicates.py
+++ b/src/examples/python/proving_opaque_predicates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Example to detect opaque predicates. This example is based
@@ -6,7 +6,7 @@
 ##
 ## Output:
 ##
-##  $ python proving_opaque_predicates.py
+##  $ python3 proving_opaque_predicates.py
 ##  xor eax, eax
 ##  jo 7
 ##  opaque predicate: never taken

--- a/src/examples/python/simplification.py
+++ b/src/examples/python/simplification.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Output:

--- a/src/examples/python/small_x86-64_symbolic_emulator.py
+++ b/src/examples/python/small_x86-64_symbolic_emulator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## An example of a small symbolic emulator for elf x86-64 binaries.

--- a/src/examples/python/symbolic_emulation_1.py
+++ b/src/examples/python/symbolic_emulation_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Output:

--- a/src/examples/python/symbolic_emulation_2.py
+++ b/src/examples/python/symbolic_emulation_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Output:

--- a/src/examples/python/symbolic_emulation_crackme_xor.py
+++ b/src/examples/python/symbolic_emulation_crackme_xor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/examples/python/synthetizing_obfuscated_expressions.py
+++ b/src/examples/python/synthetizing_obfuscated_expressions.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 ##
 ## Example of synthetizing obfuscated expressions.
 ##
-## $ time python ./synthetizing_obfuscated_expressions.py
+## $ time python3 ./synthetizing_obfuscated_expressions.py
 ## In: (((((SymVar_0 | SymVar_1) + SymVar_1) & 0xff) - ((~(SymVar_0) & 0xff) & SymVar_1)) & 0xff)
 ## Out: ((SymVar_0 + SymVar_1) & 0xff)
 ##
@@ -28,7 +28,7 @@
 ## In: (((0xed * ((((((((0x2d * ((((((((((((((((((0x3a * (((((((((((0x56 * ((((((((((((0xed * ((((0xe5 * Sy ...
 ## Out: (SymVar_0 ^ 0x5c)
 ##
-## python ./synthetizing_obfuscated_expressions.py  0.12s user 0.01s system 99% cpu 0.125 total
+## python3 ./synthetizing_obfuscated_expressions.py  0.12s user 0.01s system 99% cpu 0.125 total
 ##
 
 from __future__ import print_function

--- a/src/scripts/extract_syscall.py
+++ b/src/scripts/extract_syscall.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # This script is used to generate the files src/utils/syscalls{32,64}.cpp.
 # As the list of syscalls depends of your Kernel version. We must

--- a/src/testers/aarch64/unicorn_test_aarch64.py
+++ b/src/testers/aarch64/unicorn_test_aarch64.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-nothumb-O0-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-nothumb-O0-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-nothumb-O1-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-nothumb-O1-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-nothumb-O2-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-nothumb-O2-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-nothumb-O3-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-nothumb-O3-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-nothumb-Os-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-nothumb-Os-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-nothumb-Oz-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-nothumb-Oz-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-thumb-O0-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-thumb-O0-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-thumb-O1-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-thumb-O1-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-thumb-O2-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-thumb-O2-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-thumb-O3-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-thumb-O3-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-thumb-Os-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-thumb-Os-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/crypto_test/crypto_test-thumb-Oz-run.py
+++ b/src/testers/arm32/crypto_test/crypto_test-thumb-Oz-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/src/testers/arm32/unicorn_test_arm32_branch_arm_1.py
+++ b/src/testers/arm32/unicorn_test_arm32_branch_arm_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_branch_arm_2.py
+++ b/src/testers/arm32/unicorn_test_arm32_branch_arm_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_branch_pc_arm_1.py
+++ b/src/testers/arm32/unicorn_test_arm32_branch_pc_arm_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_branch_pc_arm_2.py
+++ b/src/testers/arm32/unicorn_test_arm32_branch_pc_arm_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_branch_thumb_1.py
+++ b/src/testers/arm32/unicorn_test_arm32_branch_thumb_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_branch_thumb_2.py
+++ b/src/testers/arm32/unicorn_test_arm32_branch_thumb_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_data_arm.py
+++ b/src/testers/arm32/unicorn_test_arm32_data_arm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_data_thumb.py
+++ b/src/testers/arm32/unicorn_test_arm32_data_thumb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_interworking_arm.py
+++ b/src/testers/arm32/unicorn_test_arm32_interworking_arm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_interworking_thumb.py
+++ b/src/testers/arm32/unicorn_test_arm32_interworking_thumb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_loadstore_arm_1.py
+++ b/src/testers/arm32/unicorn_test_arm32_loadstore_arm_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_loadstore_arm_2.py
+++ b/src/testers/arm32/unicorn_test_arm32_loadstore_arm_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_loadstore_arm_3.py
+++ b/src/testers/arm32/unicorn_test_arm32_loadstore_arm_3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_loadstore_arm_4.py
+++ b/src/testers/arm32/unicorn_test_arm32_loadstore_arm_4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_loadstore_thumb_1.py
+++ b/src/testers/arm32/unicorn_test_arm32_loadstore_thumb_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_loadstore_thumb_2.py
+++ b/src/testers/arm32/unicorn_test_arm32_loadstore_thumb_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/arm32/unicorn_test_arm32_loadstore_thumb_3.py
+++ b/src/testers/arm32/unicorn_test_arm32_loadstore_thumb_3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__          import print_function

--- a/src/testers/unittests/test_arch.py
+++ b/src/testers/unittests/test_arch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test architectures."""
 

--- a/src/testers/unittests/test_ast_conversion.py
+++ b/src/testers/unittests/test_ast_conversion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test AST conversion."""
 

--- a/src/testers/unittests/test_ast_deep.py
+++ b/src/testers/unittests/test_ast_deep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test deep AST."""
 

--- a/src/testers/unittests/test_ast_duplication.py
+++ b/src/testers/unittests/test_ast_duplication.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test AST conversion."""
 

--- a/src/testers/unittests/test_ast_eval.py
+++ b/src/testers/unittests/test_ast_eval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Testing the arithmetic and logic AST interpreter."""
 

--- a/src/testers/unittests/test_ast_reference.py
+++ b/src/testers/unittests/test_ast_reference.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test AST reference."""
 

--- a/src/testers/unittests/test_ast_representation.py
+++ b/src/testers/unittests/test_ast_representation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test AST representation."""
 

--- a/src/testers/unittests/test_ast_simplification.py
+++ b/src/testers/unittests/test_ast_simplification.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Testing AST simplification."""
 

--- a/src/testers/unittests/test_ast_utils.py
+++ b/src/testers/unittests/test_ast_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 """Test AST utils."""
 

--- a/src/testers/unittests/test_bitvector.py
+++ b/src/testers/unittests/test_bitvector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test architectures."""
 

--- a/src/testers/unittests/test_callback.py
+++ b/src/testers/unittests/test_callback.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test callback."""
 

--- a/src/testers/unittests/test_concrete_value.py
+++ b/src/testers/unittests/test_concrete_value.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test architectures."""
 

--- a/src/testers/unittests/test_disass.py
+++ b/src/testers/unittests/test_disass.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test disassembly."""
 

--- a/src/testers/unittests/test_doc.py
+++ b/src/testers/unittests/test_doc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Tester for documentation."""
 import unittest

--- a/src/testers/unittests/test_examples.py
+++ b/src/testers/unittests/test_examples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Tester for examples."""
 import glob

--- a/src/testers/unittests/test_flags.py
+++ b/src/testers/unittests/test_flags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test flags."""
 

--- a/src/testers/unittests/test_github_issues.py
+++ b/src/testers/unittests/test_github_issues.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Issue from Github."""
 

--- a/src/testers/unittests/test_im_callback.py
+++ b/src/testers/unittests/test_im_callback.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 import unittest

--- a/src/testers/unittests/test_immediate.py
+++ b/src/testers/unittests/test_immediate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test immediate."""
 

--- a/src/testers/unittests/test_immutable_registers.py
+++ b/src/testers/unittests/test_immutable_registers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test immutable registers."""
 

--- a/src/testers/unittests/test_instruction.py
+++ b/src/testers/unittests/test_instruction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test instruction."""
 

--- a/src/testers/unittests/test_memory.py
+++ b/src/testers/unittests/test_memory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test memory."""
 

--- a/src/testers/unittests/test_only_symbolized_mode.py
+++ b/src/testers/unittests/test_only_symbolized_mode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test ONLY_ON_SYMBOLIZED."""
 

--- a/src/testers/unittests/test_only_tainted_mode.py
+++ b/src/testers/unittests/test_only_tainted_mode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test ONLY_ON_TAINTED mode."""
 

--- a/src/testers/unittests/test_path_constraint.py
+++ b/src/testers/unittests/test_path_constraint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Path Constraint."""
 

--- a/src/testers/unittests/test_registers.py
+++ b/src/testers/unittests/test_registers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test register."""
 

--- a/src/testers/unittests/test_semantics.py
+++ b/src/testers/unittests/test_semantics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Semantics."""
 

--- a/src/testers/unittests/test_simulation.py
+++ b/src/testers/unittests/test_simulation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Symbolic Engine."""
 

--- a/src/testers/unittests/test_symbolic.py
+++ b/src/testers/unittests/test_symbolic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Symbolic."""
 

--- a/src/testers/unittests/test_symbolic_expression.py
+++ b/src/testers/unittests/test_symbolic_expression.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Symbolic Expression."""
 

--- a/src/testers/unittests/test_symbolic_optimizations.py
+++ b/src/testers/unittests/test_symbolic_optimizations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Symbolic Optimizations."""
 

--- a/src/testers/unittests/test_symbolic_variable.py
+++ b/src/testers/unittests/test_symbolic_variable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Symbolic Variable."""
 

--- a/src/testers/unittests/test_taint.py
+++ b/src/testers/unittests/test_taint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test Taint."""
 

--- a/src/testers/unittests/test_undefined_registers.py
+++ b/src/testers/unittests/test_undefined_registers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 """Test the undefined register behavior."""
 

--- a/src/testers/x86/unicorn_test_x86.py
+++ b/src/testers/x86/unicorn_test_x86.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ## -*- coding: utf-8 -*-
 
 from __future__        import print_function


### PR DESCRIPTION
Some distributions do not set `/usr/bin/python` if only python3 is installed, for example Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=970375

I tried to compile Triton in this environment (Debian Sid and python3-only) and it fails due to `/usr/bin/env: 'python': No such file or directory`. At this point it's better to use `python3` binary explicitly.

- https://wiki.debian.org/Python/2Removal
- https://access.redhat.com/solutions/4455511
- https://pythonclock.org/