### PR TITLE
Set clang for Bitwuzla build on Python workflow

### DIFF
--- a/src/scripts/docker/Dockerfile
+++ b/src/scripts/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN DEBIAN_FRONTEND="noninteractive" \
     apt-get install -y  --no-install-suggests --no-install-recommends \
         build-essential \
         ca-certificates \
+        clang-11 \
         cmake \
         git-core \
         less \

--- a/src/scripts/docker/build-wheel-linux.sh
+++ b/src/scripts/docker/build-wheel-linux.sh
@@ -31,11 +31,10 @@ cd ..
 # Download and build Bitwuzla.
 git clone https://github.com/bitwuzla/bitwuzla.git
 cd bitwuzla
-git checkout 9c79f32cafef01cfd88330c54e9a6d5ec3606888    # NOTE Newer commits use C++ features not supported by the default version of g++.
 ./contrib/setup-cadical.sh
 ./contrib/setup-btor2tools.sh
 ./contrib/setup-symfpu.sh
-./configure.sh --shared --prefix $(pwd)/install
+CC=clang-11 CXX=clang++-11 ./configure.sh --shared --prefix $(pwd)/install
 cd build
 make
 make install


### PR DESCRIPTION
Long term solution for building Bitwuzla on Python workflow.