### PR TITLE
Print instruction in symbolic expression comment

### DIFF
--- a/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
+++ b/src/libtriton/bindings/python/objects/pySymbolicExpression.cpp
@@ -46,17 +46,17 @@ True
 >>> for expr in inst.getSymbolicExpressions():
 ...     print(expr)
 ...
-(define-fun ref!0 () (_ BitVec 64) (bvxor (_ bv12345 64) (_ bv67890 64))) ; XOR operation
-(define-fun ref!1 () (_ BitVec 1) (_ bv0 1)) ; Clears carry flag
-(define-fun ref!2 () (_ BitVec 1) (_ bv0 1)) ; Clears overflow flag
-(define-fun ref!3 () (_ BitVec 1) (bvxor (bvxor (bvxor (bvxor (bvxor (bvxor (bvxor (bvxor (_ bv1 1) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv0 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv1 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv2 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv3 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv4 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv5 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv6 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv7 8))))) ; Parity flag
-(define-fun ref!4 () (_ BitVec 1) ((_ extract 63 63) ref!0)) ; Sign flag
-(define-fun ref!5 () (_ BitVec 1) (ite (= ref!0 (_ bv0 64)) (_ bv1 1) (_ bv0 1))) ; Zero flag
-(define-fun ref!6 () (_ BitVec 64) (_ bv4194307 64)) ; Program Counter
+(define-fun ref!0 () (_ BitVec 64) (bvxor (_ bv12345 64) (_ bv67890 64))) ; XOR operation - 0x400000: xor rax, rdx
+(define-fun ref!1 () (_ BitVec 1) (_ bv0 1)) ; Clears carry flag - 0x400000: xor rax, rdx
+(define-fun ref!2 () (_ BitVec 1) (_ bv0 1)) ; Clears overflow flag - 0x400000: xor rax, rdx
+(define-fun ref!3 () (_ BitVec 1) (bvxor (bvxor (bvxor (bvxor (bvxor (bvxor (bvxor (bvxor (_ bv1 1) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv0 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv1 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv2 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv3 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv4 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv5 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv6 8)))) ((_ extract 0 0) (bvlshr ((_ extract 7 0) ref!0) (_ bv7 8))))) ; Parity flag - 0x400000: xor rax, rdx
+(define-fun ref!4 () (_ BitVec 1) ((_ extract 63 63) ref!0)) ; Sign flag - 0x400000: xor rax, rdx
+(define-fun ref!5 () (_ BitVec 1) (ite (= ref!0 (_ bv0 64)) (_ bv1 1) (_ bv0 1))) ; Zero flag - 0x400000: xor rax, rdx
+(define-fun ref!6 () (_ BitVec 64) (_ bv4194307 64)) ; Program Counter - 0x400000: xor rax, rdx
 
 >>> expr_1 = inst.getSymbolicExpressions()[0]
 >>> print(expr_1)
-(define-fun ref!0 () (_ BitVec 64) (bvxor (_ bv12345 64) (_ bv67890 64))) ; XOR operation
+(define-fun ref!0 () (_ BitVec 64) (bvxor (_ bv12345 64) (_ bv67890 64))) ; XOR operation - 0x400000: xor rax, rdx
 
 >>> print(expr_1.getId())
 0

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -947,9 +947,12 @@ namespace triton {
         triton::uint64 address              = mem.getAddress();
         triton::uint32 writeSize            = mem.getSize();
 
+        std::stringstream s;
+        s << comment << (comment.empty() ? "" : " - ") << inst;
+
         /* Record the aligned memory for a symbolic optimization */
         if (this->modes->isModeEnabled(triton::modes::ALIGNED_MEMORY)) {
-          const SharedSymbolicExpression& aligned = this->newSymbolicExpression(node, MEMORY_EXPRESSION, "Aligned Byte reference - " + comment);
+          const SharedSymbolicExpression& aligned = this->newSymbolicExpression(node, MEMORY_EXPRESSION, "Aligned Byte reference - " + s.str());
           this->addAlignedMemory(address, writeSize, aligned);
         }
 
@@ -964,7 +967,7 @@ namespace triton {
           /* Extract each byte of the memory */
           tmp = this->astCtxt->extract(high, low, node);
           /* Assign each byte to a new symbolic expression */
-          se = this->newSymbolicExpression(tmp, MEMORY_EXPRESSION, "Byte reference - " + comment);
+          se = this->newSymbolicExpression(tmp, MEMORY_EXPRESSION, "Byte reference - " + s.str());
           /* Set the origin of the symbolic expression */
           se->setOriginMemory(triton::arch::MemoryAccess(((address + writeSize) - 1), triton::size::byte));
           /* ret is the for the final expression */
@@ -997,7 +1000,7 @@ namespace triton {
         /* Synchronize the concrete state */
         this->architecture->setConcreteMemoryValue(mem, tmp->evaluate());
 
-        se = this->newSymbolicExpression(tmp, MEMORY_EXPRESSION, "Temporary concatenation reference - " + comment);
+        se = this->newSymbolicExpression(tmp, MEMORY_EXPRESSION, "Temporary concatenation reference - " + s.str());
         se->setOriginMemory(triton::arch::MemoryAccess(address, mem.getSize()));
 
         return inst.addSymbolicExpression(se);
@@ -1072,7 +1075,9 @@ namespace triton {
       const SharedSymbolicExpression& SymbolicEngine::createSymbolicRegisterExpression(triton::arch::Instruction& inst, const triton::ast::SharedAbstractNode& node, const triton::arch::Register& reg, const std::string& comment) {
         SharedSymbolicExpression se = nullptr;
 
-        se = this->newSymbolicExpression(this->insertSubRegisterInParent(reg, node), REGISTER_EXPRESSION, comment);
+        std::stringstream s;
+        s << comment << (comment.empty() ? "" : " - ") << inst;
+        se = this->newSymbolicExpression(this->insertSubRegisterInParent(reg, node), REGISTER_EXPRESSION, s.str());
         this->assignSymbolicExpressionToRegister(se, this->architecture->getParentRegister(reg));
 
         inst.setWrittenRegister(reg, node);
@@ -1082,7 +1087,9 @@ namespace triton {
 
       /* Returns the new symbolic volatile expression */
       const SharedSymbolicExpression& SymbolicEngine::createSymbolicVolatileExpression(triton::arch::Instruction& inst, const triton::ast::SharedAbstractNode& node, const std::string& comment) {
-        const SharedSymbolicExpression& se = this->newSymbolicExpression(node, VOLATILE_EXPRESSION, comment);
+        std::stringstream s;
+        s << comment << (comment.empty() ? "" : " - ") << inst;
+        const SharedSymbolicExpression& se = this->newSymbolicExpression(node, VOLATILE_EXPRESSION, s.str());
         return inst.addSymbolicExpression(se);
       }
 

--- a/src/testers/unittests/test_github_issues.py
+++ b/src/testers/unittests/test_github_issues.py
@@ -41,11 +41,11 @@ class TestIssue656(unittest.TestCase):
 
     def test_issue(self):
         e = self.sym_exec_gadget((b'\x89\xd8', b'\xc2\x04\x00'))
-        self.assertEqual(str(e), '(define-fun ref!15 () (_ BitVec 64) ((_ zero_extend 32) ((_ extract 31 0) ref!1))) ; MOV operation')
+        self.assertEqual(str(e), '(define-fun ref!15 () (_ BitVec 64) ((_ zero_extend 32) ((_ extract 31 0) ref!1))) ; MOV operation - 0x0: mov eax, ebx')
         a = e.getAst()
         self.assertEqual(str(a + 1), '(bvadd ((_ zero_extend 32) ((_ extract 31 0) ref!1)) (_ bv1 64))')
         self.assertEqual(str(1 + a), '(bvadd (_ bv1 64) ((_ zero_extend 32) ((_ extract 31 0) ref!1)))')
-        self.assertEqual(str(e.getComment()), 'MOV operation')
+        self.assertEqual(str(e.getComment()), 'MOV operation - 0x0: mov eax, ebx')
         self.assertEqual(e.getId(), 15)
         self.assertEqual(str(e.getAst()), str(e.getNewAst()))
         self.assertEqual(str(e.getOrigin()), 'rax:64 bv[63..0]')

--- a/src/testers/unittests/test_symbolic_expression.py
+++ b/src/testers/unittests/test_symbolic_expression.py
@@ -37,7 +37,7 @@ class TestSymbolicExpression(unittest.TestCase):
 
     def test_getComment(self):
         """Test getComment"""
-        self.assertEqual(self.expr1.getComment(), "XOR operation")
+        self.assertEqual(self.expr1.getComment(), "XOR operation - 0x0: xor rax, rbx")
 
     def test_getId(self):
         """Test getId"""


### PR DESCRIPTION
Extend symbolic expression comments with instruction string representation. This allows explicitly match SMT formulas with corresponding instructions.