### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ Note that if you use AppVeyor's artefacts, you probably have to install the [Vis
 packages for Visual Studio 2012.
 
 
+### Installing from vcpkg
+
+The triton port in vcpkg is kept up to date by Microsoft team members and community contributors. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install triton using the vcpkg dependency manager:
+
+```shell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install triton
+```
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 # Contributors
 
 Triton is strongly powered by [Quarkslab](https://quarkslab.com) for years but also by several contributors:


### PR DESCRIPTION
Triton is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for triton and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build triton, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/triton/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.