### PR TITLE
Support overriding of global solving timeout per request

### DIFF
--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -1089,21 +1089,21 @@ namespace triton {
   }
 
 
-  std::unordered_map<triton::usize, triton::engines::solver::SolverModel> API::getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status) const {
+  std::unordered_map<triton::usize, triton::engines::solver::SolverModel> API::getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
     this->checkSolver();
-    return this->solver->getModel(node, status);
+    return this->solver->getModel(node, status, timeout);
   }
 
 
-  std::vector<std::unordered_map<triton::usize, triton::engines::solver::SolverModel>> API::getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status) const {
+  std::vector<std::unordered_map<triton::usize, triton::engines::solver::SolverModel>> API::getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
     this->checkSolver();
-    return this->solver->getModels(node, limit, status);
+    return this->solver->getModels(node, limit, status, timeout);
   }
 
 
-  bool API::isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status) const {
+  bool API::isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
     this->checkSolver();
-    return this->solver->isSat(node, status);
+    return this->solver->isSat(node, status, timeout);
   }
 
 

--- a/src/libtriton/engines/solver/solverEngine.cpp
+++ b/src/libtriton/engines/solver/solverEngine.cpp
@@ -77,24 +77,24 @@ namespace triton {
       }
 
 
-      std::unordered_map<triton::usize, SolverModel> SolverEngine::getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status) const {
+      std::unordered_map<triton::usize, SolverModel> SolverEngine::getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
         if (!this->solver)
           return std::unordered_map<triton::usize, SolverModel>{};
-        return this->solver->getModel(node, status);
+        return this->solver->getModel(node, status, timeout);
       }
 
 
-      std::vector<std::unordered_map<triton::usize, SolverModel>> SolverEngine::getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status) const {
+      std::vector<std::unordered_map<triton::usize, SolverModel>> SolverEngine::getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
         if (!this->solver)
           return std::vector<std::unordered_map<triton::usize, SolverModel>>{};
-        return this->solver->getModels(node, limit, status);
+        return this->solver->getModels(node, limit, status, timeout);
       }
 
 
-      bool SolverEngine::isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status) const {
+      bool SolverEngine::isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
         if (!this->solver)
           return false;
-        return this->solver->isSat(node, status);
+        return this->solver->isSat(node, status, timeout);
       }
 
 

--- a/src/libtriton/engines/solver/z3/z3Solver.cpp
+++ b/src/libtriton/engines/solver/z3/z3Solver.cpp
@@ -39,7 +39,7 @@ namespace triton {
       }
 
 
