### PR TITLE
[cmake] Fix pre-definintion and dynamic library installation, add options for examples and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ option(GCOV                 "Enable code coverage"                     OFF)
 option(LLVM_INTERFACE       "Use LLVM for lifting"                     OFF)
 option(MSVC_STATIC          "Use statically-linked runtime library"    OFF)
 option(Z3_INTERFACE         "Use Z3 as SMT solver"                     ON)
+option(BUILD_EXAMPLES       "Build the examples"                       ON)
+option(ENABLE_TEST          "Build test program"                       ON)
 
 # Define cmake dependent options
 cmake_dependent_option(PYTHON_BINDINGS      "Enable Python bindings"                        ON BUILD_SHARED_LIBS OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,16 @@
 add_subdirectory(libtriton)
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    # Disable exemples for windows as linkage doesn't work. Exported function should
-    # be marked as exported on windows.
-    add_subdirectory(examples)
-else()
-    enable_testing()
-    add_test(DummyTest echo "Windows is awesome")
+if (BUILD_EXAMPLES)
+    if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+        # Disable exemples for windows as linkage doesn't work. Exported function should
+        # be marked as exported on windows.
+        add_subdirectory(examples)
+    else()
+        enable_testing()
+        add_test(DummyTest echo "Windows is awesome")
+    endif()
 endif()
 
-add_subdirectory(testers)
+if (ENABLE_TEST)
+    add_subdirectory(testers)
+endif()

--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -275,7 +275,7 @@ if(MSVC AND MSVC_STATIC)
 endif()
 
 if(WIN32 AND BUILD_SHARED_LIBS)
-    target_compile_definitions(triton PUBLIC TRITON_BUILDING_DLL)
+    target_compile_definitions(triton PRIVATE BUILDING_DLL)
 endif()
 
 # Install tritonTargets.cmake
@@ -291,6 +291,7 @@ install(
     EXPORT tritonTargets
     PUBLIC_HEADER DESTINATION include/triton
     INCLUDES DESTINATION include
+    RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
 )


### PR DESCRIPTION
1. `TRITON_BUILDING_DLL` is not exists, it should be `BUILDING_DLL`. See https://github.com/JonathanSalwan/Triton/blob/96104b1a860dc7ddb9ab123859b2fd668e388f72/src/libtriton/includes/triton/dllexport.hpp#L12-L17
2. `BUILDING_DLL` should only be used in build process, so it must be `PRIVATE`, not `PUBLIC`.
3. The dynamic library is not installed.
4. Add options for feature `examples` and `tests`.

Related: https://github.com/microsoft/vcpkg/pull/23111