### PR TITLE
Bitwuzla termination callback

### DIFF
--- a/src/libtriton/engines/solver/bitwuzla/bitwuzlaSolver.cpp
+++ b/src/libtriton/engines/solver/bitwuzla/bitwuzlaSolver.cpp
@@ -111,7 +111,6 @@ namespace triton {
 
         // Set solving params.
         SolverParams p(this->timeout, this->memoryLimit);
-
         if (this->timeout || this->memoryLimit) {
           bitwuzla_set_termination_callback(bzla, this->terminateCallback, reinterpret_cast<void*>(&p));
         }
@@ -214,12 +213,13 @@ namespace triton {
           throw triton::exceptions::AstTranslations("BitwuzlaSolver::evaluate(): node cannot be null.");
         }
 
-        // Perform check-sat on empty solver to enable model generation.
         auto bzla = bitwuzla_new();
         bitwuzla_set_option(bzla, BITWUZLA_OPT_PRODUCE_MODELS, 1);
+
+        // Query check-sat on empty solver to put Bitwuzla in SAT-state. Thus, it should be able to evaluate concrete formulas.
         if (bitwuzla_check_sat(bzla) != BITWUZLA_SAT) {
           bitwuzla_delete(bzla);
-          return 0;
+          throw triton::exceptions::SolverEngine("BitwuzlaSolver::evaluate(): empty solver didn't return SAT.");
         }
 
         // Evaluate concrete AST in solver.

--- a/src/libtriton/includes/triton/bitwuzlaSolver.hpp
+++ b/src/libtriton/includes/triton/bitwuzlaSolver.hpp
@@ -61,9 +61,7 @@ namespace triton {
             triton::engines::solver::status_e status = triton::engines::solver::UNKNOWN;                    /*!< Reason of solving termination. */
             int64_t timeout;                                                                                /*!< Timeout (ms) for solver instance running. */
             size_t  memory_limit;                                                                           /*!< Memory limit for the whole symbolic process. */
-            size_t  call_cnt = 0;                                                                           /*!< Counter for the number of termination callback calls. */
             int64_t last_mem_check = -1;                                                                    /*!< Time when the last memory usage check was performed. */
-            size_t  delay = 1;                                                                              /*!< Check memory limit every delay seconds. */
           };
 
           //! The SMT solver timeout. By default, unlimited. This global timeout may be changed for a specific query (isSat/getModel/getModels) via argument `timeout`.

--- a/src/testers/unittests/test_ast_eval.py
+++ b/src/testers/unittests/test_ast_eval.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-from triton import ARCH, TritonContext, MODE
+from triton import ARCH, TritonContext, MODE, SOLVER
 
 
 class TestAstEval(unittest.TestCase):
@@ -13,16 +13,26 @@ class TestAstEval(unittest.TestCase):
 
     def setUp(self):
         """Define the arch."""
-        self.Triton = TritonContext()
-        self.Triton.setArchitecture(ARCH.X86_64)
-        self.astCtxt = self.Triton.getAstContext()
+        self.ctx = TritonContext()
+        self.ctx.setArchitecture(ARCH.X86_64)
+        self.astCtxt = self.ctx.getAstContext()
 
     def check_ast(self, tests):
-        """Check our evaluation is the same as the one from Z3."""
+        """Check our evaluation is the same as the one from Z3 and Bitwuzla."""
         for test in tests:
             trv = test.evaluate()
-            sv = self.Triton.evaluateAstViaSolver(test)
-            self.assertEqual(trv, sv)
+
+            # Test z3 evaluation
+            if 'Z3' in dir(SOLVER):
+                self.ctx.setSolver(SOLVER.Z3)
+                sv = self.ctx.evaluateAstViaSolver(test)
+                self.assertEqual(trv, sv)
+
+            # Test bitwuzla evaluation
+            if 'BITWUZLA' in dir(SOLVER):
+                self.ctx.setSolver(SOLVER.BITWUZLA)
+                sv = self.ctx.evaluateAstViaSolver(test)
+                self.assertEqual(trv, sv)
 
     def test_sub(self):
         """Check sub operations."""
@@ -618,9 +628,9 @@ class TestAstEval(unittest.TestCase):
             self.astCtxt.bvrol(self.astCtxt.bv(0xf2345678, 32), self.astCtxt.bv(64, 32)),
             self.astCtxt.bvrol(self.astCtxt.bv(0xf2345678, 32), self.astCtxt.bv(0x12345678, 32)),
         ]
-        self.Triton.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, False)
+        self.ctx.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, False)
         self.check_ast(tests)
-        self.Triton.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, True)
+        self.ctx.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, True)
         self.check_ast(tests)
 
     def test_ror(self):
@@ -658,9 +668,9 @@ class TestAstEval(unittest.TestCase):
             self.astCtxt.bvror(self.astCtxt.bv(0xf2345678, 32), self.astCtxt.bv(0x12345678, 32)),
             self.astCtxt.bvror(self.astCtxt.bv(11258300193617241473, 64), self.astCtxt.bv(11258300193617241473, 64))
         ]
-        self.Triton.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, False)
+        self.ctx.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, False)
         self.check_ast(tests)
-        self.Triton.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, True)
+        self.ctx.setMode(MODE.SYMBOLIZE_INDEX_ROTATION, True)
         self.check_ast(tests)
 
     def test_smod(self):
@@ -841,11 +851,11 @@ class TestAstEval(unittest.TestCase):
 
     def test_reference(self):
         """Check evaluation of reference node after variable update."""
-        self.sv1 = self.Triton.newSymbolicVariable(8)
+        self.sv1 = self.ctx.newSymbolicVariable(8)
         self.v1 = self.astCtxt.variable(self.sv1)
         subnode = self.astCtxt.bvadd(self.v1, self.v1)
-        expr = self.Triton.newSymbolicExpression(subnode)
+        expr = self.ctx.newSymbolicExpression(subnode)
         final_node = self.astCtxt.bvsub(self.astCtxt.reference(expr), self.astCtxt.bv(8, 8))
-        self.Triton.setConcreteVariableValue(self.sv1, 10)
+        self.ctx.setConcreteVariableValue(self.sv1, 10)
         trv = final_node.evaluate()
         self.assertEqual(trv, 12)


### PR DESCRIPTION
- Throw exception when on Bitwuzla failure on `evaluate()`
- Termination callback refactoring: remove `call_cnt` (doesn't slow solving time notable), remove `delay`-logic (checking every second is enough), doesn't check oom in first 100ms of solving (no need to check memory on easy queries). Thus, termination callback become more concise and clear.