-      std::vector<std::unordered_map<triton::usize, SolverModel>> Z3Solver::getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status) const {
+      std::vector<std::unordered_map<triton::usize, SolverModel>> Z3Solver::getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
         std::vector<std::unordered_map<triton::usize, SolverModel>> ret;
         triton::ast::SharedAbstractNode onode = node;
         triton::ast::TritonToZ3Ast z3Ast{false};
@@ -65,7 +65,10 @@ namespace triton {
           z3::params p(ctx);
 
           /* Define the timeout */
-          if (this->timeout) {
+          if (timeout) {
+            p.set(":timeout", timeout);
+          }
+          else if (this->timeout) {
             p.set(":timeout", this->timeout);
           }
 
@@ -142,7 +145,7 @@ namespace triton {
       }
 
 
-      bool Z3Solver::isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status) const {
+      bool Z3Solver::isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
         triton::ast::TritonToZ3Ast z3Ast{false};
 
         if (node == nullptr)
@@ -162,7 +165,10 @@ namespace triton {
           z3::params p(ctx);
 
           /* Define the timeout */
-          if (this->timeout) {
+          if (timeout) {
+            p.set(":timeout", timeout);
+          }
+          else if (this->timeout) {
             p.set(":timeout", this->timeout);
           }
 
@@ -183,11 +189,11 @@ namespace triton {
       }
 
 
-      std::unordered_map<triton::usize, SolverModel> Z3Solver::getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status) const {
+      std::unordered_map<triton::usize, SolverModel> Z3Solver::getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status, triton::uint32 timeout) const {
         std::unordered_map<triton::usize, SolverModel> ret;
         std::vector<std::unordered_map<triton::usize, SolverModel>> allModels;
 
-        allModels = this->getModels(node, 1, status);
+        allModels = this->getModels(node, 1, status, timeout);
         if (allModels.size() > 0)
           ret = allModels.front();
 

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -515,7 +515,7 @@ namespace triton {
          * **item1**: symbolic variable id<br>
          * **item2**: model
          */
-        TRITON_EXPORT std::unordered_map<triton::usize, triton::engines::solver::SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const;
+        TRITON_EXPORT std::unordered_map<triton::usize, triton::engines::solver::SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
         /*!
          * \brief [**solver api**] - Computes and returns several models from a symbolic constraint. The `limit` is the number of models returned.
@@ -524,10 +524,10 @@ namespace triton {
          * **item1**: symbolic variable id<br>
          * **item2**: model
          */
-        TRITON_EXPORT std::vector<std::unordered_map<triton::usize, triton::engines::solver::SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr) const;
+        TRITON_EXPORT std::vector<std::unordered_map<triton::usize, triton::engines::solver::SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
         //! Returns true if an expression is satisfiable.
-        TRITON_EXPORT bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const;
+        TRITON_EXPORT bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
         //! Returns the kind of solver as triton::engines::solver::solver_e.
         TRITON_EXPORT triton::engines::solver::solver_e getSolver(void) const;

--- a/src/libtriton/includes/triton/solverEngine.hpp
+++ b/src/libtriton/includes/triton/solverEngine.hpp
@@ -83,7 +83,7 @@ namespace triton {
            * **item1**: symbolic variable id<br>
            * **item2**: model
            */
-          TRITON_EXPORT std::unordered_map<triton::usize, SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const;
+          TRITON_EXPORT std::unordered_map<triton::usize, SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
           //! Computes and returns several models from a symbolic constraint. The `limit` is the max number of models returned.
           /*! \brief vector of map of symbolic variable id -> model
@@ -92,10 +92,10 @@ namespace triton {
            * **item1**: symbolic variable id<br>
            * **item2**: model
            */
-          TRITON_EXPORT std::vector<std::unordered_map<triton::usize, SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr) const;
+          TRITON_EXPORT std::vector<std::unordered_map<triton::usize, SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
           //! Returns true if an expression is satisfiable.
-          TRITON_EXPORT bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const;
+          TRITON_EXPORT bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
           //! Returns the name of the solver.
           TRITON_EXPORT std::string getName(void) const;

--- a/src/libtriton/includes/triton/solverInterface.hpp
+++ b/src/libtriton/includes/triton/solverInterface.hpp
@@ -54,7 +54,7 @@ namespace triton {
            * **item1**: symbolic variable id<br>
            * **item2**: model
            */
-          TRITON_EXPORT virtual std::unordered_map<triton::usize, SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const = 0;
+          TRITON_EXPORT virtual std::unordered_map<triton::usize, SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const = 0;
 
           //! Computes and returns several models from a symbolic constraint. The `limit` is the max number of models returned.
           /*! \brief vector of map of symbolic variable id -> model
@@ -63,10 +63,10 @@ namespace triton {
            * **item1**: symbolic variable id<br>
            * **item2**: model
            */
-          TRITON_EXPORT virtual std::vector<std::unordered_map<triton::usize, SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr) const = 0;
+          TRITON_EXPORT virtual std::vector<std::unordered_map<triton::usize, SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const = 0;
 
           //! Returns true if an expression is satisfiable.
-          TRITON_EXPORT virtual bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const = 0;
+          TRITON_EXPORT virtual bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const = 0;
 
           //! Returns the name of the solver.
           TRITON_EXPORT virtual std::string getName(void) const = 0;

--- a/src/libtriton/includes/triton/z3Solver.hpp
+++ b/src/libtriton/includes/triton/z3Solver.hpp
@@ -68,7 +68,7 @@ namespace triton {
            * **item1**: symbolic variable id<br>
            * **item2**: model
            */
-          TRITON_EXPORT std::unordered_map<triton::usize, SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const;
+          TRITON_EXPORT std::unordered_map<triton::usize, SolverModel> getModel(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
           //! Computes and returns several models from a symbolic constraint. The `limit` is the number of models returned.
           /*! \brief vector of map of symbolic variable id -> model
@@ -77,10 +77,10 @@ namespace triton {
            * **item1**: symbolic variable id<br>
            * **item2**: model
            */
-          TRITON_EXPORT std::vector<std::unordered_map<triton::usize, SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr) const;
+          TRITON_EXPORT std::vector<std::unordered_map<triton::usize, SolverModel>> getModels(const triton::ast::SharedAbstractNode& node, triton::uint32 limit, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
           //! Returns true if an expression is satisfiable.
-          TRITON_EXPORT bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr) const;
+          TRITON_EXPORT bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0) const;
 
           //! Converts a Triton's AST to a Z3's AST, perform a Z3 simplification and returns a Triton's AST.
           TRITON_EXPORT triton::ast::SharedAbstractNode simplify(const triton::ast::SharedAbstractNode& node) const;

--- a/src/libtriton/includes/triton/z3Solver.hpp
+++ b/src/libtriton/includes/triton/z3Solver.hpp
@@ -48,7 +48,7 @@ namespace triton {
       /*! \brief Solver engine using z3. */
       class Z3Solver : public SolverInterface {
         private:
-          //! The SMT solver timeout. By default, unlimited.
+          //! The SMT solver timeout. By default, unlimited. This global timeout may be changed for a specific query (isSat/getModel/getModels) via argument `timeout`.
           triton::uint32 timeout;
 
           //! The SMT solver memory limit. By default, unlimited.


### PR DESCRIPTION
The motivation of this PR is following. We would like to solve queries in parallel. And sometimes we need to change solving timeout for specific queries (e.g, to detect symbolic address bounds with a small timeout). Global timeout does not allow to have different timeout for parallel queries.