### PR TITLE
Catch Z3 max. memory exceeded exception and make it OUTOFMEM

### DIFF
--- a/src/libtriton/engines/solver/z3/z3Solver.cpp
+++ b/src/libtriton/engines/solver/z3/z3Solver.cpp
@@ -138,6 +138,12 @@ namespace triton {
           }
         }
         catch (const z3::exception& e) {
+          if (!strcmp(e.msg(), "max. memory exceeded")) {
+            if (status) {
+              *status = triton::engines::solver::OUTOFMEM;
+            }
+            return {};
+          }
           throw triton::exceptions::SolverEngine(std::string("Z3Solver::getModels(): ") + e.msg());
         }
 
@@ -184,6 +190,12 @@ namespace triton {
           return res == z3::sat;
         }
         catch (const z3::exception& e) {
+          if (!strcmp(e.msg(), "max. memory exceeded")) {
+            if (status) {
+              *status = triton::engines::solver::OUTOFMEM;
+            }
+            return {};
+          }
           throw triton::exceptions::SolverEngine(std::string("Z3Solver::isSat(): ") + e.msg());
         }
       }


### PR DESCRIPTION
This merge fixes unhandled Z3 out of memory exception.

```
terminate called after throwing an instance of 'triton::exceptions::SolverEngine'
  what():  Z3Solver::getModels(): max. memory exceeded
```