### PR TITLE
Fix reference count of Py_True/Py_False

### DIFF
--- a/src/libtriton/bindings/python/namespaces/initVersionNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initVersionNamespace.cpp
@@ -47,20 +47,26 @@ namespace triton {
         xPyDict_SetItemString(versionDict, "BUILD", PyLong_FromUint32(triton::BUILD));
 
         #ifdef TRITON_Z3_INTERFACE
+          Py_INCREF(Py_True);
           xPyDict_SetItemString(versionDict, "Z3_INTERFACE", Py_True);
         #else
+          Py_INCREF(Py_False);
           xPyDict_SetItemString(versionDict, "Z3_INTERFACE", Py_False);
         #endif
 
         #ifdef TRITON_BITWUZLA_INTERFACE
+          Py_INCREF(Py_True);
           xPyDict_SetItemString(versionDict, "BITWUZLA_INTERFACE", Py_True);
         #else
+          Py_INCREF(Py_False);
           xPyDict_SetItemString(versionDict, "BITWUZLA_INTERFACE", Py_False);
         #endif
 
         #ifdef TRITON_LLVM_INTERFACE
+          Py_INCREF(Py_True);
           xPyDict_SetItemString(versionDict, "LLVM_INTERFACE", Py_True);
         #else
+          Py_INCREF(Py_False);
           xPyDict_SetItemString(versionDict, "LLVM_INTERFACE", Py_False);
         #endif
       }


### PR DESCRIPTION
In the end of `xPyDict_SetItemString`, it will call `Py_DECREF(val)`, which means this function treats `val` as strong reference. 

`Py_True` and `Py_False` are just constant pointers to `Py_Object`, so we must increase their reference count before passing them to `xPyDict_SetItemString`.