### PR TITLE
Fix import triton on Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,7 @@ RUN cd /tmp && \
 RUN cd /opt && git clone https://github.com/JonathanSalwan/Triton.git && \
     cd Triton && mkdir build && cd build && cmake .. && make install
 
+# Configure libTriton path for Python
+RUN echo export PYTHONPATH=\"/usr/lib/python\$\(python3 -c \'import sys\; print\(\".\".join\(map\(str, sys.version_info[:2]\)\)\)\'\)/site-packages:\$PYTHONPATH\" >> /etc/bash.bashrc
+
 ENTRYPOINT /bin/bash


### PR DESCRIPTION
The environment variable $PYTHONPATH is empty. With an extra command during build of docker container I insert "/usr/lib/python<version>/site-packages" into that variable and 'import triton' works.