### PR TITLE
AARCH64: Fix instruction memory access size when it's specified by instruction (ldrb, etc)

### DIFF
--- a/src/libtriton/arch/arm/aarch64/aarch64Cpu.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Cpu.cpp
@@ -463,6 +463,7 @@ namespace triton {
                   }
 
                   /* Define a base address for next operand */
+                  size = this->getMemoryOperandSpecialSize(inst.getType());
                   if (!size) {
                     size = reg.getSize();
                   }

--- a/src/libtriton/arch/arm/aarch64/aarch64Semantics.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Semantics.cpp
@@ -1749,9 +1749,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
-
           /* Create the semantics of the LOAD */
           auto node = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -1769,9 +1766,6 @@ namespace triton {
         void AArch64Semantics::ldarh_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
 
           /* Create the semantics of the LOAD */
           auto node = this->symbolicEngine->getOperandAst(inst, src);
@@ -1809,9 +1803,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
-
           /* Create the semantics of the LOAD */
           auto node = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -1829,9 +1820,6 @@ namespace triton {
         void AArch64Semantics::ldaxrh_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
 
           /* Create the semantics of the LOAD */
           auto node = this->symbolicEngine->getOperandAst(inst, src);
@@ -1965,9 +1953,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
-
           /* Create the semantics of the LOAD */
           auto node1 = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2020,9 +2005,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
-
           /* Create the semantics of the LOAD */
           auto node1 = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2074,9 +2056,6 @@ namespace triton {
         void AArch64Semantics::ldrsb_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
 
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
@@ -2133,9 +2112,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
-
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2190,9 +2166,6 @@ namespace triton {
         void AArch64Semantics::ldrsw_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 32 bits */
-          src.getMemory().setBits(31, 0);
 
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
@@ -2267,9 +2240,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
-
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2290,9 +2260,6 @@ namespace triton {
         void AArch64Semantics::ldurh_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
 
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
@@ -2315,9 +2282,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
-
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2339,9 +2303,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
-
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2362,9 +2323,6 @@ namespace triton {
         void AArch64Semantics::ldursw_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 32 bits */
-          src.getMemory().setBits(31, 0);
 
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
@@ -2405,9 +2363,6 @@ namespace triton {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
-
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2428,9 +2383,6 @@ namespace triton {
         void AArch64Semantics::ldxrh_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
 
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
@@ -3192,9 +3144,6 @@ namespace triton {
           /* Create the semantics of the STORE */
           auto node = this->symbolicEngine->getOperandAst(inst, src);
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          dst.getMemory().setBits(7, 0);
-
           /* Create symbolic expression */
           auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STLRB operation - STORE access");
 
@@ -3212,9 +3161,6 @@ namespace triton {
 
           /* Create the semantics of the STORE */
           auto node = this->symbolicEngine->getOperandAst(inst, src);
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          dst.getMemory().setBits(15, 0);
 
           /* Create symbolic expression */
           auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STLRH operation - STORE access");
@@ -3349,9 +3295,6 @@ namespace triton {
           /* Create the semantics */
           auto node1 = this->astCtxt->extract(7, 0, op);
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          dst.getMemory().setBits(7, 0);
-
           /* Create symbolic expression */
           auto expr1 = this->symbolicEngine->createSymbolicExpression(inst, node1, dst, "STRB operation - STORE access");
 
@@ -3406,9 +3349,6 @@ namespace triton {
 
           /* Create the semantics */
           auto node1 = this->astCtxt->extract(15, 0, op);
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          dst.getMemory().setBits(15, 0);
 
           /* Create symbolic expression */
           auto expr1 = this->symbolicEngine->createSymbolicExpression(inst, node1, dst, "STRH operation - STORE access");
@@ -3483,9 +3423,6 @@ namespace triton {
           /* Create the semantics */
           auto node = this->astCtxt->extract(7, 0, op);
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          dst.getMemory().setBits(7, 0);
-
           /* Create symbolic expression */
           auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STURB operation");
 
@@ -3506,9 +3443,6 @@ namespace triton {
 
           /* Create the semantics */
           auto node = this->astCtxt->extract(15, 0, op);
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          dst.getMemory().setBits(15, 0);
 
           /* Create symbolic expression */
           auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STURH operation");

--- a/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
@@ -2060,6 +2060,39 @@ namespace triton {
           return tritonId;
         }
 
+
+        triton::uint32 AArch64Specifications::getMemoryOperandSpecialSize(triton::uint32 id) const {
+          switch (id) {
+            case ID_INS_LDARB:
+            case ID_INS_LDAXRB:
+            case ID_INS_LDRB:
+            case ID_INS_LDRSB:
+            case ID_INS_LDURB:
+            case ID_INS_LDURSB:
+            case ID_INS_LDXRB:
+            case ID_INS_STLRB:
+            case ID_INS_STRB:
+            case ID_INS_STURB:
+              return 1;
+            case ID_INS_LDARH:
+            case ID_INS_LDAXRH:
+            case ID_INS_LDRH:
+            case ID_INS_LDRSH:
+            case ID_INS_LDURH:
+            case ID_INS_LDURSH:
+            case ID_INS_LDXRH:
+            case ID_INS_STLRH:
+            case ID_INS_STRH:
+            case ID_INS_STURH:
+              return 2;
+            case ID_INS_LDRSW:
+            case ID_INS_LDURSW:
+              return 4;
+            default:
+              return 0;
+          }
+        }
+
       }; /* aarch64 namespace */
     }; /* arm namespace */
   }; /* arch namespace */

--- a/src/libtriton/arch/arm/arm32/arm32Cpu.cpp
+++ b/src/libtriton/arch/arm/arm32/arm32Cpu.cpp
@@ -350,7 +350,8 @@ namespace triton {
                   triton::arch::MemoryAccess mem;
 
                   /* Set the size of the memory access */
-                  mem.setBits(triton::bitsize::dword-1, 0);
+                  triton::uint32 size = this->getMemoryOperandSpecialSize(inst.getType());
+                  mem.setBits(size ? ((size * triton::bitsize::byte) - 1) : triton::bitsize::dword-1, 0);
 
                   /* LEA if exists */
                   const triton::arch::Register base(*this, this->capstoneRegisterToTritonRegister(op->mem.base));

--- a/src/libtriton/arch/arm/arm32/arm32Semantics.cpp
+++ b/src/libtriton/arch/arm/arm32/arm32Semantics.cpp
@@ -1987,9 +1987,6 @@ namespace triton {
           auto& dst = inst.operands[0];
           auto& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
-
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2094,9 +2091,6 @@ namespace triton {
           auto& dst = inst.operands[0];
           auto& src = inst.operands[1];
 
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
-
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
 
@@ -2200,9 +2194,6 @@ namespace triton {
         void Arm32Semantics::ldrsb_s(triton::arch::Instruction& inst) {
           auto& dst = inst.operands[0];
           auto& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          src.getMemory().setBits(7, 0);
 
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
@@ -2444,9 +2435,6 @@ namespace triton {
         void Arm32Semantics::ldrsh_s(triton::arch::Instruction& inst)  {
           auto& dst = inst.operands[0];
           auto& src = inst.operands[1];
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          src.getMemory().setBits(15, 0);
 
           /* Create symbolic operands */
           auto op = this->symbolicEngine->getOperandAst(inst, src);
@@ -4079,9 +4067,6 @@ namespace triton {
           /* Create symbolic operands */
           auto op = this->getArm32SourceOperandAst(inst, src);
 
-          /* Special behavior: Define that the size of the memory access is 8 bits */
-          dst.getMemory().setBits(7, 0);
-
           /* Create the semantics */
           auto node  = this->astCtxt->extract(7, 0, op);
           auto node1 = this->buildConditionalSemantics(inst, dst, node);
@@ -4309,9 +4294,6 @@ namespace triton {
 
           /* Create symbolic operands */
           auto op = this->getArm32SourceOperandAst(inst, src);
-
-          /* Special behavior: Define that the size of the memory access is 16 bits */
-          dst.getMemory().setBits(15, 0);
 
           /* Create the semantics */
           auto node1 = this->astCtxt->extract(15, 0, op);

--- a/src/libtriton/arch/arm/arm32/arm32Specifications.cpp
+++ b/src/libtriton/arch/arm/arm32/arm32Specifications.cpp
@@ -1946,6 +1946,22 @@ namespace triton {
           return tritonId;
         }
 
+
+        triton::uint32 Arm32Specifications::getMemoryOperandSpecialSize(triton::uint32 id) const {
+          switch (id) {
+            case ID_INS_LDRB:
+            case ID_INS_LDRSB:
+            case ID_INS_STRB:
+              return 1;
+            case ID_INS_LDRH:
+            case ID_INS_LDRSH:
+            case ID_INS_STRH:
+              return 2;
+            default:
+              return 0;
+          }
+        }
+
       }; /* arm32 namespace */
     }; /* arm namespace */
   }; /* arch namespace */

--- a/src/libtriton/includes/triton/aarch64Specifications.hpp
+++ b/src/libtriton/includes/triton/aarch64Specifications.hpp
@@ -75,6 +75,9 @@ namespace triton {
 
             //! Converts a capstone's instruction id to a triton's instruction id.
             TRITON_EXPORT triton::uint32 capstoneInstructionToTritonInstruction(triton::uint32 id) const;
+
+            //! Returns memory access size if it is specified by instruction.
+            TRITON_EXPORT triton::uint32 getMemoryOperandSpecialSize(triton::uint32 id) const;
         };
 
         //! AArch64 NOP instruction

--- a/src/libtriton/includes/triton/arm32Specifications.hpp
+++ b/src/libtriton/includes/triton/arm32Specifications.hpp
@@ -72,6 +72,9 @@ namespace triton {
 
             //! Converts a capstone's instruction id to a triton's instruction id.
             TRITON_EXPORT triton::uint32 capstoneInstructionToTritonInstruction(triton::uint32 id) const;
+
+            //! Returns memory access size if it is specified by instruction.
+            TRITON_EXPORT triton::uint32 getMemoryOperandSpecialSize(triton::uint32 id) const;
         };
 
         //! ARM32 NOP instruction


### PR DESCRIPTION
When disassembling load/store instructions memory access size is set according to the destination register size. This is wrong for some instructions like ldrb w8, [sp, #0xc] as it takes only 1 byte.