### PR TITLE
Update README to reflect that python is an optional library

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Triton relies on the following dependencies:
 
 ```
 * libboost                   >= 1.68
-* libpython                  >= 3.6
 * libcapstone                >= 4.0.x   https://github.com/capstone-engine/capstone
+* libpython     (optional)   >= 3.6
 * libz3         (optional)   >= 4.6.0   https://github.com/Z3Prover/z3
 * libbitwuzla   (optional)   n/a        https://github.com/bitwuzla/bitwuzla
 * llvm          (optional)   >= 12


### PR DESCRIPTION
Python is an optional library to build Triton. For instance Ponce does not compile python into it.
You can disable python in the build commands (`-DPYTHON_BINDINGS=OFF`):
```
cmake_dependent_option(PYTHON_BINDINGS      "Enable Python bindings"                        ON BUILD_SHARED_LIBS OFF)
```