### PR TITLE
Bitwuzla evaluate

### DIFF
--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -1107,14 +1107,19 @@ namespace triton {
   }
 
 
-  triton::uint512 API::evaluateAstViaZ3(const triton::ast::SharedAbstractNode& node) const {
+  triton::uint512 API::evaluateAstViaSolver(const triton::ast::SharedAbstractNode& node) const {
     this->checkSolver();
     #ifdef TRITON_Z3_INTERFACE
     if (this->getSolver() == triton::engines::solver::SOLVER_Z3) {
       return reinterpret_cast<const triton::engines::solver::Z3Solver*>(this->getSolverInstance())->evaluate(node);
     }
     #endif
-    throw triton::exceptions::API("API::evaluateAstViaZ3(): Solver instance must be a SOLVER_Z3.");
+    #ifdef TRITON_BITWUZLA_INTERFACE
+    if (this->getSolver() == triton::engines::solver::SOLVER_BITWUZLA) {
+        return reinterpret_cast<const triton::engines::solver::BitwuzlaSolver*>(this->getSolverInstance())->evaluate(node);
+    }
+    #endif
+    throw triton::exceptions::API("API::evaluateAstViaZ3(): Solver instance must be a SOLVER_Z3 or SOLVER_BITWUZLA.");
   }
 
 

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -107,7 +107,7 @@ Enables or disables the symbolic execution engine.
 - <b>void enableTaintEngine(bool flag)</b><br>
 Enables or disables the taint engine.
 
-- <b>integer evaluateAstViaZ3(\ref py_AstNode_page node)</b><br>
+- <b>integer evaluateAstViaSolver(\ref py_AstNode_page node)</b><br>
 Evaluates an AST via Z3 and returns the symbolic value.
 
 - <b>[\ref py_Register_page, ...] getAllRegisters(void)</b><br>
@@ -1143,12 +1143,12 @@ namespace triton {
       }
 
 
-      static PyObject* TritonContext_evaluateAstViaZ3(PyObject* self, PyObject* node) {
+      static PyObject* TritonContext_evaluateAstViaSolver(PyObject* self, PyObject* node) {
         if (!PyAstNode_Check(node))
-          return PyErr_Format(PyExc_TypeError, "TritonContext::evaluateAstViaZ3(): Expects a AstNode as argument.");
+          return PyErr_Format(PyExc_TypeError, "TritonContext::evaluateAstViaSolver(): Expects a AstNode as argument.");
 
         try {
-          return PyLong_FromUint512(PyTritonContext_AsTritonContext(self)->evaluateAstViaZ3(PyAstNode_AsAstNode(node)));
+          return PyLong_FromUint512(PyTritonContext_AsTritonContext(self)->evaluateAstViaSolver(PyAstNode_AsAstNode(node)));
         }
         catch (const triton::exceptions::PyCallbacks&) {
           return nullptr;
@@ -3213,7 +3213,7 @@ namespace triton {
         {"disassembly",                         (PyCFunction)TritonContext_disassembly,                               METH_VARARGS,                  ""},
         {"enableSymbolicEngine",                (PyCFunction)TritonContext_enableSymbolicEngine,                      METH_O,                        ""},
         {"enableTaintEngine",                   (PyCFunction)TritonContext_enableTaintEngine,                         METH_O,                        ""},
-        {"evaluateAstViaZ3",                    (PyCFunction)TritonContext_evaluateAstViaZ3,                          METH_O,                        ""},
+        {"evaluateAstViaSolver",                (PyCFunction)TritonContext_evaluateAstViaSolver,                      METH_O,                        ""},
         {"getAllRegisters",                     (PyCFunction)TritonContext_getAllRegisters,                           METH_NOARGS,                   ""},
         {"getArchitecture",                     (PyCFunction)TritonContext_getArchitecture,                           METH_NOARGS,                   ""},
         {"getAstContext",                       (PyCFunction)TritonContext_getAstContext,                             METH_NOARGS,                   ""},

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -544,8 +544,8 @@ namespace triton {
         //! Returns true if the solver is valid.
         TRITON_EXPORT bool isSolverValid(void) const;
 
-        //! [**solver api**] - Evaluates a Triton's AST via Z3 and returns a concrete value.
-        TRITON_EXPORT triton::uint512 evaluateAstViaZ3(const triton::ast::SharedAbstractNode& node) const;
+        //! [**solver api**] - Evaluates a Triton's AST via solver and returns a concrete value.
+        TRITON_EXPORT triton::uint512 evaluateAstViaSolver(const triton::ast::SharedAbstractNode& node) const;
 
         //! [**solver api**] - Converts a Triton's AST to a Z3's AST, perform a Z3 simplification and returns a Triton's AST.
         TRITON_EXPORT triton::ast::SharedAbstractNode processZ3Simplification(const triton::ast::SharedAbstractNode& node) const;

--- a/src/libtriton/includes/triton/bitwuzlaSolver.hpp
+++ b/src/libtriton/includes/triton/bitwuzlaSolver.hpp
@@ -49,6 +49,9 @@ namespace triton {
       /*! \brief Solver engine using Bitwuzla. */
       class BitwuzlaSolver : public SolverInterface {
         private:
+          //! Converts binary bitvector value from string to uint512.
+          triton::uint512 fromBvalueToUint512(const char* value) const;
+
           /*! Struct used to provide information for Bitwuzla termination callback */
           struct SolverParams {
             SolverParams(int64_t timeout, size_t memory_limit): timeout(timeout), memory_limit(memory_limit) {

--- a/src/libtriton/includes/triton/bitwuzlaSolver.hpp
+++ b/src/libtriton/includes/triton/bitwuzlaSolver.hpp
@@ -94,6 +94,9 @@ namespace triton {
           //! Returns true if an expression is satisfiable.
           TRITON_EXPORT bool isSat(const triton::ast::SharedAbstractNode& node, triton::engines::solver::status_e* status = nullptr, triton::uint32 timeout = 0, triton::uint32* solvingTime = nullptr) const;
 
+          //! Evaluates a Triton's AST via Bitwuzla and returns a concrete value.
+          TRITON_EXPORT triton::uint512 evaluate(const triton::ast::SharedAbstractNode& node) const;
+
           //! Returns the name of this solver.
           TRITON_EXPORT std::string getName(void) const;
 

--- a/src/libtriton/includes/triton/tritonToBitwuzlaAst.hpp
+++ b/src/libtriton/includes/triton/tritonToBitwuzlaAst.hpp
@@ -39,7 +39,7 @@ namespace triton {
     class TritonToBitwuzlaAst {
       public:
         //! Constructor.
-        TRITON_EXPORT TritonToBitwuzlaAst();
+        TRITON_EXPORT TritonToBitwuzlaAst(bool eval=false);
 
         //! Destructor.
         TRITON_EXPORT ~TritonToBitwuzlaAst();
@@ -68,6 +68,9 @@ namespace triton {
 
         //! All bitvector sorts that used in the expression.
         std::map<size_t, const BitwuzlaSort*> bvSorts;
+
+        //! This flag define if the conversion is used to evaluated a node or not.
+        bool isEval;
     };
 
   /*! @} End of ast namespace */

--- a/src/testers/unittests/test_ast_conversion.py
+++ b/src/testers/unittests/test_ast_conversion.py
@@ -78,7 +78,7 @@ class TestAstConversion(unittest.TestCase):
                     n.evaluate(),
                     "ref = {} and triton value = {} with operator {} operands were {} and {}".format(ref, n.evaluate(), op, cv1, cv2)
                 )
-                self.assertEqual(ref, self.Triton.evaluateAstViaZ3(n))
+                self.assertEqual(ref, self.Triton.evaluateAstViaSolver(n))
                 self.assertEqual(ref, self.Triton.simplify(n, True).evaluate())
 
     def test_unop(self):
@@ -105,7 +105,7 @@ class TestAstConversion(unittest.TestCase):
                                                              n.evaluate(),
                                                              op,
                                                              cv1))
-                self.assertEqual(ref, self.Triton.evaluateAstViaZ3(n))
+                self.assertEqual(ref, self.Triton.evaluateAstViaSolver(n))
                 self.assertEqual(ref, self.Triton.simplify(n, True).evaluate())
 
     def test_smtbinop(self):
@@ -168,8 +168,8 @@ class TestAstConversion(unittest.TestCase):
                     n = op(self.v1, self.v2)
                 self.assertEqual(
                     n.evaluate(),
-                    self.Triton.evaluateAstViaZ3(n),
-                    "triton = {} and z3 = {} with operator {} operands were {} and {}".format(n.evaluate(), self.Triton.evaluateAstViaZ3(n), op, cv1, cv2)
+                    self.Triton.evaluateAstViaSolver(n),
+                    "triton = {} and z3 = {} with operator {} operands were {} and {}".format(n.evaluate(), self.Triton.evaluateAstViaSolver(n), op, cv1, cv2)
                 )
                 self.assertEqual(
                     n.evaluate(),
@@ -202,7 +202,7 @@ class TestAstConversion(unittest.TestCase):
                     n = op(self.v1 != 0)
                 else:
                     n = op(self.v1)
-                self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaZ3(n))
+                self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaSolver(n))
                 self.assertEqual(n.evaluate(), self.Triton.simplify(n, True).evaluate())
 
     def test_bvnode(self):
@@ -210,7 +210,7 @@ class TestAstConversion(unittest.TestCase):
         for _ in range(100):
             cv1 = random.randint(-127, 255)
             n = self.astCtxt.bv(cv1, 8)
-            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaZ3(n))
+            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaSolver(n))
             self.assertEqual(n.evaluate(), self.Triton.simplify(n, True).evaluate())
 
     def test_extract(self):
@@ -226,7 +226,7 @@ class TestAstConversion(unittest.TestCase):
                                      "ref = {} and triton value = {} with operator"
                                      "'extract' operands was {} low was : {} and "
                                      "hi was : {}".format(ref, n.evaluate(), cv1, lo, hi))
-                    self.assertEqual(ref, self.Triton.evaluateAstViaZ3(n))
+                    self.assertEqual(ref, self.Triton.evaluateAstViaSolver(n))
                     self.assertEqual(ref, self.Triton.simplify(n, True).evaluate())
 
     def test_ite(self):
@@ -237,7 +237,7 @@ class TestAstConversion(unittest.TestCase):
             self.Triton.setConcreteVariableValue(self.sv1, cv1)
             self.Triton.setConcreteVariableValue(self.sv2, cv2)
             n = self.astCtxt.ite(self.v1 < self.v2, self.v1, self.v2)
-            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaZ3(n))
+            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaSolver(n))
             self.assertEqual(n.evaluate(), self.Triton.simplify(n, True).evaluate())
 
     @utils.xfail
@@ -245,7 +245,7 @@ class TestAstConversion(unittest.TestCase):
         # Decimal node is not exported in the python interface
         for cv1 in range(0, 256):
             n = self.astCtxt.integer(cv1)
-            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaZ3(n))
+            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaSolver(n))
             self.assertEqual(n.evaluate(), self.Triton.simplify(n, True).evaluate())
 
     @utils.xfail
@@ -257,7 +257,7 @@ class TestAstConversion(unittest.TestCase):
             self.Triton.setConcreteVariableValue(self.sv1, cv1)
             self.Triton.setConcreteVariableValue(self.sv2, cv2)
             n = self.astCtxt.let("b", self.astCtxt.bvadd(self.v1, self.v2), self.astCtxt.bvadd(self.astCtxt.string("b"), self.v1))
-            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaZ3(n))
+            self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaSolver(n))
             self.assertEqual(n.evaluate(), self.Triton.simplify(n, True).evaluate())
 
     def test_fuzz(self):
