### PR TITLE
Switch to CMake's `Python3` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ private/*
 *.so
 .cache
 .vscode
+dist/
+*.egg-info/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,18 +46,56 @@ add_custom_target(check
 
 if(PYTHON_BINDINGS)
     message(STATUS "Compiling with Python bindings")
+
+    if(NOT PYTHON_VERSION AND NOT PYTHON_EXECUTABLE)
+        # Find the python version the user has in the PATH
+        # This prevents an issue where an unexpected python version is used
+        # (eg the system/homebrew python in a virtual environment)
+        find_program(PYTHON_EXECUTABLE
+            NAMES python3 python
+            NO_PACKAGE_ROOT_PATH
+            NO_CMAKE_PATH
+            NO_CMAKE_ENVIRONMENT_PATH
+            NO_CMAKE_SYSTEM_PATH
+            NO_CMAKE_INSTALL_PREFIX
+            REQUIRED
+        )
+    endif()
+
+    if(PYTHON_EXECUTABLE)
+        # Make sure the specified python is not fully broken
+        execute_process(COMMAND ${PYTHON_EXECUTABLE} --version
+            RESULT_VARIABLE PYTHON_RESULT
+            OUTPUT_QUIET
+        )
+        if(NOT PYTHON_RESULT EQUAL 0)
+            message(FATAL_ERROR "Broken python: ${PYTHON_EXECUTABLE}")
+        endif()
+    endif()
+
+    # Set the hints for the Python3 package
+    # Reference: https://cmake.org/cmake/help/latest/module/FindPython3.html#hints
+    # The PYTHON_XXX variables are not used by FindPython3, but they are translated
+    # for backwards compatibility with previous Triton versions
+    set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE}")
+    if(PYTHON_LIBRARY)
+        set(Python3_LIBRARY "${PYTHON_LIBRARY}")
+    elseif(PYTHON_LIBRARIES)
+        set(Python3_LIBRARY "${PYTHON_LIBRARIES}")
+    endif()
+    if(PYTHON_INCLUDE_DIRS)
+        set(Python3_INCLUDE_DIR "${PYTHON_INCLUDE_DIRS}")
+    endif()
+    set(Python3_FIND_VIRTUALENV "FIRST")
+
+    find_package(Python3 ${PYTHON_VERSION} COMPONENTS Interpreter Development REQUIRED)
+    message(STATUS "Python3 includes: ${Python3_INCLUDE_DIRS}")
+    message(STATUS "Python3 libraries: ${Python3_LIBRARIES}")
+
+    # For backwards compatibility with existing CMake
+    set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+    
     set(PYTHONPATH_CMD ${CMAKE_COMMAND} -E env PYTHONPATH=$<TARGET_FILE_DIR:triton>/)
-    if(NOT PYTHON_VERSION)
-        set(PYTHON_VERSION 3.6)
-    endif()
-    if(NOT PYTHON_EXECUTABLE)
-        find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
-    endif()
-    if(NOT PYTHON_LIBRARIES AND NOT PYTHON_INCLUDE_DIRS)
-        find_package(PythonLibs ${PYTHON_VERSION} REQUIRED)
-    endif()
-    include_directories(${PYTHON_INCLUDE_DIRS})
-    add_definitions("-DPYTHON_LIBRARIES=\"${PYTHON_LIBRARIES}\"")
     add_custom_target(test-python
         COMMAND ${PYTHONPATH_CMD} ${PYTHON_EXECUTABLE} -m unittest discover ${TRITON_ROOT}/src/testers/unittests
         DEPENDS python-triton

--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -272,13 +272,16 @@ target_include_directories(triton BEFORE PUBLIC
 
 # Link Triton's dependencies
 target_link_libraries(triton PUBLIC
-    ${PYTHON_LIBRARIES}
     ${Boost_LIBRARIES}
     ${Z3_LIBRARIES}
     ${LLVM_LIBRARIES}
     ${BITWUZLA_LIBRARIES}
     ${CAPSTONE_LIBRARIES}
 )
+
+if(PYTHON_BINDINGS)
+    target_link_libraries(triton PRIVATE Python3::Module)
+endif()
 
 # Workaround to allow building 'namespace linux' (defined by -std=gnu++11)
 if(NOT MSVC AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))


### PR DESCRIPTION
The `find_package(PythonInterp)` and `find_package(PythonLibs)` are deprecated and on my system they were returning results from two different python versions installed (interpreter from my PATH and libraries from homebrew's python). This caused me to run into this (very confusing) error: https://github.com/JonathanSalwan/Triton/issues/1145#issuecomment-1206549486

The `Python3` package fixed this behaviour and I made sure to keep the interface compatible (`PYTHON_XXX` variables work the same). The default behaviour (you just run `cmake -B build`) now also finds the python the user would expect (the one that's currently in the PATH) and things are working properly from a virtual environment. Here is a `requirements.txt` to test:

```
git+https://github.com/mrexodia/Triton@8ee04d36ff732f0a89dfe7609806ad45addc0e45#egg=triton-library
```