### PR TITLE
Fix Python 3.9.1 build

### DIFF
--- a/src/libtriton/includes/triton/py3c_compat.h
+++ b/src/libtriton/includes/triton/py3c_compat.h
@@ -12,7 +12,7 @@
 
 #define IS_PY3 1
 
-#if PY_MINOR_VERSION >= 8
+#if PY_MINOR_VERSION == 8
 #define IS_PY3_8 1
 #else
 #define IS_PY3_8 0


### PR DESCRIPTION
Fix Python 3.9.1 build. Only tested on Mac OSX with Python 3.9.1.



Error Log:
```
> make -j2 install

No syscall32 to extract on your plateform
[  1%] Built target gen-syscall64
[  1%] Built target gen-syscall32
[  3%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyAstContext.cpp.o
[  3%] Building CXX object src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyAstNode.cpp.o
/Triton/src/libtriton/bindings/python/objects/pyAstNode.cpp:960:9: error: excess elements in struct initializer
        0,                                          /* bpo-37250: kept for backwards compatibility in CPython 3.8 only */
        ^
1 error generated.
make[2]: *** [src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyAstNode.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/Triton/src/libtriton/bindings/python/objects/pyAstContext.cpp:1774:9: error: excess elements in struct initializer
        0,                                          /* bpo-37250: kept for backwards compatibility in CPython 3.8 only */
        ^
1 error generated.
make[2]: *** [src/libtriton/CMakeFiles/triton.dir/bindings/python/objects/pyAstContext.cpp.o] Error 1
make[1]: *** [src/libtriton/CMakeFiles/triton.dir/all] Error 2
make: *** [all] Error 2
```