### PR TITLE
Instruction semantics

### DIFF
--- a/src/libtriton/arch/x86/x86Semantics.cpp
+++ b/src/libtriton/arch/x86/x86Semantics.cpp
@@ -179,10 +179,12 @@ NOT                          |            | One's Complement Negation
 OR                           |            | Logical Inclusive OR
 ORPD                         | sse2       | Bitwise Logical OR of Double-Precision Floating-Point Values
 ORPS                         | sse1       | Bitwise Logical OR of Single-Precision Floating-Point Values
+PACKUSWB                     | mmx/sse2   | Pack with unsigned saturation
 PADDB                        | mmx/sse2   | Add packed byte integers
 PADDD                        | mmx/sse2   | Add packed doubleword integers
 PADDQ                        | mmx/sse2   | Add packed quadword integers
 PADDW                        | mmx/sse2   | Add packed word integers
+PALIGNR                      | sse3       | Packed Align Right
 PAND                         | mmx/sse2   | Logical AND
 PANDN                        | mmx/sse2   | Logical AND NOT
 PAUSE                        | sse2       | Spin Loop Hint
@@ -326,6 +328,9 @@ VMOVD                        | avx        | VEX Move Doubleword
 VMOVDQA                      | avx        | VEX Move aligned packed integer values
 VMOVDQU                      | avx        | VEX Move unaligned packed integer values
 VMOVQ                        | avx        | VEX Move Quadword
+VMOVSD                       | avx        | VEX Move or Merge Scalar Double-Precision Floating-Point Value
+VMOVAPS                      | avx        | VEX Move Aligned Packed Single-Precision Floating-Point Values
+VMOVUPS                      | avx        | VEX Move Unaligned Packed Single-Precision Floating-Point Values
 VPAND                        | avx/avx2   | VEX Logical AND
 VPANDN                       | avx/avx2   | VEX Logical AND NOT
 VPEXTRB                      | avx/avx2   | VEX Extract Byte
@@ -336,12 +341,21 @@ VPCMPEQB                     | avx/avx2   | VEX Compare packed Bytes for equalit
 VPCMPEQD                     | avx/avx2   | VEX Compare packed Doublewords for equality
 VPCMPEQQ                     | avx/avx2   | VEX Compare packed Quadwords for equality
 VPCMPEQW                     | avx/avx2   | VEX Compare packed Words for equality
+VPCMPGTB                     | avx/avx2   | VEX Compare Packed Bytes for Greater Than
+VPCMPGTD                     | avx/avx2   | VEX Compare Packed Doublewords for Greater Than
+VPCMPGTW                     | avx/avx2   | VEX Compare Packed Words for Greater Than
 VPMOVMSKB                    | avx/avx2   | VEX Move Byte Mask
 VPMINUB                      | avx/avx2   | VEX Minimum of Packed Unsigned Byte Integers
 VPOR                         | avx/avx2   | VEX Logical OR
 VPSHUFD                      | avx/avx2   | VEX Shuffle Packed Doublewords
+VPSLLDQ                      | avx/avx2   | VEX Byte Shift Double Quadword Left Logical
+VPSUBB                       | avx/avx2   | VEX Subtract packed Byte integers
+VPSUBD                       | avx/avx2   | VEX Subtract packed Doubleword integers
+VPSUBQ                       | avx/avx2   | VEX Subtract packed Quadword integers
+VPSUBW                       | avx/avx2   | VEX Subtract packed Word integers
 VPTEST                       | avx        | VEX Logical Compare
 VPXOR                        | avx/avx2   | VEX Logical XOR
+VXORPS                       | avx        | VEX Bitwise Logical XOR for Single-Precision Floating-Point Values
 WAIT                         |            | Wait
 WBINVD                       |            | Write Back and Invalidate Cache
 XADD                         |            | Exchange and Add
