### PR TITLE
Reduce AstNode hash collisions

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -2671,7 +2671,12 @@ namespace triton {
 
 
     void IntegerNode::initHash(void) {
-      this->hash = static_cast<triton::uint64>(this->type) ^ this->value;
+      static const triton::uint512 even_flag = (triton::uint512(1) << 64) | 1;
+      if ((this->value & 1) == 0) {
+        this->hash = static_cast<triton::uint64>(this->type) ^ this->value;
+      } else {
+        this->hash = static_cast<triton::uint64>(this->type) ^ this->value ^ (even_flag);
+      }
     }
 
 
@@ -3473,7 +3478,7 @@ namespace triton {
     triton::uint512 rotl(const triton::uint512& value, triton::uint32 shift) {
       if ((shift &= 511) == 0)
         return value;
-      return ((value << shift) | (value >> (512 - shift)));
+      return ((value << shift) | (value >> (512 - shift))) | 1;
     }
 
 

--- a/src/libtriton/includes/triton/astEnums.hpp
+++ b/src/libtriton/includes/triton/astEnums.hpp
@@ -32,7 +32,7 @@ namespace triton {
       ASSERT_NODE = 3,                /*!< (assert x) */
       BSWAP_NODE = 5,                 /*!< (bswap x) */
       BVADD_NODE = 7,                 /*!< (bvadd x y) */
-      BVAND_NODE = 12,                /*!< (bvand x y) */
+      BVAND_NODE = 13,                /*!< (bvand x y) */
       BVASHR_NODE = 17,               /*!< (bvashr x y) */
       BVLSHR_NODE = 19,               /*!< (bvlshr x y) */
       BVMUL_NODE = 23,                /*!< (bvmul x y) */
@@ -42,7 +42,7 @@ namespace triton {
       BVNOT_NODE = 41,                /*!< (bvnot x) */
       BVOR_NODE = 43,                 /*!< (bvor x y) */
       BVROL_NODE = 47,                /*!< ((_ rotate_left x) y) */
-      BVROR_NODE = 52,                /*!< ((_ rotate_right x) y) */
+      BVROR_NODE = 53,                /*!< ((_ rotate_right x) y) */
       BVSDIV_NODE = 59,               /*!< (bvsdiv x y) */
       BVSGE_NODE = 61,                /*!< (bvsge x y) */
       BVSGT_NODE = 67,                /*!< (bvsgt x y) */


### PR DESCRIPTION
- ast_e should all be prime (per the existing comment in ast.hpp)
- even values appear to poorly affect triton::ast::hash2n, therefore updated IntegerNode and triton::ast::rotl to (naively) ensure the hash value is odd.

### Rationale

Disclaimer: I am not a mathematician

Here is the existing hash2n:
https://github.com/JonathanSalwan/Triton/blob/48de90d395a626c6247f0d71abd6cac1290daf62/src/libtriton/ast/ast.cpp#L3465-L3470

Problem:
```
>>> def hash2n(h, n):
...     mask = (1 << 512)-1
...     for i in range(n):
...         h = (h*h) & mask
...     return h
...
>>> hex(hash2n(0x234567634254235abcdef347429930357493234568, 6))
'0xe5e18ae21077c93b662e1178fad20e6f28cb5ec2729268fd1fdcee1eba6a4aa98d0ba763cc453901000000000000000000000000000000000000000000000000'
>>> hex(hash2n(0x234567634254235abcdef347429930357493234568, 8))
'0x0'
>>> hex(hash2n(0x234567634254235abcdef347429930357493234569, 6))
'0x51c42032b604df2f5518592a48f2c8a77f8514bad777283e7e8c56c8855115221358021fdc912b71bc7bf2344f908b2d0e6ddab534f3bd1e0bf69fb856e9201'
```
