### PR TITLE
Fix printf example.

### DIFF
--- a/src/examples/python/samples/sample_2.c
+++ b/src/examples/python/samples/sample_2.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+int main (int argc, char *argv[]) {
+
+   printf("Some numbers and %s (%d,%d,%d,%d,%d) (%c) (%s) (%d)\n", "some strings", 1,2,3,4,5,'c', "abcdefg", 323);
+
+   return(0);
+}

--- a/src/examples/python/small_x86-64_symbolic_emulator.py
+++ b/src/examples/python/small_x86-64_symbolic_emulator.py
@@ -88,6 +88,20 @@ def getMemoryString(addr):
 
     return s
 
+def getStringPosition(text):
+    formatters = ['%s','%d','%#02x', '%#x', '%02x', '%x', '%*s',    \
+                  '%02X', '%lX', '%ld', '%08x', '%lu', '%u', '%c']
+
+    text = text.replace("%s", " %s ").replace("%d", " %d ").replace("%#02x", " %#02x ")   \
+           .replace("%#x", " %#x ").replace("%x", " %x ").replace("%02X", " %02X ")       \
+           .replace("%c", " %c ").replace("%02x", " %02x ").replace("%ld", " %ld ")       \
+           .replace("%*s", " %*s ").replace("%lX", " %lX").replace("%08x", " %08x ")      \
+           .replace("%u", " %u ").replace("%lu", " %lu ")                                 \
+
+
+    matches = [y for x in text.split() for y in formatters if y in x]
+    indexes = [index for index, value in enumerate(matches) if value == '%s']
+    return indexes
 
 def getFormatString(addr):
     return getMemoryString(addr)                                                    \
@@ -185,25 +199,35 @@ def __strtoul():
     # Return value
     return int(nptr, base)
 
-
-# Simulate the printf() function
-def __printf():
+# Simulate the printf() function                                                
+def __printf():                                                                 
     debug('printf hooked')
 
-    # Get arguments
+    string_pos = getStringPosition(getMemoryString(Triton.getConcreteRegisterValue(Triton.registers.rdi)))
+                                                                                
+    # Get arguments                                                             
     arg1   = getFormatString(Triton.getConcreteRegisterValue(Triton.registers.rdi))
-    arg2   = Triton.getConcreteRegisterValue(Triton.registers.rsi)
-    arg3   = Triton.getConcreteRegisterValue(Triton.registers.rdx)
-    arg4   = Triton.getConcreteRegisterValue(Triton.registers.rcx)
-    arg5   = Triton.getConcreteRegisterValue(Triton.registers.r8)
-    arg6   = Triton.getConcreteRegisterValue(Triton.registers.r9)
-    nbArgs = arg1.count("{")
-    args   = [arg2, arg3, arg4, arg5, arg6][:nbArgs]
-    s      = arg1.format(*args)
-
-    sys.stdout.write(s)
-
-    # Return value
+    arg2   = Triton.getConcreteRegisterValue(Triton.registers.rsi)              
+    arg3   = Triton.getConcreteRegisterValue(Triton.registers.rdx)              
+    arg4   = Triton.getConcreteRegisterValue(Triton.registers.rcx)              
+    arg5   = Triton.getConcreteRegisterValue(Triton.registers.r8)               
+    arg6   = Triton.getConcreteRegisterValue(Triton.registers.r9)               
+    nbArgs = arg1.count("{")                                                    
+    args   = [arg2, arg3, arg4, arg5, arg6][:nbArgs]                            
+    rsp    = Triton.getConcreteRegisterValue(Triton.registers.rsp)              
+                                                                                
+    if nbArgs > 5:                                                              
+        for i in range(nbArgs - 5):                                             
+            args.append(Triton.getConcreteMemoryValue(MemoryAccess(rsp + CPUSIZE.QWORD * (i + 1), CPUSIZE.QWORD)))
+                                                                                
+    for i in string_pos:                                                        
+        args[i] = getMemoryString(args[i])                                      
+                                                                                
+    s = arg1.format(*args)                                                      
+                                                                                
+    sys.stdout.write(s)                                                         
+                                                                                
+    # Return value                                                              
     return len(s)
 
 
@@ -311,6 +335,35 @@ def __atoll():
     # Return value
     return int(arg1)
 
+def __memcpy():
+    debug('memcpy hooked')
+
+    #Get arguments
+    arg1 = Triton.getConcreteRegisterValue(Triton.registers.rdi)
+    arg2 = Triton.getConcreteRegisterValue(Triton.registers.rsi)
+    arg3 = Triton.getConcreteRegisterValue(Triton.registers.rdx)
+
+    for index in range(arg3):
+        value = Triton.getConcreteMemoryValue(arg2 + index)
+        Triton.setConcreteMemoryValue(arg1 + index, value)
+
+    return arg1
+
+def __strcat():
+    debug('strcat hooked')
+
+    #Get arguments
+    arg1 = Triton.getConcreteRegisterValue(Triton.registers.rdi)
+    arg2 = Triton.getConcreteRegisterValue(Triton.registers.rsi)
+
+    src_length = len(getMemoryString(arg1))
+    dest_length = len(getMemoryString(arg2))
+    for index in range(dest_length):
+        value = Triton.getConcreteMemoryValue(arg2 + index)
+        Triton.setConcreteMemoryValue(arg1 + index + src_length, value)
+
+    return arg1
+
 
 customRelocation = [
     ['__libc_start_main', __libc_start_main,    None],
@@ -318,12 +371,14 @@ customRelocation = [
     ['atol',              __atol,               None],
     ['atoll',             __atoll,              None],
     ['malloc',            __malloc,             None],
+    ['memcpy',            __memcpy,             None],
     ['printf',            __printf,             None],
     ['putchar',           __putchar,            None],
     ['puts',              __puts,               None],
     ['raise',             __raise,              None],
     ['rand',              __rand,               None],
     ['signal',            __signal,             None],
+    ['strcat',            __strcat,             None],
     ['strlen',            __strlen,             None],
     ['strtoul',           __strtoul,            None],
 ]
@@ -365,7 +420,6 @@ def emulate(pc):
         count += 1
 
         #print instruction
-
         if instruction.getType() == OPCODE.X86.HLT:
             break
 


### PR DESCRIPTION
Added support for various numbers of arguments for the printf function.
Solved the problem of printing strings. This problem was solved just for the case in which the address of the string is saved in a register. When the address of the string is on the stack, a problem occurs because it seems that an invalid address is put on the stack.
I added a simple example to show this. After I investigated the problem with objdump and gdb, I found out that the address of the string is put in the RAX register through a "lea" instruction and after that, the RAX register is pushed on the stack.
Could you give me an insight into this "lea" instruction? Is there a corner case that I didn't take into account?