### PR TITLE
[WIP] Add support for building Python Wheel packages

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,121 @@
+name: Build Python Package
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build-nix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip version
+        run: |
+          python -m pip install -U pip
+
+      - name: Install build package
+        run: |
+          python -m pip install build
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install python-setuptools
+
+      - name: Download Z3
+        run: |
+          wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.17/z3-4.8.17-x64-glibc-2.31.zip
+          unzip z3-4.8.17-x64-glibc-2.31.zip
+
+      - name: Install Capstone
+        run: |
+          wget https://github.com/aquynh/capstone/archive/4.0.2.tar.gz
+          tar -xf ./4.0.2.tar.gz
+          cd ./capstone-4.0.2
+          bash ./make.sh
+          sudo make install
+          cd ../
+
+      - name: Build Triton Python package
+        run: python -m build --wheel
+        env:
+          Z3_INCLUDE_DIRS: ${{ github.workspace }}/z3-4.8.17-x64-glibc-2.31/include
+          Z3_LIBRARIES: ${{ github.workspace }}/z3-4.8.17-x64-glibc-2.31/bin/libz3.a
+          CAPSTONE_INCLUDE_DIRS: /usr/include
+          CAPSTONE_LIBRARIES: /usr/lib/libcapstone.a
+
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: triton_library-1.0.0-cp38-cp38-linux_x86_64.whl
+          path: ${{ github.workspace }}/dist/triton_library-1.0.0-cp38-cp38-linux_x86_64.whl
+          if-no-files-found: warn
+
+  build-win:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get CMake
+        uses: lukka/get-cmake@latest
+
+      - name: Setup Windows dev environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: 'x64'
+
+      - name: Upgrade pip version
+        run: |
+          python -m pip install -U pip
+
+      - name: Install build package
+        run: |
+          python -m pip install build
+
+      - name: Download and build Z3
+        run: |
+          wget -UseBasicParsing https://github.com/Z3Prover/z3/releases/download/z3-4.8.17/z3-4.8.17-x64-win.zip -O z3-4.8.17-x64-win.zip
+          tar -xf z3-4.8.17-x64-win.zip
+          wget -UseBasicParsing https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.17.zip -O z3-4.8.17.zip
+          tar -xf z3-4.8.17.zip
+          cd z3-z3-4.8.17
+          python scripts\mk_make.py --x64 --staticlib
+          cd build
+          nmake
+        shell: powershell
+
+      - name: Download Capstone
+        run: |
+          wget -UseBasicParsing https://github.com/capstone-engine/capstone/releases/download/4.0.2/capstone-4.0.2-win64.zip -O capstone-4.0.2-win64.zip
+          tar -xf capstone-4.0.2-win64.zip
+        shell: powershell
+
+      - name: Build Triton Python package
+        run: |
+          python -c "import os; import sys; print(os.path.dirname(sys.executable))" >> $PYTHON_DIR
+          echo "$PYTHON_DIR\include" >> $PYTHON_INCLUDE_DIRS
+          echo "$PYTHON_DIR\libs\python38.lib" >> $PYTHON_LIBRARIES
+          python -m build --wheel
+        env:
+          Z3_INCLUDE_DIRS: ${{ github.workspace }}\z3-4.8.17-x64-win\include
+          Z3_LIBRARIES: ${{ github.workspace }}\z3-z3-4.8.17\build\libz3-static.lib
+          CAPSTONE_INCLUDE_DIRS: ${{ github.workspace }}\capstone-4.0.2-win64\include
+          CAPSTONE_LIBRARIES: ${{ github.workspace }}\capstone-4.0.2-win64\capstone.lib
+
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: triton_library-1.0.0-cp39-cp39-win_amd64.whl
+          path: ${{ github.workspace }}/dist/triton_library-1.0.0-cp39-cp39-win_amd64.whl
+          if-no-files-found: warn

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,144 @@
+import os
+import platform
+import re
+import subprocess
+import sys
+
+from distutils.file_util import copy_file
+from distutils.version import LooseVersion
+from setuptools import Extension
+from setuptools import setup
+from setuptools.command.build_ext import build_ext
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        ext = self.extensions[0]
+        self.build_extension(ext)
+        self.copy_extension_to_source(ext)
+
+    def build_extension(self, ext):
+        ext_dir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+
+        # Set platform-agnostric arguments.
+        cmake_args = [
+            # General arguments.
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + ext_dir,
+            '-DPYTHON_EXECUTABLE=' + sys.executable,
+            '-DCMAKE_BUILD_TYPE=Release',
+            # Common arguments.
+            '-DZ3_INTERFACE=On',
+            '-DBOOST_INTERFACE=Off',
+            '-DLLVM_INTERFACE=Off',
+        ]
+
+        build_args = []
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''), self.distribution.get_version())
+
+        # Set platform-specific arguments.
+        if platform.system() == "Linux":
+            cmake_args = [
+                '-DBITWUZLA_INTERFACE=Off',
+            ]
+            build_args += ['--', '-j4']
+        elif platform.system() == "Windows":
+            cmake_args += [
+                '-DBITWUZLA_INTERFACE=Off',
+                '-G Visual Studio 17 2022',
+            ]
+            build_args += ['--', '/m:4']
+        else:
+            raise Exception(f'Platform not supported: {platform.system()}')
+
+        # Custom Python paths.
+        if os.getenv('PYTHON_LIBRARIES'):
+            cmake_args += ['-DPYTHON_LIBRARIES=' + os.getenv('PYTHON_LIBRARIES')]
+
+        if os.getenv('PYTHON_INCLUDE_DIRS'):
+            cmake_args += ['-DPYTHON_INCLUDE_DIRS=' + os.getenv('PYTHON_INCLUDE_DIRS')]
+
+        # Custom Z3 paths.
+        if os.getenv('Z3_LIBRARIES'):
+            cmake_args += ['-DZ3_LIBRARIES=' + os.getenv('Z3_LIBRARIES')]
+
+        if os.getenv('Z3_INCLUDE_DIRS'):
+            cmake_args += ['-DZ3_INCLUDE_DIRS=' + os.getenv('Z3_INCLUDE_DIRS')]
+
+        # Custom Bitwuzla paths.
+        if os.getenv('BITWUZLA_LIBRARIES'):
+            cmake_args += ['-DBITWUZLA_LIBRARIES=' + os.getenv('BITWUZLA_LIBRARIES')]
+
+        if os.getenv('BITWUZLA_INCLUDE_DIRS'):
+            cmake_args += ['-DBITWUZLA_INCLUDE_DIRS=' + os.getenv('BITWUZLA_INCLUDE_DIRS')]
+
+        # Custom Capstone paths.
+        if os.getenv('CAPSTONE_LIBRARIES'):
+            cmake_args += ['-DCAPSTONE_LIBRARIES=' + os.getenv('CAPSTONE_LIBRARIES')]
+
+        if os.getenv('CAPSTONE_INCLUDE_DIRS'):
+            cmake_args += ['-DCAPSTONE_INCLUDE_DIRS=' + os.getenv('CAPSTONE_INCLUDE_DIRS')]
+
+        # Create temp and lib folders.
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+
+        if not os.path.exists(self.build_lib):
+            os.makedirs(self.build_lib)
+
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.', '--config', 'Release', '--target', 'python-triton'] + build_args, cwd=self.build_temp)
+
+    def copy_extension_to_source(self, ext):
+        fullname = self.get_ext_fullname(ext.name)
+        filename = self.get_ext_filename(fullname)
+
+        if platform.system() == "Linux":
+            src_filename = os.path.join(self.build_temp + '/src/libtriton', 'triton.so')
+            dst_filename = os.path.join(self.build_lib, os.path.basename(filename))
+        elif platform.system() == "Windows":
+            src_filename = os.path.join(self.build_temp + '\\src\\libtriton\\Release', 'triton.pyd')
+            dst_filename = os.path.join(self.build_lib, os.path.basename(filename))
+        else:
+            raise Exception(f'Platform not supported: {platform.system()}')
+
+        copy_file(src_filename, dst_filename, verbose=self.verbose, dry_run=self.dry_run)
+
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+
+setup(
+    name="triton-library",
+    version="1.0.0",
+    author="Jonathan Salwan",
+    author_email="jonathan.salwan@gmail.com",
+    description="Triton is a dynamic binary analysis library",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    license = "Apache License Version 2.0",
+    license_files = ('LICENSE.txt',),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: POSIX :: Linux"
+    ],
+    python_requires='>=3.6',
+    project_urls={
+        'Homepage': 'https://triton-library.github.io/',
+        'Source': 'https://github.com/jonathansalwan/Triton',
+    },
+    ext_modules=[
+        CMakeExtension('triton', sourcedir='.')
+    ],
+    cmdclass=dict(build_ext=CMakeBuild),
+    zip_safe=False,
+    install_requires=[]
+)


