### PR TITLE
Code changes to support using capstone next

### DIFF
--- a/src/libtriton/arch/x86/x86Specifications.cpp
+++ b/src/libtriton/arch/x86/x86Specifications.cpp
@@ -155,9 +155,11 @@ namespace triton {
             tritonId = triton::arch::x86::ID_INS_FIADD;
             break;
 
+#if CS_API_MAJOR < 5
           case triton::extlibs::capstone::X86_INS_FADDP:
             tritonId = triton::arch::x86::ID_INS_FADDP;
             break;
+#endif
 
           case triton::extlibs::capstone::X86_INS_ADOX:
             tritonId = triton::arch::x86::ID_INS_ADOX;
@@ -2879,9 +2881,11 @@ namespace triton {
             tritonId = triton::arch::x86::ID_INS_FUCOM;
             break;
 
+#if CS_API_MAJOR < 5
           case triton::extlibs::capstone::X86_INS_UD2B:
             tritonId = triton::arch::x86::ID_INS_UD2B;
             break;
+#endif
 
           case triton::extlibs::capstone::X86_INS_UNPCKHPD:
             tritonId = triton::arch::x86::ID_INS_UNPCKHPD;
@@ -3039,17 +3043,21 @@ namespace triton {
             tritonId = triton::arch::x86::ID_INS_VCVTDQ2PS;
             break;
 
+#if CS_API_MAJOR < 5
           case triton::extlibs::capstone::X86_INS_VCVTPD2DQX:
             tritonId = triton::arch::x86::ID_INS_VCVTPD2DQX;
             break;
+#endif
 
           case triton::extlibs::capstone::X86_INS_VCVTPD2DQ:
             tritonId = triton::arch::x86::ID_INS_VCVTPD2DQ;
             break;
 
+#if CS_API_MAJOR < 5
           case triton::extlibs::capstone::X86_INS_VCVTPD2PSX:
             tritonId = triton::arch::x86::ID_INS_VCVTPD2PSX;
             break;
+#endif
 
           case triton::extlibs::capstone::X86_INS_VCVTPD2PS:
             tritonId = triton::arch::x86::ID_INS_VCVTPD2PS;
@@ -3095,9 +3103,11 @@ namespace triton {
             tritonId = triton::arch::x86::ID_INS_VCVTSS2USI;
             break;
 
+#if CS_API_MAJOR < 5
           case triton::extlibs::capstone::X86_INS_VCVTTPD2DQX:
             tritonId = triton::arch::x86::ID_INS_VCVTTPD2DQX;
             break;
+#endif
 
           case triton::extlibs::capstone::X86_INS_VCVTTPD2DQ:
             tritonId = triton::arch::x86::ID_INS_VCVTTPD2DQ;


### PR DESCRIPTION
## Description

This PR introduce code changes to allow using Triton with the current HEAD of [capstone-engine/capstone](https://github.com/capstone-engine/capstone) (as of writing).

I have seen the previous conversion in #972 but although capstone is not finalized yet I think there is some value to be able to try Triton with the current repository.
Especially as those code changes looks fairly backward compatible to my untrained eyes (disclaimer: I am not a heavy Triton user).

There is an interesting thread at capstone-engine/capstone#1456 which give many information about some of the capstone 5 changes, which I used as inspiration for this PR.