### PR TITLE
added a fix for reference counting with python callbacks

### DIFF
--- a/src/libtriton/arch/x86/x86Specifications.cpp
+++ b/src/libtriton/arch/x86/x86Specifications.cpp
@@ -50,7 +50,7 @@ namespace triton {
                                                       X86_LOWER,                                            \
                                                       true)                                                 \
                               );                                                                            \
-            name2id.emplace(#LOWER_NAME, ID_REG_X86_##UPPER_NAME);
+          name2id.emplace(#LOWER_NAME, ID_REG_X86_##UPPER_NAME);
           // Handle register not available in capstone as normal registers
           #define REG_SPEC_NO_CAPSTONE REG_SPEC
           #include "triton/x86.spec"

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -635,6 +635,7 @@ namespace triton {
                   PyTuple_SetItem(args, 0, cb_self);
                   PyTuple_SetItem(args, 1, triton::bindings::python::PyTritonContextRef(api));
                   PyTuple_SetItem(args, 2, triton::bindings::python::PyAstNode(node));
+                  Py_INCREF(cb_self);
                 }
                 else {
                   args = triton::bindings::python::xPyTuple_New(2);

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -478,6 +478,7 @@ namespace triton {
         if (function == nullptr || !PyCallable_Check(function))
           return PyErr_Format(PyExc_TypeError, "TritonContext::addCallback(): Expects a function as second argument.");
 
+        Py_INCREF(function);
         if (PyMethod_Check(function)) {
           cb_self = PyMethod_GET_SELF(function);
           cb = PyMethod_GET_FUNCTION(function);
@@ -490,7 +491,7 @@ namespace triton {
           switch (static_cast<triton::callbacks::callback_e>(PyLong_AsUint32(mode))) {
 
             case callbacks::GET_CONCRETE_MEMORY_VALUE:
-              PyTritonContext_AsTritonContext(self)->addCallback(callbacks::GET_CONCRETE_MEMORY_VALUE, callbacks::getConcreteMemoryValueCallback([cb_self, cb](triton::API& api, const triton::arch::MemoryAccess& mem) {
+              PyTritonContext_AsTritonContext(self)->addCallback(callbacks::GET_CONCRETE_MEMORY_VALUE, callbacks::getConcreteMemoryValueCallback([cb_self, cb, function](triton::API& api, const triton::arch::MemoryAccess& mem) {
                 /********* Lambda *********/
                 PyObject* args = nullptr;
 
@@ -500,7 +501,6 @@ namespace triton {
                   PyTuple_SetItem(args, 0, cb_self);
                   PyTuple_SetItem(args, 1, triton::bindings::python::PyTritonContextRef(api));
                   PyTuple_SetItem(args, 2, triton::bindings::python::PyMemoryAccess(mem));
-                  Py_INCREF(cb_self);
                 }
                 else {
                   args = triton::bindings::python::xPyTuple_New(2);
@@ -509,7 +509,6 @@ namespace triton {
                 }
 
                 /* Call the callback */
-                Py_INCREF(cb);
                 PyObject* ret = PyObject_CallObject(cb, args);
 
                 /* Check the call */
@@ -533,7 +532,6 @@ namespace triton {
                   PyTuple_SetItem(args, 0, cb_self);
                   PyTuple_SetItem(args, 1, triton::bindings::python::PyTritonContextRef(api));
                   PyTuple_SetItem(args, 2, triton::bindings::python::PyRegister(reg));
-                  Py_INCREF(cb_self);
                 }
                 else {
                   args = triton::bindings::python::xPyTuple_New(2);
@@ -542,7 +540,6 @@ namespace triton {
                 }
 
                 /* Call the callback */
-                Py_INCREF(cb);
                 PyObject* ret = PyObject_CallObject(cb, args);
 
                 /* Check the call */
@@ -567,7 +564,6 @@ namespace triton {
                   PyTuple_SetItem(args, 1, triton::bindings::python::PyTritonContextRef(api));
                   PyTuple_SetItem(args, 2, triton::bindings::python::PyMemoryAccess(mem));
                   PyTuple_SetItem(args, 3, triton::bindings::python::PyLong_FromUint512(value));
-                  Py_INCREF(cb_self);
                 }
                 else {
                   args = triton::bindings::python::xPyTuple_New(3);
@@ -577,7 +573,6 @@ namespace triton {
                 }
 
                 /* Call the callback */
-                Py_INCREF(cb);
                 PyObject* ret = PyObject_CallObject(cb, args);
 
                 /* Check the call */
@@ -602,7 +597,6 @@ namespace triton {
                   PyTuple_SetItem(args, 1, triton::bindings::python::PyTritonContextRef(api));
                   PyTuple_SetItem(args, 2, triton::bindings::python::PyRegister(reg));
                   PyTuple_SetItem(args, 3, triton::bindings::python::PyLong_FromUint512(value));
-                  Py_INCREF(cb_self);
                 }
                 else {
                   args = triton::bindings::python::xPyTuple_New(3);
@@ -612,7 +606,6 @@ namespace triton {
                 }
 
                 /* Call the callback */
-                Py_INCREF(cb);
                 PyObject* ret = PyObject_CallObject(cb, args);
 
                 /* Check the call */
@@ -636,7 +629,6 @@ namespace triton {
                   PyTuple_SetItem(args, 0, cb_self);
                   PyTuple_SetItem(args, 1, triton::bindings::python::PyTritonContextRef(api));
                   PyTuple_SetItem(args, 2, triton::bindings::python::PyAstNode(node));
-                  Py_INCREF(cb_self);
                 }
                 else {
                   args = triton::bindings::python::xPyTuple_New(2);
@@ -645,7 +637,6 @@ namespace triton {
                 }
 
                 /* Call the callback */
-                Py_INCREF(cb);
                 PyObject* ret = PyObject_CallObject(cb, args);
 
                 /* Check the call */
@@ -2368,6 +2359,8 @@ namespace triton {
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
         }
+
+        Py_DECREF(function);
 
         Py_INCREF(Py_None);
         return Py_None;

--- a/src/libtriton/callbacks/callbacks.cpp
+++ b/src/libtriton/callbacks/callbacks.cpp
@@ -97,15 +97,25 @@ namespace triton {
       this->defined = false;
     }
 
+    template <typename T>
+    void Callbacks::removeSingleCallback(std::list<T> & container, T cb) {
+      for (auto it = container.begin(); it != container.end(); ++it) {
+        if (cb == *it) {
+          container.erase(it);
+          return;
+        }
+      }
+      throw triton::exceptions::Exception("Unable to find callback for removal");
+    }
 
     void Callbacks::removeCallback(triton::callbacks::callback_e kind, ComparableFunctor<void(triton::API&, const triton::arch::MemoryAccess&)> cb) {
       switch (kind) {
         case triton::callbacks::GET_CONCRETE_MEMORY_VALUE:
-          this->getConcreteMemoryValueCallbacks.remove(cb);
+          this->removeSingleCallback(this->getConcreteMemoryValueCallbacks, cb);
           break;
 
         default:
-          break;
+          throw triton::exceptions::Exception("Incorrect callback kind for removal");
       }
 
       if (this->countCallbacks() == 0) {
@@ -117,11 +127,11 @@ namespace triton {
     void Callbacks::removeCallback(triton::callbacks::callback_e kind, ComparableFunctor<void(triton::API&, const triton::arch::Register&)> cb) {
       switch (kind) {
         case triton::callbacks::GET_CONCRETE_REGISTER_VALUE:
-          this->getConcreteRegisterValueCallbacks.remove(cb);
+          this->removeSingleCallback(this->getConcreteRegisterValueCallbacks, cb);
           break;
 
         default:
-          break;
+          throw triton::exceptions::Exception("Incorrect callback kind for removal");
       }
 
       if (this->countCallbacks() == 0) {
@@ -133,11 +143,11 @@ namespace triton {
     void Callbacks::removeCallback(triton::callbacks::callback_e kind, ComparableFunctor<void(triton::API&, const triton::arch::MemoryAccess&, const triton::uint512& value)> cb) {
       switch (kind) {
         case triton::callbacks::SET_CONCRETE_MEMORY_VALUE:
-          this->setConcreteMemoryValueCallbacks.remove(cb);
+          this->removeSingleCallback(this->setConcreteMemoryValueCallbacks, cb);
           break;
 
         default:
-          break;
+          throw triton::exceptions::Exception("Incorrect callback kind for removal");
       }
 
       if (this->countCallbacks() == 0) {
@@ -149,11 +159,11 @@ namespace triton {
     void Callbacks::removeCallback(triton::callbacks::callback_e kind, ComparableFunctor<void(triton::API&, const triton::arch::Register&, const triton::uint512& value)> cb) {
       switch (kind) {
         case triton::callbacks::SET_CONCRETE_REGISTER_VALUE:
-          this->setConcreteRegisterValueCallbacks.remove(cb);
+          this->removeSingleCallback(this->setConcreteRegisterValueCallbacks, cb);
           break;
 
         default:
-          break;
+          throw triton::exceptions::Exception("Incorrect callback kind for removal");
       }
 
       if (this->countCallbacks() == 0) {
@@ -165,11 +175,11 @@ namespace triton {
     void Callbacks::removeCallback(triton::callbacks::callback_e kind, ComparableFunctor<triton::ast::SharedAbstractNode(triton::API&, const triton::ast::SharedAbstractNode&)> cb) {
       switch (kind) {
         case triton::callbacks::SYMBOLIC_SIMPLIFICATION:
-          this->symbolicSimplificationCallbacks.remove(cb);
+          this->removeSingleCallback(this->symbolicSimplificationCallbacks, cb);
           break;
 
         default:
-          break;
+          throw triton::exceptions::Exception("Incorrect callback kind for removal");
       }
 
       if (this->countCallbacks() == 0) {

--- a/src/libtriton/includes/triton/callbacks.hpp
+++ b/src/libtriton/includes/triton/callbacks.hpp
@@ -115,6 +115,9 @@ namespace triton {
         //! Returns the number of callbacks recorded.
         triton::usize countCallbacks(void) const;
 
+        //! Trys to find and remove the callback, raises an exception if not able
+        template <typename T> void removeSingleCallback(std::list<T> & container, T cb);
+
       public:
         //! Constructor.
         TRITON_EXPORT Callbacks(triton::API& api);

--- a/src/testers/unittests/test_callback.py
+++ b/src/testers/unittests/test_callback.py
@@ -72,3 +72,16 @@ class TestCallback(unittest.TestCase):
         self.Triton.addCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, self.method_callback)
         self.Triton.removeCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, self.method_callback)
         self.assertTrue(cb_initial_refcnt == sys.getrefcount(cb))
+
+        cb = self.method_callback
+        cb_initial_refcnt = tuple(sys.getrefcount(x) for x in (cb, cb.__self__, cb.__func__))
+        self.Triton.addCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, self.method_callback)
+        self.Triton.removeCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, self.method_callback)
+        cb_new_refcnt = tuple(sys.getrefcount(x) for x in (cb, cb.__self__, cb.__func__))
+        self.assertTrue(cb_initial_refcnt == cb_new_refcnt)
+
+        self.Triton.addCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, self.method_callback)
+        self.Triton.getConcreteMemoryAreaValue(0x1000, 1)
+        self.Triton.removeCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, self.method_callback)
+        cb_new_refcnt = tuple(sys.getrefcount(x) for x in (cb, cb.__self__, cb.__func__))
+        self.assertTrue(cb_initial_refcnt == cb_new_refcnt)


### PR DESCRIPTION
PR created in response to https://github.com/JonathanSalwan/Triton/issues/1035

This has more changes than the patch referenced in that issue. This causes Triton to now throw an exception if you try to remove a callback and do not find the callback. If the same callback is registered multiple times, previously one call to remove would remove all the duplicates as well. With this update remove must be called the same number of times as add.

This was added because it is necessary to prevent bad dereferences on python objects passed to `removeCallback`.