### PR TITLE
Improve performance while setting concrete memory during initialization

### DIFF
--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -173,6 +173,12 @@ namespace triton {
 
       /* Removes an aligned memory */
       void SymbolicEngine::removeAlignedMemory(triton::uint64 address, triton::uint32 size) {
+        // Avoid accessing the alignedMemoryReference array when empty. This usually happens when
+        // you initialize the symbolic engine and concretize whole sections of an executable using
+        // setConcreteMemoryValue. No symbolic memory has been created yet but this function will
+        // still try to rougly erase (size * 7) elements.
+        if(this->alignedMemoryReference.empty())
+          return;
         /* Remove overloaded positive ranges */
         for (triton::uint32 index = 0; index < size; index++) {
           this->alignedMemoryReference.erase(std::make_pair(address+index, triton::size::byte));


### PR DESCRIPTION
I was playing around with triton and big binaries (~50-200MB). I was noticing huge load times trying to concretize whole segments during initialization.

By avoiding iterating on the `alignedMemoryReference` map when empty, we save roughly 50% of CPU time. Trying to concretize 50MB on init went from ~60s to 30s.

This will still happen if you try to concretize big memory section after the symbolic execution engine did some calculation, as the map won't be empty. But this fix will allow users to optimize load times by concretizing memory during initialization at least.