### PR TITLE
Example symbolic emulator must care about dynamic relocations

### DIFF
--- a/src/examples/python/small_x86-64_symbolic_emulator.py
+++ b/src/examples/python/small_x86-64_symbolic_emulator.py
@@ -397,8 +397,11 @@ def makeRelocation(binary):
     for pltIndex in range(len(customRelocation)):
         customRelocation[pltIndex][2] = BASE_PLT + pltIndex
 
+    relocations = [x for x in binary.pltgot_relocations]
+    relocations.extend([x for x in binary.dynamic_relocations])
+
     # Perform our own relocations
-    for rel in binary.pltgot_relocations:
+    for rel in relocations:
         symbolName = rel.symbol.name
         symbolRelo = rel.address
         for crel in customRelocation:


### PR DESCRIPTION
The [sample_1](https://github.com/JonathanSalwan/Triton/tree/master/src/examples/python/samples) binary was compiled 5 years ago (based on GH history).

For the `sample_1` binary, `__libc_start_main` is placed in the `.rela.plt` section, as you can see in the output below
```
$ readelf -r sample_1_orig

Relocation section '.rela.dyn' at offset 0x3b8 contains 1 entry:
  Offset          Info           Type           Sym. Value    Sym. Name + Addend
000000600ff8  000400000006 R_X86_64_GLOB_DAT 0000000000000000 __gmon_start__ + 0

Relocation section '.rela.plt' at offset 0x3d0 contains 4 entries:
  Offset          Info           Type           Sym. Value    Sym. Name + Addend
000000601018  000100000007 R_X86_64_JUMP_SLO 0000000000000000 strlen@GLIBC_2.2.5 + 0
000000601020  000200000007 R_X86_64_JUMP_SLO 0000000000000000 printf@GLIBC_2.2.5 + 0
000000601028  000300000007 R_X86_64_JUMP_SLO 0000000000000000 __libc_start_main@GLIBC_2.2.5 + 0
000000601030  000400000007 R_X86_64_JUMP_SLO 0000000000000000 __gmon_start__ + 0
```

This makes it ok to only look for relocations in the [pltgot](https://github.com/JonathanSalwan/Triton/compare/master...edi33416:fix_example_symbolic_emulator?expand=1#diff-08b8b112c95bd285627c8ad88b4b1367598cf39867dd0bb72c7f1b5797f955c1L401)

Now, when compiling the `sample_1.c` file with a newer gcc version, as below
```
$ gcc --version
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
$ gcc sample_1.c -o sample_1
```
`__libc_start_main` will be placed in the `.rela.dyn` section
```
$ readelf -r sample_1

Relocation section '.rela.dyn' at offset 0x548 contains 8 entries:
  Offset          Info           Type           Sym. Value    Sym. Name + Addend
000000003db0  000000000008 R_X86_64_RELATIVE                    1160
000000003db8  000000000008 R_X86_64_RELATIVE                    1120
000000004008  000000000008 R_X86_64_RELATIVE                    4008
000000003fd8  000100000006 R_X86_64_GLOB_DAT 0000000000000000 _ITM_deregisterTMClone + 0
000000003fe0  000400000006 R_X86_64_GLOB_DAT 0000000000000000 __libc_start_main@GLIBC_2.2.5 + 0
000000003fe8  000500000006 R_X86_64_GLOB_DAT 0000000000000000 __gmon_start__ + 0
000000003ff0  000600000006 R_X86_64_GLOB_DAT 0000000000000000 _ITM_registerTMCloneTa + 0
000000003ff8  000700000006 R_X86_64_GLOB_DAT 0000000000000000 __cxa_finalize@GLIBC_2.2.5 + 0

Relocation section '.rela.plt' at offset 0x608 contains 2 entries:
  Offset          Info           Type           Sym. Value    Sym. Name + Addend
000000003fc8  000200000007 R_X86_64_JUMP_SLO 0000000000000000 strlen@GLIBC_2.2.5 + 0
000000003fd0  000300000007 R_X86_64_JUMP_SLO 0000000000000000 printf@GLIBC_2.2.5 + 0
```

Because `__libc_start_main` is palced in a different section, the emulator will fail to correctly run the program.

This PR fixes this issue, by also looking for `customRelocation`s in the dynamic section