@@ -531,10 +545,12 @@ namespace triton {
           case ID_INS_OR:             this->or_s(inst);           break;
           case ID_INS_ORPD:           this->orpd_s(inst);         break;
           case ID_INS_ORPS:           this->orps_s(inst);         break;
+          case ID_INS_PACKUSWB:       this->packuswb_s(inst);     break;
           case ID_INS_PADDB:          this->paddb_s(inst);        break;
           case ID_INS_PADDD:          this->paddd_s(inst);        break;
           case ID_INS_PADDQ:          this->paddq_s(inst);        break;
           case ID_INS_PADDW:          this->paddw_s(inst);        break;
+          case ID_INS_PALIGNR:        this->palignr_s(inst);      break;
           case ID_INS_PAND:           this->pand_s(inst);         break;
           case ID_INS_PANDN:          this->pandn_s(inst);        break;
           case ID_INS_PAUSE:          this->pause_s(inst);        break;
@@ -678,6 +694,9 @@ namespace triton {
           case ID_INS_VMOVDQA:        this->vmovdqa_s(inst);      break;
           case ID_INS_VMOVDQU:        this->vmovdqu_s(inst);      break;
           case ID_INS_VMOVQ:          this->vmovq_s(inst);        break;
+          case ID_INS_VMOVSD:         this->vmovsd_s(inst);       break;
+          case ID_INS_VMOVAPS:        this->vmovaps_s(inst);      break;
+          case ID_INS_VMOVUPS:        this->vmovups_s(inst);      break;
           case ID_INS_VPAND:          this->vpand_s(inst);        break;
           case ID_INS_VPANDN:         this->vpandn_s(inst);       break;
           case ID_INS_VPEXTRB:        this->vpextrb_s(inst);      break;
@@ -689,12 +708,21 @@ namespace triton {
           case ID_INS_VPCMPEQD:       this->vpcmpeqd_s(inst);     break;
           case ID_INS_VPCMPEQQ:       this->vpcmpeqq_s(inst);     break;
           case ID_INS_VPCMPEQW:       this->vpcmpeqw_s(inst);     break;
+          case ID_INS_VPCMPGTB:       this->vpcmpgtb_s(inst);     break;
+          case ID_INS_VPCMPGTD:       this->vpcmpgtd_s(inst);     break;
+          case ID_INS_VPCMPGTW:       this->vpcmpgtw_s(inst);     break;
           case ID_INS_VPMOVMSKB:      this->vpmovmskb_s(inst);    break;
           case ID_INS_VPMINUB:        this->vpminub_s(inst);      break;
           case ID_INS_VPOR:           this->vpor_s(inst);         break;
           case ID_INS_VPSHUFD:        this->vpshufd_s(inst);      break;
+          case ID_INS_VPSLLDQ:        this->vpslldq_s(inst);      break;
+          case ID_INS_VPSUBB:         this->vpsubb_s(inst);       break;
+          case ID_INS_VPSUBD:         this->vpsubd_s(inst);       break;
+          case ID_INS_VPSUBQ:         this->vpsubq_s(inst);       break;
+          case ID_INS_VPSUBW:         this->vpsubw_s(inst);       break;
           case ID_INS_VPTEST:         this->vptest_s(inst);       break;
           case ID_INS_VPXOR:          this->vpxor_s(inst);        break;
+          case ID_INS_VXORPS:         this->vxorps_s(inst);       break;
           case ID_INS_WAIT:           this->wait_s(inst);         break;
           case ID_INS_WBINVD:         this->wbinvd_s(inst);       break;
           case ID_INS_XADD:           this->xadd_s(inst);         break;
@@ -7472,7 +7500,6 @@ namespace triton {
         /*
          * F2 0F 10 /r MOVSD xmm1, xmm2
          * F2 0F 10 /r MOVSD xmm1, m64
-         * F2 0F 11 /r MOVSD m64, xmm2
          */
         if (dst.getBitSize() == triton::bitsize::dqword) {
           auto op1  = this->symbolicEngine->getOperandAst(inst, src);
@@ -8073,6 +8100,48 @@ namespace triton {
       }
 
 
+      void x86Semantics::packuswb_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src = inst.operands[1];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, dst);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize());
+
+        std::vector<triton::ast::SharedAbstractNode> ops{op2, op1};
+        for (triton::uint32 i = 0; i < ops.size(); i++) {
+          for (triton::uint32 index = 0; index < dst.getSize() / triton::size::word; index++) {
+            uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::word);
+            uint32 low  = (dst.getBitSize() - triton::bitsize::word) - (index * triton::bitsize::word);
+            auto signed_word = this->astCtxt->extract(high, low, ops[i]);
+            pck.push_back(this->astCtxt->ite(
+                           this->astCtxt->bvsge(signed_word, this->astCtxt->bv(0xff, triton::bitsize::word)),
+                           this->astCtxt->bv(0xff, triton::bitsize::byte),
+                           this->astCtxt->ite(
+                             this->astCtxt->bvsle(signed_word, this->astCtxt->bv(0x00, triton::bitsize::word)),
+                             this->astCtxt->bv(0x00, triton::bitsize::byte),
+                             this->astCtxt->extract(triton::bitsize::byte - 1, 0, signed_word)))
+                         );
+          }
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "PACKUSWB operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintUnion(dst, src);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
       void x86Semantics::paddb_s(triton::arch::Instruction& inst) {
         auto& dst = inst.operands[0];
         auto& src = inst.operands[1];
@@ -8253,6 +8322,42 @@ namespace triton {
 
         /* Spread taint */
         expr->isTainted = this->taintEngine->taintUnion(dst, src);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::palignr_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto size = 2 * dst.getBitSize();
+        auto op1 = this->symbolicEngine->getOperandAst(inst, dst);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op3 = this->astCtxt->zx(size - src2.getBitSize(),
+                                      this->symbolicEngine->getOperandAst(inst, src2));
+
+        /* Create the semantics */
+        auto node = this->astCtxt->extract(
+                      dst.getBitSize() - 1, 0,
+                      this->astCtxt->bvlshr(
+                        this->astCtxt->concat(op1, op2),
+                        this->astCtxt->bvmul(
+                          this->astCtxt->ite(
+                            this->astCtxt->bvuge(op3, this->astCtxt->bv(2 * dst.getSize(), size)),
+                            this->astCtxt->bv(2 * dst.getSize(), size),
+                            op3),
+                          this->astCtxt->bv(triton::bitsize::byte, size)
+                        )));
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "PALIGNR operation");
+
+        /* Spread taint */
+        expr->isTainted = this->taintEngine->taintUnion(dst, src1);
 
         /* Update the symbolic control flow */
         this->controlFlow_s(inst);
@@ -13856,6 +13961,105 @@ namespace triton {
       }
 
 
+      void x86Semantics::vmovsd_s(triton::arch::Instruction& inst) {
+        /* Move scalar double-precision floating-point value */
+        if (inst.operands.size() == 2) {
+          auto& dst = inst.operands[0];
+          auto& src = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op1  = this->symbolicEngine->getOperandAst(inst, dst);
+          auto op2  = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          triton::ast::SharedAbstractNode node;
+          if (dst.getSize() == triton::size::dqword && src.getSize() == triton::size::qword) {
+            /* VEX.LIG.F2.0F.WIG 10 /r VMOVSD xmm1, m64 */
+            node = op2;
+          }
+          else if (dst.getSize() == triton::size::qword && src.getSize() == triton::size::dqword) {
+            /* VEX.LIG.F2.0F.WIG 11 /r VMOVSD m64, xmm1 */
+            node = this->astCtxt->extract(triton::bitsize::qword - 1, 0, op2);
+          }
+          else {
+            throw triton::exceptions::Semantics("x86Semantics::vmovsd_s(): Invalid operand size.");
+          }
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VMOVSD operation");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+        }
+
+        /* Merge scalar double-precision floating-point value
+         *
+         * VEX.NDS.LIG.F2.0F.WIG 10 /r VMOVSD xmm1, xmm2, xmm3
+         * VEX.NDS.LIG.F2.0F.WIG 11 /r VMOVSD xmm1, xmm2, xmm3
+         */
+        else if (inst.operands.size() == 3) {
+          auto& dst = inst.operands[0];
+          auto& src1 = inst.operands[1];
+          auto& src2 = inst.operands[2];
+
+           /* Create symbolic operands */
+          auto op1  = this->symbolicEngine->getOperandAst(inst, dst);
+          auto op2  = this->symbolicEngine->getOperandAst(inst, src1);
+          auto op3  = this->symbolicEngine->getOperandAst(inst, src2);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->concat(
+                        this->astCtxt->extract(triton::bitsize::dqword - 1, triton::bitsize::qword, op2),
+                        this->astCtxt->extract(triton::bitsize::qword - 1, 0, op3));
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VMOVSD operation");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+        }
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vmovaps_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src = inst.operands[1];
+
+        /* Create the semantics */
+        auto node = this->symbolicEngine->getOperandAst(inst, src);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VMOVAPS operation");
+
+        /* Spread taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vmovups_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src = inst.operands[1];
+
+        /* Create the semantics */
+        auto node = this->symbolicEngine->getOperandAst(inst, src);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VMOVUPS operation");
+
+        /* Spread taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
       void x86Semantics::vpand_s(triton::arch::Instruction& inst) {
         auto& dst  = inst.operands[0];
         auto& src1 = inst.operands[1];
@@ -14082,8 +14286,7 @@ namespace triton {
         auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPCMPEQB operation");
 
         /* Apply the taint */
-        expr->isTainted = this->taintEngine->taintAssignment(dst, src1);
-        expr->isTainted = this->taintEngine->taintUnion(dst, src2);
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
 
         /* Update the symbolic control flow */
         this->controlFlow_s(inst);
@@ -14121,8 +14324,7 @@ namespace triton {
         auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPCMPEQD operation");
 
         /* Apply the taint */
-        expr->isTainted = this->taintEngine->taintAssignment(dst, src1);
-        expr->isTainted = this->taintEngine->taintUnion(dst, src2);
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
 
         /* Update the symbolic control flow */
         this->controlFlow_s(inst);
@@ -14160,8 +14362,7 @@ namespace triton {
         auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPCMPEQQ operation");
 
         /* Apply the taint */
-        expr->isTainted = this->taintEngine->taintAssignment(dst, src1);
-        expr->isTainted = this->taintEngine->taintUnion(dst, src2);
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
 
         /* Update the symbolic control flow */
         this->controlFlow_s(inst);
@@ -14199,8 +14400,121 @@ namespace triton {
         auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPCMPEQW operation");
 
         /* Apply the taint */
-        expr->isTainted = this->taintEngine->taintAssignment(dst, src1);
-        expr->isTainted = this->taintEngine->taintUnion(dst, src2);
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vpcmpgtb_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize());
+
+        for (triton::uint32 index = 0; index < dst.getSize(); index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::byte);
+          uint32 low  = (dst.getBitSize() - triton::bitsize::byte) - (index * triton::bitsize::byte);
+          pck.push_back(this->astCtxt->ite(
+                          this->astCtxt->bvsgt(
+                            this->astCtxt->extract(high, low, op1),
+                            this->astCtxt->extract(high, low, op2)),
+                          this->astCtxt->bv(0xff, triton::bitsize::byte),
+                          this->astCtxt->bv(0x00, triton::bitsize::byte))
+                       );
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPCMPGTB operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vpcmpgtd_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize() / triton::size::dword);
+
+        for (triton::uint32 index = 0; index < dst.getSize() / triton::size::dword; index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::dword);
+          uint32 low  = (dst.getBitSize() - triton::bitsize::dword) - (index * triton::bitsize::dword);
+          pck.push_back(this->astCtxt->ite(
+                          this->astCtxt->bvsgt(
+                            this->astCtxt->extract(high, low, op1),
+                            this->astCtxt->extract(high, low, op2)),
+                          this->astCtxt->bv(0xffffffff, triton::bitsize::dword),
+                          this->astCtxt->bv(0x00000000, triton::bitsize::dword))
+                       );
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPCMPGTD operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vpcmpgtw_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize() / triton::size::word);
+
+        for (triton::uint32 index = 0; index < dst.getSize() / triton::size::word; index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::word);
+          uint32 low  = (dst.getBitSize() - triton::bitsize::word) - (index * triton::bitsize::word);
+          pck.push_back(this->astCtxt->ite(
+                          this->astCtxt->bvsgt(
+                            this->astCtxt->extract(high, low, op1),
+                            this->astCtxt->extract(high, low, op2)),
+                          this->astCtxt->bv(0xffff, triton::bitsize::word),
+                          this->astCtxt->bv(0x0000, triton::bitsize::word))
+                       );
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPCMPGTW operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
 
         /* Update the symbolic control flow */
         this->controlFlow_s(inst);
@@ -14307,8 +14621,7 @@ namespace triton {
         auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPMINUB operation");
 
         /* Apply the taint */
-        expr->isTainted = this->taintEngine->taintAssignment(dst, src1);
-        expr->isTainted = this->taintEngine->taintUnion(dst, src2);
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
 
         /* Update the symbolic control flow */
         this->controlFlow_s(inst);
@@ -14466,6 +14779,191 @@ namespace triton {
       }
 
 
+      void x86Semantics::vpslldq_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->astCtxt->zx(triton::bitsize::dqword - src2.getBitSize(),
+                                      this->symbolicEngine->getOperandAst(inst, src2));
+
+        /* Create the semantics */
+        triton::ast::SharedAbstractNode node;
+
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize() / triton::size::dqword);
+
+        for (triton::uint32 index = 0; index < dst.getSize() / triton::size::dqword; index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::dqword);
+          uint32 low = (dst.getBitSize() - triton::bitsize::dqword) - (index * triton::bitsize::dqword);
+          pck.push_back(this->astCtxt->bvshl(
+                         this->astCtxt->extract(high, low, op1),
+                         this->astCtxt->bvmul(
+                           this->astCtxt->ite(
+                             this->astCtxt->bvuge(op2, this->astCtxt->bv(triton::bitsize::word, triton::bitsize::dqword)),
+                             this->astCtxt->bv(triton::bitsize::word, triton::bitsize::dqword),
+                             op2
+                           ),
+                           this->astCtxt->bv(triton::bitsize::byte, triton::bitsize::dqword)
+                         )
+                       ));
+        }
+
+        node = pck.size() > 1 ? this->astCtxt->concat(pck) : pck[0];
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPSLLDQ operation");
+
+        /* Spread taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vpsubb_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize());
+
+        for (triton::uint32 index = 0; index < dst.getSize(); index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::byte);
+          uint32 low  = (dst.getBitSize() - triton::bitsize::byte) - (index * triton::bitsize::byte);
+          pck.push_back(this->astCtxt->bvsub(
+                            this->astCtxt->extract(high, low, op1),
+                            this->astCtxt->extract(high, low, op2))
+                       );
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPSUBB operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vpsubd_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize() / triton::size::dword);
+
+        for (triton::uint32 index = 0; index < dst.getSize() / triton::size::dword; index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::dword);
+          uint32 low  = (dst.getBitSize() - triton::bitsize::dword) - (index * triton::bitsize::dword);
+          pck.push_back(this->astCtxt->bvsub(
+                            this->astCtxt->extract(high, low, op1),
+                            this->astCtxt->extract(high, low, op2))
+                       );
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPSUBD operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vpsubq_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize() / triton::size::qword);
+
+        for (triton::uint32 index = 0; index < dst.getSize() / triton::size::qword; index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::qword);
+          uint32 low  = (dst.getBitSize() - triton::bitsize::qword) - (index * triton::bitsize::qword);
+          pck.push_back(this->astCtxt->bvsub(
+                            this->astCtxt->extract(high, low, op1),
+                            this->astCtxt->extract(high, low, op2))
+                       );
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPSUBQ operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vpsubw_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        std::vector<triton::ast::SharedAbstractNode> pck;
+        pck.reserve(dst.getSize() / triton::size::word);
+
+        for (triton::uint32 index = 0; index < dst.getSize() / triton::size::word; index++) {
+          uint32 high = (dst.getBitSize() - 1) - (index * triton::bitsize::word);
+          uint32 low  = (dst.getBitSize() - triton::bitsize::word) - (index * triton::bitsize::word);
+          pck.push_back(this->astCtxt->bvsub(
+                            this->astCtxt->extract(high, low, op1),
+                            this->astCtxt->extract(high, low, op2))
+                       );
+        }
+
+        auto node = this->astCtxt->concat(pck);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPSUBW operation");
+
+        /* Apply the taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
       void x86Semantics::vptest_s(triton::arch::Instruction& inst) {
         auto& src1 = inst.operands[0];
         auto& src2 = inst.operands[1];
@@ -14515,6 +15013,29 @@ namespace triton {
         auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VPXOR operation");
 
         /* Spread taint */
+        expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
+
+        /* Update the symbolic control flow */
+        this->controlFlow_s(inst);
+      }
+
+
+      void x86Semantics::vxorps_s(triton::arch::Instruction& inst) {
+        auto& dst = inst.operands[0];
+        auto& src1 = inst.operands[1];
+        auto& src2 = inst.operands[2];
+
+        /* Create symbolic operands */
+        auto op1 = this->symbolicEngine->getOperandAst(inst, src1);
+        auto op2 = this->symbolicEngine->getOperandAst(inst, src2);
+
+        /* Create the semantics */
+        auto node = this->astCtxt->bvxor(op1, op2);
+
+        /* Create symbolic expression */
+        auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "VXORPS operation");
+
+        /* Apply the taint */
         expr->isTainted = this->taintEngine->taintAssignment(dst, src1) | this->taintEngine->taintUnion(dst, src2);
 
         /* Update the symbolic control flow */

--- a/src/libtriton/arch/x86/x86Semantics.cpp
+++ b/src/libtriton/arch/x86/x86Semantics.cpp
@@ -337,6 +337,7 @@ VPEXTRB                      | avx/avx2   | VEX Extract Byte
 VPEXTRD                      | avx/avx2   | VEX Extract Dword
 VPEXTRQ                      | avx/avx2   | VEX Extract Qword
 VPEXTRW                      | avx/avx2   | VEX Extract Word
+VPBROADCASTB                 | avx2       | VEX Load Byte Integer and broadcast
 VPCMPEQB                     | avx/avx2   | VEX Compare packed Bytes for equality
 VPCMPEQD                     | avx/avx2   | VEX Compare packed Doublewords for equality
 VPCMPEQQ                     | avx/avx2   | VEX Compare packed Quadwords for equality
@@ -6846,7 +6847,9 @@ namespace triton {
         /* Create the semantics */
         std::vector<triton::ast::SharedAbstractNode> exprs;
         for (size_t i = 0; i < src.getSize(); ++i) {
-          exprs.push_back(this->astCtxt->extract(8*i + 7, 8*i, op));
+          exprs.push_back(this->astCtxt->extract(triton::bitsize::byte * i + (triton::bitsize::byte - 1),
+                                                 triton::bitsize::byte * i,
+                                                 op));
         }
         auto node = this->astCtxt->concat(exprs);
 
@@ -7607,10 +7610,10 @@ namespace triton {
         /* Create the semantics */
         auto node = op;
         if (src.getType() == OP_REG) {
-          node = this->astCtxt->extract(triton::bitsize::dword-1, 0, node);
+          node = this->astCtxt->extract(triton::bitsize::dword - 1, 0, node);
           if (dst.getType() == OP_REG) {
             auto op1 = this->symbolicEngine->getOperandAst(inst, dst);
-            auto upper = this->astCtxt->extract(triton::bitsize::dqword-1, triton::bitsize::dword, op1);
+            auto upper = this->astCtxt->extract(triton::bitsize::dqword - 1, triton::bitsize::dword, op1);
             node = this->astCtxt->concat(upper, node);
           }
         }

--- a/src/libtriton/includes/triton/x86Semantics.hpp
+++ b/src/libtriton/includes/triton/x86Semantics.hpp
@@ -886,6 +886,9 @@ namespace triton {
           //! The ORPS semantics.
           void orps_s(triton::arch::Instruction& inst);
 
+          //! The PACKUSWB semantics.
+          void packuswb_s(triton::arch::Instruction& inst);
+
           //! The PADDB semantics.
           void paddb_s(triton::arch::Instruction& inst);
 
@@ -897,6 +900,9 @@ namespace triton {
 
           //! The PADDW semantics.
           void paddw_s(triton::arch::Instruction& inst);
+
+          //! The PALIGNR semantics.
+          void palignr_s(triton::arch::Instruction& inst);
 
           //! The PAND semantics.
           void pand_s(triton::arch::Instruction& inst);
@@ -1309,6 +1315,15 @@ namespace triton {
           //! The VMOVQ semantics.
           void vmovq_s(triton::arch::Instruction& inst);
 
+          //! The VMOVSD semantics.
+          void vmovsd_s(triton::arch::Instruction& inst);
+
+          //! The VMOVAPS semantics.
+          void vmovaps_s(triton::arch::Instruction& inst);
+
+          //! The VMOVUPS semantics.
+          void vmovups_s(triton::arch::Instruction& inst);
+
           //! The VPAND semantics.
           void vpand_s(triton::arch::Instruction& inst);
 
@@ -1326,6 +1341,15 @@ namespace triton {
 
           //! The VPCMPEQW semantics.
           void vpcmpeqw_s(triton::arch::Instruction& inst);
+
+          //! The VPCMPGTB semantics.
+          void vpcmpgtb_s(triton::arch::Instruction& inst);
+
+          //! The VPCMPGTD semantics.
+          void vpcmpgtd_s(triton::arch::Instruction& inst);
+
+          //! The VPCMPGTW semantics.
+          void vpcmpgtw_s(triton::arch::Instruction& inst);
 
           //! The VPMOVMSKB semantics.
           void vpmovmskb_s(triton::arch::Instruction& inst);
@@ -1354,11 +1378,29 @@ namespace triton {
           //! The VPSHUFD semantics.
           void vpshufd_s(triton::arch::Instruction& inst);
 
+          //! The VPSLLDQ semantics.
+          void vpslldq_s(triton::arch::Instruction& inst);
+
+          //! The VPSUBB semantics.
+          void vpsubb_s(triton::arch::Instruction& inst);
+
+          //! The VPSUBD semantics.
+          void vpsubd_s(triton::arch::Instruction& inst);
+
+          //! The VPSUBQ semantics.
+          void vpsubq_s(triton::arch::Instruction& inst);
+
+          //! The VPSUBW semantics.
+          void vpsubw_s(triton::arch::Instruction& inst);
+
           //! The VPTEST semantics.
           void vptest_s(triton::arch::Instruction& inst);
 
           //! The VPXOR semantics.
           void vpxor_s(triton::arch::Instruction& inst);
+
+          //! The VXORPS semantics.
+          void vxorps_s(triton::arch::Instruction& inst);
 
           //! The WAIT semantics.
           void wait_s(triton::arch::Instruction& inst);

--- a/src/samples/ir_test_suite/ir.c
+++ b/src/samples/ir_test_suite/ir.c
@@ -1,7 +1,7 @@
 // Test cases for Triton
 // gcc -O0 -masm=intel ./ir.c -o ir
 
-void init(int *tab1, int *tab2, int *tab3, int *tab4) {
+void init(int *tab1, int *tab2, int *tab3, int *tab4, int *tab5, int *tab6, int *tab7) {
   tab1[0] = 0x11111111;
   tab1[1] = 0x22222222;
   tab1[2] = 0x33333333;
@@ -21,6 +21,29 @@ void init(int *tab1, int *tab2, int *tab3, int *tab4) {
   tab4[1] = 0x8bbbbbbb;
   tab4[2] = 0x12345678;
   tab4[3] = 0xfedcba98;
+
+  tab5[0] = 0x00050001;
+  tab5[1] = 0x000b000a;
+  tab5[2] = 0x00fe0016;
+  tab5[3] = 0x010000ff;
+
+  tab6[0] = 0x11111111;
+  tab6[1] = 0x22222222;
+  tab6[2] = 0x33333333;
+  tab6[3] = 0x44444444;
+  tab6[4] = 0x55555555;
+  tab6[5] = 0x66666666;
+  tab6[6] = 0x77777777;
+  tab6[7] = 0x88888888;
+
+  tab7[0] = 0x12010101;
+  tab7[1] = 0xff112290;
+  tab7[2] = 0x12345678;
+  tab7[3] = 0x11111111;
+  tab7[4] = 0x010101dd;
+  tab7[5] = 0x88885555;
+  tab7[6] = 0x905588b2;
+  tab7[7] = 0xffff2222;
 }
 
 void check(void)
@@ -29,6 +52,9 @@ void check(void)
   int tab2[4];
   int tab3[4];
   int tab4[4];
+  int tab5[4];
+  int tab6[8];
+  int tab7[8];
 
   int _utab1[5];
   int _utab2[5];
@@ -40,7 +66,7 @@ void check(void)
   int* utab3 = (int*)((char*)_utab3 + 1);
   int* utab4 = (int*)((char*)_utab4 + 1);
 
-  init(tab1, tab2, tab3, tab4);
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
 
   // Check concat symbolic expression
   asm("mov sil, 0x99");
@@ -235,7 +261,7 @@ void check(void)
   asm("or ah, 0x8");
   asm("or al, byte ptr [rsp+0xf]");
 
-  init(tab1, tab2, tab3, tab4);
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
 
   asm("mov rax, 0x99");
   asm("mov rbx, 0xaa");
@@ -318,7 +344,7 @@ void check(void)
   asm("mov rax, 0x8000000000000000");
   asm("tzcnt ebx, eax");
 
-  init(tab1, tab2, tab3, tab4);
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
 
   asm("mov rax, 0x1111111111111111");
   asm("mov rbx, 0xffffffffffffffff");
@@ -350,7 +376,7 @@ void check(void)
   asm("mov rbx, 0x99");
   asm("cmpxchg ebx, ecx");
 
-  init(tab1, tab2, tab3, tab4);
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
 
   asm("cmpxchg8b qword ptr [%0]" :: "r"(tab1));
 
@@ -2826,7 +2852,7 @@ void check(void)
   asm("adcx rdi, rdx");
   asm("adcx rbx, rdi");
 
-  init(tab1, tab2, tab3, tab4);
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
 
   // SSE
   asm("movapd xmm0, xmmword ptr [%0]" :: "r"(tab1));
@@ -3499,7 +3525,7 @@ void check(void)
   asm("paddq xmm1, xmm2");
   asm("paddq xmm2, xmm4");
 
-  init(tab1, tab2, tab3, tab4);
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
   asm("lddqu xmm1, xmmword ptr [%0]" :: "r"(tab1));
   asm("lddqu xmm2, xmmword ptr [%0]" :: "r"(tab2));
   asm("lddqu xmm3, xmmword ptr [%0]" :: "r"(tab3));
@@ -3641,7 +3667,7 @@ void check(void)
   asm("pavgw xmm4, xmm3");
   asm("pavgw xmm4, xmm4");
 
-  init(tab1, tab2, tab3, tab4);
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
   asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
   asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
   asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab3));
@@ -3674,7 +3700,7 @@ void check(void)
   asm("vpshufd xmm1, xmm4, 0xff");
   asm("vpshufd xmm3, xmm1, 0xaa");
 
-  init(utab1, utab2, utab3, utab4);
+  init(utab1, utab2, utab3, utab4, tab5, tab6, tab7);
   asm("vmovdqu xmm1, xmmword ptr [%0]" :: "r"(utab1));
   asm("vmovdqu xmm2, xmmword ptr [%0]" :: "r"(utab2));
   asm("vmovdqu xmm3, xmmword ptr [%0]" :: "r"(utab3));
@@ -3801,6 +3827,158 @@ void check(void)
   asm("psllq mm1, mm1");
   asm("psllq mm1, mm2");
   asm("psllq mm1, mm3");
+
+  // vpslldq
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vpslldq xmm1, xmm1, 1");
+  asm("vpslldq xmm4, xmm2, 10");
+  asm("vpslldq xmm1, xmm3, 16");
+
+  asm("vmovdqa ymm1, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vpslldq ymm1, ymm1, 1");
+  asm("vpslldq ymm4, ymm2, 15");
+  asm("vpslldq ymm5, ymm3, 16");
+
+  // vpcmpgtb, vpcmpgtw, vpcmpgtd
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab3));
+  asm("vpcmpgtb xmm1, xmm2, xmm3");
+  asm("vpcmpgtb xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab3));
+  asm("vpcmpgtw xmm1, xmm2, xmm3");
+  asm("vpcmpgtw xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab3));
+  asm("vpcmpgtd xmm1, xmm2, xmm3");
+  asm("vpcmpgtd xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab3));
+
+  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpcmpgtb ymm1, ymm2, ymm3");
+  asm("vpcmpgtb ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpcmpgtw ymm1, ymm2, ymm3");
+  asm("vpcmpgtw ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpcmpgtd ymm1, ymm2, ymm3");
+  asm("vpcmpgtd ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+
+  // vpsubb, vpsubw, vpsubd, vpsubq
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab5));
+  asm("vpsubb xmm1, xmm2, xmm3");
+  asm("vpsubb xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab5));
+  asm("vpsubw xmm1, xmm2, xmm3");
+  asm("vpsubw xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab5));
+  asm("vpsubd xmm1, xmm2, xmm3");
+  asm("vpsubd xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab5));
+  asm("vpsubq xmm1, xmm2, xmm3");
+  asm("vpsubq xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab5));
+
+  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpsubb ymm1, ymm2, ymm3");
+  asm("vpsubb ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpsubw ymm1, ymm2, ymm3");
+  asm("vpsubw ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpsubd ymm1, ymm2, ymm3");
+  asm("vpsubd ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpsubq ymm1, ymm2, ymm3");
+  asm("vpsubq ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+
+  // vxorps
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab2));
+  asm("vxorps xmm1, xmm2, xmm3");
+  asm("vxorps xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab2));
+
+  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vxorps ymm1, ymm2, ymm3");
+  asm("vxorps ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+
+  // vmovaps
+  asm("vmovaps xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("vmovaps xmm1, xmm2");
+
+  asm("vmovaps ymm1, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vmovaps ymm1, ymm2");
+
+  // vmovups
+  asm("vmovups xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("vmovups xmm1, xmm2");
+
+  asm("vmovups ymm1, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vmovups ymm1, ymm2");
+
+  // vmovsd
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab3));
+  asm("vmovsd xmm1, xmm2, xmm3");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovsd xmm1, qword ptr [%0]" :: "r"(tab2));
+  asm("vmovsd qword ptr [%0], xmm1" :: "r"(tab1));
+
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
+
+  // packuswb
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab5));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("packuswb xmm1, xmm2");
+  asm("packuswb xmm2, xmmword ptr [%0]" :: "r"(tab5));
+
+  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
+  asm("packuswb mm1, mm2");
+  asm("packuswb mm2, qword ptr [%0]" :: "r"(tab1));
+
+  // palignr
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("palignr xmm1, xmm2, 0x1");
+  asm("palignr xmm2, xmmword ptr [%0], 0x1" :: "r"(tab1));
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("palignr xmm1, xmm2, 0x5");
+  asm("palignr xmm2, xmmword ptr [%0], 0x5" :: "r"(tab1));
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("palignr xmm1, xmm2, 0x1f");
+  asm("palignr xmm2, xmmword ptr [%0], 0x1f" :: "r"(tab1));
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("palignr xmm1, xmm2, 0x20");
+  asm("palignr xmm2, xmmword ptr [%0], 0x20" :: "r"(tab1));
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("palignr xmm1, xmm2, 0x25");
+  asm("palignr xmm2, xmmword ptr [%0], 0x25" :: "r"(tab1));
+
+  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
+  asm("palignr mm1, mm2, 0x1");
+  asm("palignr mm2, qword ptr [%0], 0x1" :: "r"(tab1));
+  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
+  asm("palignr mm1, mm2, 0x5");
+  asm("palignr mm2, qword ptr [%0], 0x5" :: "r"(tab1));
+  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
+  asm("palignr mm1, mm2, 0xf");
+  asm("palignr mm2, qword ptr [%0], 0xf" :: "r"(tab1));
+  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
+  asm("palignr mm1, mm2, 0x10");
+  asm("palignr mm2, qword ptr [%0], 0x10" :: "r"(tab1));
+  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
+  asm("palignr mm1, mm2, 0x15");
+  asm("palignr mm2, qword ptr [%0], 0x15" :: "r"(tab1));
+
 }
 
 int main(){

--- a/src/samples/ir_test_suite/ir.c
+++ b/src/samples/ir_test_suite/ir.c
@@ -3828,6 +3828,98 @@ void check(void)
   asm("psllq mm1, mm2");
   asm("psllq mm1, mm3");
 
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
+
+  // movss
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
+  asm("movss xmm1, xmm2");
+  asm("movss xmm2, dword ptr [%0]" :: "r"(tab1));
+  asm("movss dword ptr [%0], xmm2" :: "r"(tab2));
+
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
+
+  // movbe
+  asm("xor rbx, rbx");
+  asm("movbe bx, word ptr [%0]" :: "r"(tab5));
+  asm("xor rbx, rbx");
+  asm("movbe ebx, dword ptr [%0]" :: "r"(tab5));
+  asm("xor rbx, rbx");
+  asm("movbe rbx, qword ptr [%0]" :: "r"(tab5));
+
+  asm("mov qword ptr [%0], rbx" :: "r"(tab5));
+  asm("movbe word ptr [%0], bx" :: "r"(tab1));
+  asm("movbe dword ptr [%0], ebx" :: "r"(tab1));
+  asm("movbe qword ptr [%0], rbx" :: "r"(tab1));
+
+  init(tab1, tab2, tab3, tab4, tab5, tab6, tab7);
+
+  // vpbroadcastb
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vpbroadcastb xmm2, xmm1");
+  asm("vpbroadcastb xmm3, byte ptr [%0]" :: "r"(tab2));
+
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vpbroadcastb ymm2, xmm1");
+  asm("vpbroadcastb ymm3, byte ptr [%0]" :: "r"(tab2));
+
+  // vpminub
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab2));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab3));
+  asm("vpminub xmm3, xmm1, xmm2");
+  asm("vpminub xmm4, xmm1, xmmword ptr [%0]" :: "r"(tab3));
+
+  asm("vmovdqu ymm1, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpminub ymm3, ymm1, ymm2");
+  asm("vpminub ymm4, ymm1, ymmword ptr [%0]" :: "r"(tab7));
+
+  // vpcmpeqb, vpcmpeqw, vpcmpeqd, vpcmpeqq
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab2));
+  asm("vpcmpeqb xmm1, xmm2, xmm3");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab4));
+  asm("vpcmpeqb xmm1, xmm3, xmmword ptr [%0]" :: "r"(tab3));
+
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab4));
+  asm("vpcmpeqw xmm1, xmm2, xmm3");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab4));
+  asm("vpcmpeqw xmm1, xmm3, xmmword ptr [%0]" :: "r"(tab3));
+
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab4));
+  asm("vpcmpeqd xmm1, xmm2, xmm3");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab4));
+  asm("vpcmpeqd xmm1, xmm3, xmmword ptr [%0]" :: "r"(tab3));
+
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab4));
+  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab6));
+  asm("vpcmpeqq xmm1, xmm2, xmm3");
+  asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab4));
+  asm("vpcmpeqq xmm1, xmm3, xmmword ptr [%0]" :: "r"(tab3));
+
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm3, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vpcmpeqb ymm1, ymm2, ymm3");
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vpcmpeqb ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vpcmpeqw ymm1, ymm2, ymm3");
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vpcmpeqw ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vpcmpeqd ymm1, ymm2, ymm3");
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vpcmpeqd ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vpcmpeqq ymm1, ymm2, ymm3");
+  asm("vpxor ymm1, ymm1, ymm1");
+  asm("vpcmpeqq ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
+
   // vpslldq
   asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
   asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
@@ -3836,9 +3928,9 @@ void check(void)
   asm("vpslldq xmm4, xmm2, 10");
   asm("vpslldq xmm1, xmm3, 16");
 
-  asm("vmovdqa ymm1, ymmword ptr [%0]" :: "r"(tab6));
-  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
-  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm1, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm3, ymmword ptr [%0]" :: "r"(tab6));
   asm("vpslldq ymm1, ymm1, 1");
   asm("vpslldq ymm4, ymm2, 15");
   asm("vpslldq ymm5, ymm3, 16");
@@ -3853,8 +3945,8 @@ void check(void)
   asm("vpcmpgtd xmm1, xmm2, xmm3");
   asm("vpcmpgtd xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab3));
 
-  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
-  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm3, ymmword ptr [%0]" :: "r"(tab7));
   asm("vpcmpgtb ymm1, ymm2, ymm3");
   asm("vpcmpgtb ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
   asm("vpcmpgtw ymm1, ymm2, ymm3");
@@ -3863,8 +3955,8 @@ void check(void)
   asm("vpcmpgtd ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
 
   // vpsubb, vpsubw, vpsubd, vpsubq
-  asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab1));
-  asm("vmovdqa xmm3, xmmword ptr [%0]" :: "r"(tab5));
+  asm("vmovdqu xmm2, xmmword ptr [%0]" :: "r"(tab1));
+  asm("vmovdqu xmm3, xmmword ptr [%0]" :: "r"(tab5));
   asm("vpsubb xmm1, xmm2, xmm3");
   asm("vpsubb xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab5));
   asm("vpsubw xmm1, xmm2, xmm3");
@@ -3874,8 +3966,8 @@ void check(void)
   asm("vpsubq xmm1, xmm2, xmm3");
   asm("vpsubq xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab5));
 
-  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
-  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm3, ymmword ptr [%0]" :: "r"(tab7));
   asm("vpsubb ymm1, ymm2, ymm3");
   asm("vpsubb ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
   asm("vpsubw ymm1, ymm2, ymm3");
@@ -3891,8 +3983,8 @@ void check(void)
   asm("vxorps xmm1, xmm2, xmm3");
   asm("vxorps xmm1, xmm2, xmmword ptr [%0]" :: "r"(tab2));
 
-  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab6));
-  asm("vmovdqa ymm3, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm3, ymmword ptr [%0]" :: "r"(tab7));
   asm("vxorps ymm1, ymm2, ymm3");
   asm("vxorps ymm1, ymm2, ymmword ptr [%0]" :: "r"(tab7));
 
@@ -3901,8 +3993,8 @@ void check(void)
   asm("vmovdqa xmm2, xmmword ptr [%0]" :: "r"(tab2));
   asm("vmovaps xmm1, xmm2");
 
-  asm("vmovaps ymm1, ymmword ptr [%0]" :: "r"(tab6));
-  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  //asm("vmovaps ymm1, ymmword ptr [%0]" :: "r"(tab6));
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab7));
   asm("vmovaps ymm1, ymm2");
 
   // vmovups
@@ -3911,7 +4003,7 @@ void check(void)
   asm("vmovups xmm1, xmm2");
 
   asm("vmovups ymm1, ymmword ptr [%0]" :: "r"(tab6));
-  asm("vmovdqa ymm2, ymmword ptr [%0]" :: "r"(tab7));
+  asm("vmovdqu ymm2, ymmword ptr [%0]" :: "r"(tab7));
   asm("vmovups ymm1, ymm2");
 
   // vmovsd
@@ -3931,10 +4023,10 @@ void check(void)
   asm("packuswb xmm1, xmm2");
   asm("packuswb xmm2, xmmword ptr [%0]" :: "r"(tab5));
 
-  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  /*asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
   asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
   asm("packuswb mm1, mm2");
-  asm("packuswb mm2, qword ptr [%0]" :: "r"(tab1));
+  asm("packuswb mm2, qword ptr [%0]" :: "r"(tab1));*/
 
   // palignr
   asm("vmovdqa xmm1, xmmword ptr [%0]" :: "r"(tab1));
@@ -3958,7 +4050,7 @@ void check(void)
   asm("palignr xmm1, xmm2, 0x25");
   asm("palignr xmm2, xmmword ptr [%0], 0x25" :: "r"(tab1));
 
-  asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
+  /*asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
   asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
   asm("palignr mm1, mm2, 0x1");
   asm("palignr mm2, qword ptr [%0], 0x1" :: "r"(tab1));
@@ -3977,7 +4069,7 @@ void check(void)
   asm("movq mm1, qword ptr [%0]" :: "r"(tab1));
   asm("movq mm2, qword ptr [%0]" :: "r"(tab2));
   asm("palignr mm1, mm2, 0x15");
-  asm("palignr mm2, qword ptr [%0], 0x15" :: "r"(tab1));
+  asm("palignr mm2, qword ptr [%0], 0x15" :: "r"(tab1));*/
 
 }
 

--- a/src/testers/pin/check_semantics.py
+++ b/src/testers/pin/check_semantics.py
@@ -69,14 +69,12 @@ def cafter(instruction):
 
     for reg in regs:
 
-        cvalue = Pintool.getCurrentRegisterValue(reg)
-        se     = Triton.getSymbolicRegister(reg)
-
-        if se is None:
+        # Skip unsupported registers
+        if reg.getName().startswith("dr"):
             continue
 
-        expr   = se.getAst()
-        svalue = expr.evaluate()
+        cvalue = Pintool.getCurrentRegisterValue(reg)
+        svalue = Triton.getSymbolicRegisterValue(reg)
 
         # Check register
         if cvalue != svalue:


### PR DESCRIPTION
Add semantics for `vpcmpgtb`, `vpcmpgtd`, `vpcmpgtw`, `vmovaps`, `vmovups`, `vmovsd`, `vpsubb`, `vpsubd`, `vpsubq`, `vpsubw`, `vpslldq`, `vxorps`, `packuswb`, `palignr`.

Add tests for pintool in `ir_test_suite` for these instructions and previously implemented.