@@ -326,7 +326,7 @@ class TestAstConversion(unittest.TestCase):
                 cv2 = random.randint(0, 255)
                 self.Triton.setConcreteVariableValue(self.sv1, cv1)
                 self.Triton.setConcreteVariableValue(self.sv2, cv2)
-                self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaZ3(n))
+                self.assertEqual(n.evaluate(), self.Triton.evaluateAstViaSolver(n))
 
     def new_node(self, depth, possible):
         """Recursive function to create a random ast."""
@@ -413,4 +413,4 @@ class TestAstTraversal(unittest.TestCase):
         ref1 = self.ast.reference(self.ctx.newSymbolicExpression(g))
         ref2 = self.ast.reference(self.ctx.newSymbolicExpression(a))
         k = ref1 + ref2
-        self.assertEqual(k.evaluate(), self.ctx.evaluateAstViaZ3(k))
+        self.assertEqual(k.evaluate(), self.ctx.evaluateAstViaSolver(k))

--- a/src/testers/unittests/test_ast_eval.py
+++ b/src/testers/unittests/test_ast_eval.py
@@ -21,8 +21,8 @@ class TestAstEval(unittest.TestCase):
         """Check our evaluation is the same as the one from Z3."""
         for test in tests:
             trv = test.evaluate()
-            z3v = self.Triton.evaluateAstViaZ3(test)
-            self.assertEqual(trv, z3v)
+            sv = self.Triton.evaluateAstViaSolver(test)
+            self.assertEqual(trv, sv)
 
     def test_sub(self):
         """Check sub operations."""


### PR DESCRIPTION
Implemented `evaluate()` method for Bitwuzla solver. Also renamed `evaluateAstViaZ3()` -> `evaluateAstViaSolver()`. Unittests from `test_ast_eval.py` now pass for both solvers.