### PR TITLE
Support instruction assembly printing for symbolic expressions in lifting engine

### DIFF
--- a/src/libtriton/api/api.cpp
+++ b/src/libtriton/api/api.cpp
@@ -1319,15 +1319,15 @@ namespace triton {
   }
 
 
-  std::ostream& API::liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr) {
+  std::ostream& API::liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool icomment) {
     this->checkLifting();
-    return this->lifting->liftToPython(stream, expr);
+    return this->lifting->liftToPython(stream, expr, icomment);
   }
 
 
-  std::ostream& API::liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_) {
+  std::ostream& API::liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_, bool icomment) {
     this->checkLifting();
-    return this->lifting->liftToSMT(stream, expr, assert_);
+    return this->lifting->liftToSMT(stream, expr, assert_, icomment);
   }
 
 

--- a/src/libtriton/engines/lifters/liftingToPython.cpp
+++ b/src/libtriton/engines/lifters/liftingToPython.cpp
@@ -104,8 +104,10 @@ namespace triton {
           auto& e = ssa[id];
           stream << e->getFormattedExpression();
           if (icomment && !e->getDisassembly().empty()) {
-            if (!e->getComment().empty())
-            {
+            if (e->getComment().empty()) {
+              stream << " # ";
+            }
+            else {
               stream << " - ";
             }
             stream << e->getDisassembly();

--- a/src/libtriton/engines/lifters/liftingToPython.cpp
+++ b/src/libtriton/engines/lifters/liftingToPython.cpp
@@ -62,7 +62,7 @@ namespace triton {
       }
 
 
-      std::ostream& LiftingToPython::liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr) {
+      std::ostream& LiftingToPython::liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool icomment) {
         /* Save the AST representation mode */
         triton::ast::representations::mode_e mode = this->astCtxt->getRepresentationMode();
         this->astCtxt->setRepresentationMode(triton::ast::representations::PYTHON_REPRESENTATION);
@@ -101,7 +101,16 @@ namespace triton {
 
         /* Print symbolic expressions */
         for (const auto& id : symExprs) {
-          stream << ssa[id]->getFormattedExpression() << std::endl;
+          auto& e = ssa[id];
+          stream << e->getFormattedExpression();
+          if (icomment && !e->getDisassembly().empty()) {
+            if (!e->getComment().empty())
+            {
+              stream << " - ";
+            }
+            stream << e->getDisassembly();
+          }
+          stream << std::endl;
         }
 
         /* Restore the AST representation mode */

--- a/src/libtriton/engines/lifters/liftingToSMT.cpp
+++ b/src/libtriton/engines/lifters/liftingToSMT.cpp
@@ -160,8 +160,10 @@ namespace triton {
           auto& e = ssa[id];
           stream << e->getFormattedExpression();
           if (icomment && !e->getDisassembly().empty()) {
-            if (!e->getComment().empty())
-            {
+            if (e->getComment().empty()) {
+              stream << " ; ";
+            }
+            else {
               stream << " - ";
             }
             stream << e->getDisassembly();

--- a/src/libtriton/engines/lifters/liftingToSMT.cpp
+++ b/src/libtriton/engines/lifters/liftingToSMT.cpp
@@ -114,7 +114,7 @@ namespace triton {
       }
 
 
-      std::ostream& LiftingToSMT::liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_) {
+      std::ostream& LiftingToSMT::liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_, bool icomment) {
         /* Save the AST representation mode */
         triton::ast::representations::mode_e mode = this->astCtxt->getRepresentationMode();
         this->astCtxt->setRepresentationMode(triton::ast::representations::SMT_REPRESENTATION);
@@ -157,7 +157,16 @@ namespace triton {
 
         /* Print symbolic expressions */
         for (const auto& id : symExprs) {
-          stream << ssa[id]->getFormattedExpression() << std::endl;
+          auto& e = ssa[id];
+          stream << e->getFormattedExpression();
+          if (icomment && !e->getDisassembly().empty()) {
+            if (!e->getComment().empty())
+            {
+              stream << " - ";
+            }
+            stream << e->getDisassembly();
+          }
+          stream << std::endl;
         }
 
         if (assert_) {

--- a/src/libtriton/includes/triton/api.hpp
+++ b/src/libtriton/includes/triton/api.hpp
@@ -679,11 +679,11 @@ namespace triton {
         //! [**lifting api**] - Lifts a symbolic expression and all its references to LLVM format. `fname` represents the name of the LLVM function.
         TRITON_EXPORT std::ostream& liftToLLVM(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, const char* fname="__triton", bool optimize=false);
 
-        //! [**lifting api**] - Lifts a symbolic expression and all its references to Python format.
-        TRITON_EXPORT std::ostream& liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr);
+        //! [**lifting api**] - Lifts a symbolic expression and all its references to Python format. If `icomment` is true, then print instructions assembly in expression comments.
+        TRITON_EXPORT std::ostream& liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool icomment=false);
 
-        //! [**lifting api**] - Lifts a symbolic expression and all its references to SMT format. If `assert_` is true, then (assert <expr>).
-        TRITON_EXPORT std::ostream& liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_);
+        //! [**lifting api**] - Lifts a symbolic expression and all its references to SMT format. If `assert_` is true, then (assert <expr>). If `icomment` is true, then print instructions assembly in expression comments.
+        TRITON_EXPORT std::ostream& liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_=false, bool icomment=false);
 
         //! [**lifting api**] - Lifts an AST and all its references to Dot format.
         TRITON_EXPORT std::ostream& liftToDot(std::ostream& stream, const triton::ast::SharedAbstractNode& node);

--- a/src/libtriton/includes/triton/liftingToPython.hpp
+++ b/src/libtriton/includes/triton/liftingToPython.hpp
@@ -57,8 +57,8 @@ namespace triton {
           //! Constructor.
           TRITON_EXPORT LiftingToPython(const triton::ast::SharedAstContext& astCtxt, triton::engines::symbolic::SymbolicEngine* symbolic);
 
-          //! Lifts a symbolic expression and all its references to Python format.
-          TRITON_EXPORT std::ostream& liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr);
+          //! Lifts a symbolic expression and all its references to Python format. If `icomment` is true, then print instructions assembly in expression comments.
+          TRITON_EXPORT std::ostream& liftToPython(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool icomment=false);
       };
 
     /*! @} End of lifters namespace */

--- a/src/libtriton/includes/triton/liftingToSMT.hpp
+++ b/src/libtriton/includes/triton/liftingToSMT.hpp
@@ -57,8 +57,8 @@ namespace triton {
           //! Constructor.
           TRITON_EXPORT LiftingToSMT(const triton::ast::SharedAstContext& astCtxt, triton::engines::symbolic::SymbolicEngine* symbolic);
 
-          //! Lifts a symbolic expression and all its references to SMT format. If `assert_` is true, then (assert <expr>).
-          TRITON_EXPORT std::ostream& liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_);
+          //! Lifts a symbolic expression and all its references to SMT format. If `assert_` is true, then (assert <expr>). If `icomment` is true, then print instructions assembly in expression comments.
+          TRITON_EXPORT std::ostream& liftToSMT(std::ostream& stream, const triton::engines::symbolic::SharedSymbolicExpression& expr, bool assert_=false, bool icomment=false);
       };
 
     /*! @} End of lifters namespace */


### PR DESCRIPTION
This PR brings back #982 for new lifting engine. One is able to use boolean argument to enable instruction assembly printing for symbolic expressions.

Closes #1133