### PR DESCRIPTION
This is the first step to provide users the chance to install Triton using `pip` (`pip install triton-library`).

This PR adds a `setup.py` script with support for Linux and Windows. Now you can build and install Triton's Python package by running `pip install .` from Triton's main folder. This will invoke `cmake`, `cmake --build` and then install the generated package.

It is possible to set custom builds for `Z3`, `Bitwuzla` and `Capstone` using environment variables (for example, `Z3_INCLUDE_DIRS` and `Z3_LIBRARIES}`). I tried this on Ubuntu and Windows (for Python 3.8) and it seems to be working fine.

You can also generate the `.whl` package in Linux by running:

```bash
# Install build package
pip install build
# Set environment variables for custom build (if you want/need)
export Z3_LIBRARIES=<path/to/z3/lib>
export Z3_INCLUDE_DIRS=<path/to/z3/include>
# ...
# Build the .whl package
python -m build --wheel
```

This PR also adds a workflow for building Triton's Python packages for both Linux and Windows (currently, it generates two artifacts: `triton_library-1.0.0-cp38-cp38-linux_x86_64.whl` and `triton_library-1.0.0-cp39-cp39-win_amd64.whl`). The goal is to build the Python packages with `Z3` and `Bitwuzla` linked statically for both Linux and Windows, and to use `wide-integer` instead of `Boost`, in order to make them as standalone as possible.

Pending tasks:

1. Build Bitwuzla in the workflow (WIP)
2. Link Visual C++ Runtime statically
3. Use VCPKG to build the packages
4. Add support for macOS
5. Tweaks here and there (for instance, provide builds for more Python versions)

Any help on the following will be much appreciated! :

* Item 2. This shouldn't be hard but as I'm not very familiar with Windows development I don't know which is the right way to do it.
* Item 3. Ideally, we should use something similar to the `cmake.yml` workflow. As I'm not familiar with VCPKG I went for the "standard" approach. However, the VCPKG seems like a better way to do it.
* Item 4. I don't have a working environment to test this but I don't think it will differ much from the Linux one.
