### PR TITLE
Modernize fetching the python install directory

### DIFF
--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -360,7 +360,7 @@ if(PYTHON_BINDINGS)
         DEPENDS triton
     )
 
-    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from __future__ import print_function; from distutils.sysconfig import get_python_lib; print(get_python_lib())" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from sysconfig import get_path; print(get_path('platlib'))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" AND NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
         install (FILES ${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}/triton${PYTHON_SUFFIX} DESTINATION ${PYTHON_SITE_PACKAGES})
     else()


### PR DESCRIPTION
The current way of fetching the python install directory gets the wrong one on systems where `get_python_lib()` (the general directory) differs from `get_python_lib(True)` (the platform-specific directory).  For example, on 64-bit Fedora Linux systems, the former is `/usr/lib/python[version]/site-packages` while the latter is `/usr/lib64/python[version]/site-packages`.

This commit:
- removes `from __future__ import print_function`, which is only needed for python 2
- uses `sysconfig.get_path` instead of `distutils.sysconfig.get_python_lib`.  The former has been available since python 3.2; the latter has been deprecated and will be removed in some future version of python.
