### PR TITLE
Exclude symbolic results from exceptions

### DIFF
--- a/src/libtriton/arch/x86/x86Semantics.cpp
+++ b/src/libtriton/arch/x86/x86Semantics.cpp
@@ -5459,7 +5459,7 @@ namespace triton {
             /* Apply the taint */
             expr->isTainted = this->taintEngine->taintUnion(ax, src);
             /* Divide error */
-            if (result->evaluate() > 0xff) {
+            if (!result->isSymbolized() && result->evaluate() > 0xff) {
               this->exception = triton::arch::FAULT_DE;
               return;
             }
@@ -5485,7 +5485,7 @@ namespace triton {
             /* Apply the taint for DX */
             expr2->isTainted = this->taintEngine->taintUnion(dx, src);
             /* Divide error */
-            if (temp->evaluate() > 0xffff) {
+            if (!temp->isSymbolized() && temp->evaluate() > 0xffff) {
               this->exception = triton::arch::FAULT_DE;
               return;
             }
@@ -5511,7 +5511,7 @@ namespace triton {
             /* Apply the taint for EDX */
             expr2->isTainted = this->taintEngine->taintUnion(edx, src);
             /* Divide error */
-            if (temp->evaluate() > 0xffffffff) {
+            if (!temp->isSymbolized() && temp->evaluate() > 0xffffffff) {
               this->exception = triton::arch::FAULT_DE;
               return;
             }
@@ -5537,7 +5537,7 @@ namespace triton {
             /* Apply the taint for EDX */
             expr2->isTainted = this->taintEngine->taintUnion(rdx, src);
             /* Divide error */
-            if (temp->evaluate() > 0xffffffffffffffff) {
+            if (!temp->isSymbolized() && temp->evaluate() > 0xffffffffffffffff) {
               this->exception = triton::arch::FAULT_DE;
               return;
             }
@@ -5555,7 +5555,7 @@ namespace triton {
         this->undefined_s(inst, this->architecture->getRegister(ID_REG_X86_ZF));
 
         /* Return an exception if the divisor is zero */
-        if (divisor->evaluate() == 0) {
+        if (!divisor->isSymbolized() && (divisor->evaluate() == 0)) {
           this->exception = triton::arch::FAULT_DE;
           return;
         }
@@ -7170,6 +7170,11 @@ namespace triton {
             auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, ax, "IDIV operation");
             /* Apply the taint */
             expr->isTainted = this->taintEngine->taintUnion(ax, src);
+            /* Divide error */
+            if (!result->isSymbolized() && result->evaluate() > 0xff) {
+              this->exception = triton::arch::FAULT_DE;
+              return;
+            }
             break;
           }
 
@@ -7191,6 +7196,11 @@ namespace triton {
             auto expr2 = this->symbolicEngine->createSymbolicExpression(inst, mod, dx, "IDIV operation");
             /* Apply the taint for DX */
             expr2->isTainted = this->taintEngine->taintUnion(dx, src);
+            /* Divide error */
+            if (!temp->isSymbolized() && temp->evaluate() > 0xffff) {
+              this->exception = triton::arch::FAULT_DE;
+              return;
+            }
             break;
           }
 
@@ -7212,6 +7222,11 @@ namespace triton {
             auto expr2 = this->symbolicEngine->createSymbolicExpression(inst, mod, edx, "IDIV operation");
             /* Apply the taint for EDX */
             expr2->isTainted = this->taintEngine->taintUnion(edx, src);
+            /* Divide error */
+            if (!temp->isSymbolized() && temp->evaluate() > 0xffffffff) {
+              this->exception = triton::arch::FAULT_DE;
+              return;
+            }
             break;
           }
 
@@ -7233,6 +7248,11 @@ namespace triton {
             auto expr2 = this->symbolicEngine->createSymbolicExpression(inst, mod, rdx, "IDIV operation");
             /* Apply the taint for EDX */
             expr2->isTainted = this->taintEngine->taintUnion(rdx, src);
+            /* Divide error */
+            if (!temp->isSymbolized() && temp->evaluate() > 0xffffffffffffffff) {
+              this->exception = triton::arch::FAULT_DE;
+              return;
+            }
             break;
           }
 
@@ -7247,7 +7267,7 @@ namespace triton {
         this->undefined_s(inst, this->architecture->getRegister(ID_REG_X86_ZF));
 
         /* Return an exception if the divisor is zero */
-        if (divisor->evaluate() == 0) {
+        if (!divisor->isSymbolized() && divisor->evaluate() == 0) {
           this->exception = triton::arch::FAULT_DE;
           return;
         }


### PR DESCRIPTION
added test cases for  #1159 

Now the results are only evaluated when they are not symbolic.
