### PR TITLE
Allow ONLY_ON_SYMBOLIZED clean to happen manually

### DIFF
--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -515,6 +515,10 @@ namespace triton {
     this->arch.disassembly(inst);
   }
 
+  void API::manualClearInstruction(triton::arch::Instruction& inst) {
+    this->irBuilder->clearIrInst(inst);
+  }
+
 
 
   /* Processing API ================================================================================ */

--- a/src/libtriton/arch/irBuilder.cpp
+++ b/src/libtriton/arch/irBuilder.cpp
@@ -127,6 +127,16 @@ namespace triton {
 
 
     void IrBuilder::postIrInit(triton::arch::Instruction& inst) {
+      /* Set the taint */
+      inst.setTaint();
+
+      if (!this->modes->isModeEnabled(triton::modes::MANUAL_CLEAN_INSTRUCTION)) {
+        this->clearIrInst(inst);
+      }
+    }
+
+
+    void IrBuilder::clearIrInst(triton::arch::Instruction& inst) {
       std::vector<triton::engines::symbolic::SharedSymbolicExpression> newVector;
 
       auto& loadAccess        = inst.getLoadAccess();
@@ -134,9 +144,6 @@ namespace triton {
       auto& readImmediates    = inst.getReadImmediates();
       auto& storeAccess       = inst.getStoreAccess();
       auto& writtenRegisters  = inst.getWrittenRegisters();
-
-      /* Set the taint */
-      inst.setTaint();
 
       // ----------------------------------------------------------------------
 

--- a/src/libtriton/bindings/python/namespaces/initModeNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initModeNamespace.cpp
@@ -49,6 +49,9 @@ Enabled, Triton will perform symbolic execution only on symbolized expressions.
 - **MODE.ONLY_ON_TAINTED**<br>
 Enabled, Triton will perform symbolic execution only on tainted instructions.
 
+- **MODE.MANUAL_CLEAN_INSTRUCTION**<br>
+Enabled, Triton will require manual cleaning of instructions after processing.
+
 - **MODE.PC_TRACKING_SYMBOLIC**<br>
 Enabled, Triton will track path constraints only if they are symbolized. This mode is enabled by default.
 
@@ -72,6 +75,7 @@ namespace triton {
         xPyDict_SetItemString(modeDict, "CONSTANT_FOLDING",               PyLong_FromUint32(triton::modes::CONSTANT_FOLDING));
         xPyDict_SetItemString(modeDict, "ONLY_ON_SYMBOLIZED",             PyLong_FromUint32(triton::modes::ONLY_ON_SYMBOLIZED));
         xPyDict_SetItemString(modeDict, "ONLY_ON_TAINTED",                PyLong_FromUint32(triton::modes::ONLY_ON_TAINTED));
+        xPyDict_SetItemString(modeDict, "MANUAL_CLEAN_INSTRUCTION",       PyLong_FromUint32(triton::modes::MANUAL_CLEAN_INSTRUCTION));
         xPyDict_SetItemString(modeDict, "PC_TRACKING_SYMBOLIC",           PyLong_FromUint32(triton::modes::PC_TRACKING_SYMBOLIC));
         xPyDict_SetItemString(modeDict, "SYMBOLIZE_INDEX_ROTATION",       PyLong_FromUint32(triton::modes::SYMBOLIZE_INDEX_ROTATION));
         xPyDict_SetItemString(modeDict, "TAINT_THROUGH_POINTERS",         PyLong_FromUint32(triton::modes::TAINT_THROUGH_POINTERS));

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -3229,7 +3229,6 @@ namespace triton {
         {"untaintMemory",                       (PyCFunction)TritonContext_untaintMemory,                             METH_O,                        ""},
         {"untaintRegister",                     (PyCFunction)TritonContext_untaintRegister,                           METH_O,                        ""},
         {nullptr,                               nullptr,                                                              0,                             nullptr}
-        {"manualClearInstruction",              (PyCFunction)TritonContext_manualClearInstruction,                 METH_O,             ""},
       };
 
 

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -95,6 +95,10 @@ Returns the new symbolic volatile expression and links this expression to the in
 - <b>void disassembly(\ref py_Instruction_page inst)</b><br>
 Disassembles the instruction and sets up operands. You must define an architecture before.
 
+- <b>void manualClearInstruction(triton::arch::Instruction& inst)</b><br>
+Manually clears the instruction. Should be used if MANUAL_CLEAN_INSTRUCION mode is on. You must define an architecture before. \sa processing().
+        TRITON_EXPORT 
+
 - <b>void enableSymbolicEngine(bool flag)</b><br>
 Enables or disables the symbolic execution engine.
 
@@ -1058,6 +1062,25 @@ namespace triton {
 
         try {
           PyTritonContext_AsTritonContext(self)->disassembly(*PyInstruction_AsInstruction(inst));
+        }
+        catch (const triton::exceptions::PyCallbacks&) {
+          return nullptr;
+        }
+        catch (const triton::exceptions::Exception& e) {
+          return PyErr_Format(PyExc_TypeError, "%s", e.what());
+        }
+
+        Py_INCREF(Py_None);
+        return Py_None;
+      }
+
+
+      static PyObject* TritonContext_manualClearInstruction(PyObject* self, PyObject* inst) {
+        if (!PyInstruction_Check(inst))
+          return PyErr_Format(PyExc_TypeError, "TritonContext::manualClearInstruction(): Expects an Instruction as argument.");
+
+        try {
+          PyTritonContext_AsTritonContext(self)->manualClearInstruction(*PyInstruction_AsInstruction(inst));
         }
         catch (const triton::exceptions::PyCallbacks&) {
           return nullptr;
@@ -3121,6 +3144,7 @@ namespace triton {
         {"createSymbolicRegisterExpression",    (PyCFunction)TritonContext_createSymbolicRegisterExpression,          METH_VARARGS,                  ""},
         {"createSymbolicVolatileExpression",    (PyCFunction)TritonContext_createSymbolicVolatileExpression,          METH_VARARGS,                  ""},
         {"disassembly",                         (PyCFunction)TritonContext_disassembly,                               METH_O,                        ""},
+        {"manualClearInstruction",              (PyCFunction)TritonContext_manualClearInstruction,                    METH_O,                        ""},
         {"enableSymbolicEngine",                (PyCFunction)TritonContext_enableSymbolicEngine,                      METH_O,                        ""},
         {"enableTaintEngine",                   (PyCFunction)TritonContext_enableTaintEngine,                         METH_O,                        ""},
         {"evaluateAstViaZ3",                    (PyCFunction)TritonContext_evaluateAstViaZ3,                          METH_O,                        ""},

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -96,8 +96,7 @@ Returns the new symbolic volatile expression and links this expression to the in
 Disassembles the instruction and sets up operands. You must define an architecture before.
 
 - <b>void manualClearInstruction(triton::arch::Instruction& inst)</b><br>
-Manually clears the instruction. Should be used if MANUAL_CLEAN_INSTRUCION mode is on. You must define an architecture before. \sa processing().
-        TRITON_EXPORT 
+Manually clears the instruction. Should be used if MANUAL_CLEAN_INSTRUCION mode is on. You must define an architecture before. \sa processing(). 
 
 - <b>void enableSymbolicEngine(bool flag)</b><br>
 Enables or disables the symbolic execution engine.

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -236,6 +236,8 @@ namespace triton {
         //! [**architecture api**] - Disassembles the instruction and setup operands. You must define an architecture before. \sa processing().
         TRITON_EXPORT void disassembly(triton::arch::Instruction& inst) const;
 
+        //! [**architecture api**] - Manually clears the instruction. Should be used if MANUAL_CLEAN_INSTRUCION mode is on. You must define an architecture before. \sa processing().
+        TRITON_EXPORT void manualClearInstruction(triton::arch::Instruction& inst);
 
 
         /* Processing API ================================================================================ */

--- a/src/libtriton/includes/triton/irBuilder.hpp
+++ b/src/libtriton/includes/triton/irBuilder.hpp
@@ -94,11 +94,14 @@ namespace triton {
         //! Builds the semantics of the instruction. Returns true if the instruction is supported.
         TRITON_EXPORT bool buildSemantics(triton::arch::Instruction& inst);
 
-        //! Everything which must be done before buiding the semantics
+        //! Everything which must be done before buiding the semantics.
         TRITON_EXPORT void preIrInit(triton::arch::Instruction& inst);
 
         //! Everything which must be done after building the semantics.
         TRITON_EXPORT void postIrInit(triton::arch::Instruction& inst);
+
+        //! Cleans the instruction of unneeded data after processing.
+        TRITON_EXPORT void clearIrInst(triton::arch::Instruction& inst);
     };
 
   /*! @} End of arch namespace */

--- a/src/libtriton/includes/triton/modesEnums.hpp
+++ b/src/libtriton/includes/triton/modesEnums.hpp
@@ -33,6 +33,7 @@ namespace triton {
       CONSTANT_FOLDING,               //!< [symbolic] Perform a constant folding optimization of sub ASTs which do not contain symbolic variables.
       ONLY_ON_SYMBOLIZED,             //!< [symbolic] Perform symbolic execution only on symbolized expressions.
       ONLY_ON_TAINTED,                //!< [symbolic] Perform symbolic execution only on tainted instructions.
+      MANUAL_CLEAN_INSTRUCTION,       //!< [symbolic] Require manual cleaning of instructions after processing.
       PC_TRACKING_SYMBOLIC,           //!< [symbolic] Track path constraints only if they are symbolized.
       SYMBOLIZE_INDEX_ROTATION,       //!< [symbolic] Symbolize index rotation for bvrol and bvror (see #751). This mode increases the complexity of solving.
       TAINT_THROUGH_POINTERS,         //!< [taint] Spread the taint if an index pointer is already tainted (see #725).

--- a/src/testers/unittests/test_manual_clean_mode.py
+++ b/src/testers/unittests/test_manual_clean_mode.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""Test ONLY_ON_SYMBOLIZED."""
+
+import unittest
+
+from triton import ARCH, MODE, CPUSIZE, TritonContext, Instruction, MemoryAccess
+
+
+def checkAstIntegrity(instruction):
+    """
+    This function check if all ASTs under an Instruction class are still
+    available.
+    """
+    try:
+        for se in instruction.getSymbolicExpressions():
+            str(se.getAst())
+
+        for x, y in instruction.getLoadAccess():
+            str(y)
+
+        for x, y in instruction.getStoreAccess():
+            str(y)
+
+        for x, y in instruction.getReadRegisters():
+            str(y)
+
+        for x, y in instruction.getWrittenRegisters():
+            str(y)
+
+        for x, y in instruction.getReadImmediates():
+            str(y)
+
+        return True
+
+    except:
+        return False
+
+
+class TestOnlySymbolizedMode(unittest.TestCase):
+
+    """Testing the MANUAL_CLEAN_INSTRUCTION mode."""
+
+    def test_1(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, False)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+
+        inst = Instruction(b"\x48\x89\xc3") # mov rbx, rax
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertEqual(len(inst.getReadRegisters()), 0)
+        self.assertEqual(len(inst.getWrittenRegisters()), 0)
+        self.assertEqual(len(inst.getLoadAccess()), 0)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+    def test_2(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        ctx.symbolizeRegister(ctx.registers.rax)
+
+        inst = Instruction(b"\x48\x89\xc3") # mov rbx, rax
+        self.assertTrue(ctx.processing(inst))
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 1)
+        self.assertEqual(len(inst.getLoadAccess()), 0)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+    def test_3(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+
+        inst = Instruction(b"\x48\x8b\x18") # mov rbx, qword ptr [rax]
+        self.assertTrue(ctx.processing(inst))
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+        self.assertEqual(len(inst.getLoadAccess()), 1)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+    def test_4(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        ctx.symbolizeRegister(ctx.registers.rax)
+
+        inst = Instruction(b"\x48\x8b\x18") # mov rbx, qword ptr [rax]
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 0)
+        self.assertEqual(len(inst.getLoadAccess()), 0)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+    def test_5(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        ctx.symbolizeMemory(MemoryAccess(0, CPUSIZE.QWORD))
+
+        inst = Instruction(b"\x48\x8b\x18") # mov rbx, qword ptr [rax]
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+        self.assertEqual(len(inst.getLoadAccess()), 1)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertEqual(len(inst.getReadRegisters()), 0)
+        self.assertEqual(len(inst.getWrittenRegisters()), 1)
+        self.assertEqual(len(inst.getLoadAccess()), 1)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+    def test_6(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        ctx.symbolizeRegister(ctx.registers.rax)
+        ctx.symbolizeMemory(MemoryAccess(0, CPUSIZE.QWORD))
+
+        inst = Instruction(b"\x48\x8b\x18") # mov rbx, qword ptr [rax]
+        self.assertTrue(ctx.processing(inst))
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 1)
+        self.assertEqual(len(inst.getLoadAccess()), 1)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+    def test_7(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        ctx.setConcreteRegisterValue(ctx.registers.rax, 0x1337)
+
+        inst = Instruction(b"\x48\x8b\x18") # mov rbx, qword ptr [rax]
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(inst.getOperands()[1].getAddress(), 0x1337)
+        self.assertIsNotNone(inst.getOperands()[1].getLeaAst())
+        self.assertTrue(inst.isMemoryRead())
+
+        ctx.manualClearInstruction(inst)
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(inst.getOperands()[1].getAddress(), 0x1337)
+        self.assertIsNone(inst.getOperands()[1].getLeaAst())
+
+    def test_8(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        ctx.setConcreteRegisterValue(ctx.registers.rax, 0x1337)
+        ctx.symbolizeRegister(ctx.registers.rax)
+        ctx.symbolizeMemory(MemoryAccess(0, CPUSIZE.QWORD))
+
+        inst = Instruction(b"\x48\x8b\x18") # mov rbx, qword ptr [rax]
+        self.assertTrue(ctx.processing(inst))
+
+        ctx.manualClearInstruction(inst)
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(inst.getOperands()[1].getAddress(), 0x1337)
+        self.assertIsNotNone(inst.getOperands()[1].getLeaAst())
+
+    def test_9(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+        ctx.setMode(MODE.ONLY_ON_TAINTED, False)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        self.assertEqual(ctx.isModeEnabled(MODE.ONLY_ON_TAINTED), False)
+        self.assertEqual(ctx.isModeEnabled(MODE.MANUAL_CLEAN_INSTRUCTION), True)
+
+        inst = Instruction(b"\x48\x89\xc3") # mov rbx, rax
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+
+        ctx.manualClearInstruction(inst)
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+
+        ctx.setMode(MODE.ONLY_ON_TAINTED, True)
+        self.assertEqual(ctx.isModeEnabled(MODE.ONLY_ON_TAINTED), True)
+
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertEqual(len(inst.getSymbolicExpressions()), 0)
+        self.assertEqual(len(inst.getReadRegisters()), 0)
+        self.assertEqual(len(inst.getReadImmediates()), 0)
+        self.assertEqual(len(inst.getWrittenRegisters()), 0)
+        self.assertEqual(len(inst.getLoadAccess()), 0)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+    def test_10(self):
+        ctx = TritonContext()
+        ctx.setArchitecture(ARCH.X86_64)
+
+        self.assertEqual(ctx.isModeEnabled(MODE.ONLY_ON_TAINTED), False)
+        ctx.setMode(MODE.ONLY_ON_TAINTED, True)
+        self.assertEqual(ctx.isModeEnabled(MODE.ONLY_ON_TAINTED), True)
+
+        self.assertEqual(ctx.isModeEnabled(MODE.MANUAL_CLEAN_INSTRUCTION), False)
+        ctx.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
+        self.assertEqual(ctx.isModeEnabled(MODE.MANUAL_CLEAN_INSTRUCTION), True)
+
+        ctx.taintRegister(ctx.registers.rax)
+
+        inst = Instruction(b"\x48\x89\xc3") # mov rbx, rax
+        self.assertTrue(ctx.processing(inst))
+        self.assertTrue(checkAstIntegrity(inst))
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+        self.assertEqual(len(inst.getLoadAccess()), 0)
+        self.assertEqual(len(inst.getStoreAccess()), 0)
+
+        ctx.manualClearInstruction(inst)
+
+        self.assertEqual(len(inst.getReadRegisters()), 1)
+        self.assertEqual(len(inst.getWrittenRegisters()), 2)
+        self.assertEqual(len(inst.getLoadAccess()), 0)
+        self.assertEqual(len(inst.getStoreAccess()), 0)


### PR DESCRIPTION
I need the speed and memory benefits of "ONLY_ON_SYMBOLIZED", but still would like to test some instruction semantics after processing an instruction.
This patch adds a mode "MANUAL_CLEAN_INSTRUCTION" which will delay doing most of what was in `IrBuilder::postIrInit` until the user manually calls `API::manualClearInstruction`

The use pattern is something like this
```
Triton.setMode(MODE.ONLY_ON_SYMBOLIZED, True)
Triton.setMode(MODE.MANUAL_CLEAN_INSTRUCTION, True)
while pc:
        # Fetch opcode
        opcode = Triton.getConcreteMemoryAreaValue(pc, 16)

        # Create the Triton instruction
        instruction = Instruction()
        instruction.setOpcode(opcode)
        instruction.setAddress(pc)

        # Process
        Triton.processing(instruction)

        ###
        # ... use instruction semantics here, like getLoadAccess or getWrittenRegisters
        ###

        Triton.manualClearInstruction(instruction)

        # Next
        pc = Triton.getConcreteRegisterValue(Triton.registers.rip)

```
This can be used just as easily with ONLY_ON_TAINTED as well, to check some information before you throw away untainted info.

If you would rather have this implemented some other way, let me know. I am happy to change things. This seemed to be the simplest method without any code duplication.

Thanks!