### PR TITLE
Store instruction address in symbolic expression created from instructions.

### DIFF
--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -973,6 +973,7 @@ namespace triton {
         if (this->isAlignedMode() && this->isArrayMode() == false) {
           const SharedSymbolicExpression& aligned = this->newSymbolicExpression(node, MEMORY_EXPRESSION, "Aligned optimization - " + comment);
           aligned->setOriginMemory(mem);
+          aligned->setAddress(inst.getAddress());
           this->addAlignedMemory(address, writeSize, aligned);
           /* Refresh the current id to not link the aligned expression to the instruction */
           id = this->uniqueSymExprId;
@@ -1003,12 +1004,14 @@ namespace triton {
             auto cell = this->astCtxt->store(this->astCtxt->reference(this->getMemoryArray()), final_ea, tmp);
             this->memoryArray = this->newSymbolicExpression(cell, MEMORY_EXPRESSION, "Byte reference - " + comment);
             this->memoryArray->setOriginMemory(triton::arch::MemoryAccess((address + writeSize) - 1, triton::size::byte));
+            this->memoryArray->setAddress(inst.getAddress());
             this->addBitvectorMemory((address + writeSize) - 1, this->memoryArray);
           }
           /* Symbolic bitvector */
           else {
             se = this->newSymbolicExpression(tmp, MEMORY_EXPRESSION, "Byte reference - " + comment);
             se->setOriginMemory(triton::arch::MemoryAccess(((address + writeSize) - 1), triton::size::byte));
+            se->setAddress(inst.getAddress());
             this->addBitvectorMemory((address + writeSize) - 1, se);
           }
 
@@ -1027,6 +1030,7 @@ namespace triton {
 
         /* Keep a symbolic expression that represents the original store assignment */
         se = this->newSymbolicExpression(node, MEMORY_EXPRESSION, "Original memory access - " + comment);
+        se->setAddress(inst.getAddress());
         se->setOriginMemory(mem);
 
         return this->addSymbolicExpressions(inst, id);
@@ -1116,6 +1120,7 @@ namespace triton {
       const SharedSymbolicExpression& SymbolicEngine::createSymbolicVolatileExpression(triton::arch::Instruction& inst, const triton::ast::SharedAbstractNode& node, const std::string& comment) {
         triton::usize id = this->uniqueSymExprId;
         const SharedSymbolicExpression& se = this->newSymbolicExpression(node, VOLATILE_EXPRESSION, comment);
+        se->setAddress(inst.getAddress());
         return this->addSymbolicExpressions(inst, id);
       }
 

--- a/src/libtriton/engines/symbolic/symbolicEngine.cpp
+++ b/src/libtriton/engines/symbolic/symbolicEngine.cpp
@@ -1104,6 +1104,7 @@ namespace triton {
         SharedSymbolicExpression se = nullptr;
 
         se = this->newSymbolicExpression(this->insertSubRegisterInParent(reg, node), REGISTER_EXPRESSION, comment);
+        se->setAddress(inst.getAddress());
         this->assignSymbolicExpressionToRegister(se, this->architecture->getParentRegister(reg));
 
         inst.setWrittenRegister(reg, node);

--- a/src/libtriton/engines/symbolic/symbolicExpression.cpp
+++ b/src/libtriton/engines/symbolic/symbolicExpression.cpp
@@ -28,6 +28,7 @@ namespace triton {
           originRegister() {
         this->ast           = node;
         this->comment       = comment;
+        this->address       = 0;
         this->id            = id;
         this->isTainted     = false;
         this->type          = type;
@@ -42,6 +43,7 @@ namespace triton {
         this->originMemory   = other.originMemory;
         this->originRegister = other.originRegister;
         this->type           = other.type;
+        this->address        = other.address;
       }
 
 
@@ -53,6 +55,7 @@ namespace triton {
         this->originMemory   = other.originMemory;
         this->originRegister = other.originRegister;
         this->type           = other.type;
+        this->address        = other.address;
         return *this;
       }
 
@@ -222,6 +225,16 @@ namespace triton {
 
       void SymbolicExpression::setComment(const std::string& comment) {
         this->comment = comment;
+      }
+
+
+      void SymbolicExpression::setAddress(const uint64_t address) {
+        this->address = address;
+      }
+
+
+      uint64_t SymbolicExpression::getAddress() const {
+        return this->address;
       }
 
 

--- a/src/libtriton/includes/triton/symbolicExpression.hpp
+++ b/src/libtriton/includes/triton/symbolicExpression.hpp
@@ -56,6 +56,9 @@ namespace triton {
           //! The comment of the symbolic expression.
           std::string comment;
 
+          //! The address of the instruction behind the symbolic expression. 0 if empty.
+          uint64_t address;
+
           //! The instruction disassembly where the symbolic expression comes from.
           std::string disassembly;
 
@@ -138,6 +141,12 @@ namespace triton {
 
           //! Sets the kind of the symbolic expression.
           TRITON_EXPORT void setType(triton::engines::symbolic::expression_e type);
+
+          //! Sets the symbolic expression address.
+          TRITON_EXPORT void setAddress(const uint64_t address);
+
+          //! Get the address of the symbolic expression, if any.
+          TRITON_EXPORT uint64_t getAddress() const;
 
           //! Sets the origin memory acccess.
           TRITON_EXPORT void setOriginMemory(const triton::arch::MemoryAccess& mem);


### PR DESCRIPTION
Hey @JonathanSalwan,

This is a small proposal, and hopefully a small enough change. If you could give some feedback it would be much appreciated :)

Currently, apart the disassembly string, symbolic expressions don't have any information regarding the original instruction that was used for lifting. Having the original address embedded in the symbolic expression would be useful to do backtracking using the backward slicing functionality (through `sliceExpressions`)

For example: looking at the dead store elimination simplification, it seems there's a [small hack](https://github.com/JonathanSalwan/Triton/blob/2b655f20528065cf70e0fa95e2d01b34a8ef6a17/src/libtriton/engines/symbolic/symbolicSimplification.cpp#L263) parsing the disassembly string to retrieve the original instruction address.

If we keep this information in the symbolic expression this would not be required.

- I've mainly added an `address` field to the `SymbolicExpression` object. With a setter and a getter. And everytime a new expression is created from an instruction we set this value.
- If address is unknown, it is set to 0. Maybe we could also use a `std::optional` instead of a `uint64_t` to reflect the absence of address?
- Maybe I could just put the `setAddress(getAddress())` in `Instruction::addSymbolicExpression`. But from an ownership point of view it feels better if it is set as it is done in this PR.