### PR TITLE
Fix call semantics

### DIFF
--- a/src/libtriton/arch/x86/x86Semantics.cpp
+++ b/src/libtriton/arch/x86/x86Semantics.cpp
@@ -4020,18 +4020,17 @@ namespace triton {
 
 
       void x86Semantics::call_s(triton::arch::Instruction& inst) {
-        auto stack = this->architecture->getStackPointer();
-
-        /* Create the semantics - side effect */
-        auto  stackValue = alignSubStack_s(inst, stack.getSize());
-        auto  pc         = triton::arch::OperandWrapper(this->architecture->getProgramCounter());
-        auto  sp         = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue, stack.getSize()));
         auto& src        = inst.operands[0];
 
         /* Create symbolic operands */
         auto op1 = this->symbolicEngine->getOperandAst(inst, src);
 
         /* Create the semantics - side effect */
+        auto stack      = this->architecture->getStackPointer();
+        auto stackValue = alignSubStack_s(inst, stack.getSize());
+        auto pc         = triton::arch::OperandWrapper(this->architecture->getProgramCounter());
+        auto sp         = triton::arch::OperandWrapper(triton::arch::MemoryAccess(stackValue, stack.getSize()));
+
         auto node1 = this->astCtxt->bv(inst.getNextAddress(), pc.getBitSize());
 
         /* Create the semantics */

--- a/src/testers/unittests/test_callback.py
+++ b/src/testers/unittests/test_callback.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-from triton import (TritonContext, ARCH, CALLBACK, Instruction)
+from triton import (TritonContext, ARCH, CALLBACK, Instruction, MemoryAccess)
 
 
 class TestCallback(unittest.TestCase):
@@ -85,3 +85,27 @@ class TestCallback(unittest.TestCase):
         self.Triton.removeCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, self.method_callback)
         cb_new_refcnt = tuple(sys.getrefcount(x) for x in (cb, cb.__self__, cb.__func__))
         self.assertTrue(cb_initial_refcnt == cb_new_refcnt)
+
+    def test_call_rsp_issue(self):
+        def test_call(add_callback):
+            def get_concrete_memory_value_hook(ctx, mem):
+                pass
+
+            ctx = TritonContext(ARCH.X86_64)
+
+            rsp = 0xeffffd80
+
+            ctx.setConcreteMemoryValue(MemoryAccess(rsp + 0x48, 8), 0x41c8e0)
+            ctx.setConcreteMemoryValue(MemoryAccess(rsp + 0x50, 8), 0x41c910)
+
+            ctx.setConcreteRegisterValue(ctx.registers.rsp, rsp)
+
+            if add_callback:
+                ctx.addCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, get_concrete_memory_value_hook)
+
+            ctx.processing(Instruction(0x41C690, b"\xff\x54\x24\x50"))  # call qword ptr [rsp + 0x50]
+
+            self.assertTrue(ctx.getConcreteRegisterValue(ctx.registers.rip) == 0x41c910)
+
+        test_call(False)
+        test_call(True)


### PR DESCRIPTION
Hey @JonathanSalwan o/ There is an issue with the semantics of `call`. It has an odd behavoir that depends on whether a `GET_CONCRETE_MEMORY_VALUE` callback is set. The following snippet exposes the issue:

```python
from triton import *

def test_call(add_callback):
    def get_concrete_memory_value_hook(ctx, mem):
        print(f'\tInside callback, mem: {mem}')

    ctx = TritonContext(ARCH.X86_64)

    rsp = 0xeffffd80

    ctx.setConcreteMemoryValue(MemoryAccess(rsp + 0x48, 8), 0x41c8e0)
    ctx.setConcreteMemoryValue(MemoryAccess(rsp + 0x50, 8), 0x41c910)

    ctx.setConcreteRegisterValue(ctx.registers.rsp, 0xeffffd80)

    print(f"\t[rsp + 0x48]([{rsp + 0x48:#x}]) = {ctx.getConcreteMemoryValue(MemoryAccess(rsp + 0x48, 8)):#x}")
    print(f"\t[rsp + 0x50]([{rsp + 0x50:#x}]) = {ctx.getConcreteMemoryValue(MemoryAccess(rsp + 0x50, 8)):#x}")

    if add_callback:
        ctx.addCallback(CALLBACK.GET_CONCRETE_MEMORY_VALUE, get_concrete_memory_value_hook)

    inst = Instruction(0x41C690, b"\xff\x54\x24\x50")   # call qword ptr [rsp + 0x50]

    ctx.processing(inst)

    print(f'\t{inst}')

    print(f'\trip: {ctx.getConcreteRegisterValue(ctx.registers.rip):x}')

print('[+] Without setting the callback: ')
test_call(False)

print('[+] Setting the callback: ')
test_call(True)
```

This is the output:

```
[+] Without setting the callback:
    [rsp + 0x48]([0xeffffdc8]) = 0x41c8e0
    [rsp + 0x50]([0xeffffdd0]) = 0x41c910
    0x41c690: call qword ptr [rsp + 0x50]
    rip: 41c910
[+] Setting the callback:
    [rsp + 0x48]([0xeffffdc8]) = 0x41c8e0
    [rsp + 0x50]([0xeffffdd0]) = 0x41c910
    Inside callback, mem: [@0xeffffdd0]:64 bv[63..0]
    0x41c690: call qword ptr [rsp + 0x50]
    rip: 41c8e0
```

The address of mem access varies when the callback is set (the first is the correct one, which can be determine by the value that ends up in `rip` and not the value that is shown by the callback). The reason why it happens when the callback is set is because after calling the callback, `processCallback` sets the `leaAst` of the memory access. The first thing done in `call_s` is aligning the stack to reserve space for holding the return address. After that the AST for the memory access is computed. This AST is affected by what the `processCallback` does. When the callback is set it takes into account the stack alignment.

This PR fixes this (by reserving the space after building the AST of the mem access in `call_s`) for this but I wanted to double check with you that I'm not missing anything here.