### PR TITLE
Expose CPU memory from cpuInterface.

### DIFF
--- a/src/libtriton/arch/architecture.cpp
+++ b/src/libtriton/arch/architecture.cpp
@@ -172,6 +172,12 @@ namespace triton {
       return this->cpu->getAllRegisters();
     }
 
+    const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& Architecture::getAllMemory(void) const {
+      if (!this->cpu)
+        throw triton::exceptions::Architecture("Architecture::getAllMemory(): You must define an architecture.");
+      return this->cpu->getAllMemory();
+    }
+
 
     std::set<const triton::arch::Register*> Architecture::getParentRegisters(void) const {
       if (!this->cpu)

--- a/src/libtriton/arch/arm/aarch64/aarch64Cpu.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Cpu.cpp
@@ -285,6 +285,10 @@ namespace triton {
           return this->id2reg;
         }
 
+        const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& AArch64Cpu::getAllMemory(void) const {
+          return this->memory;
+        }
+
 
         std::set<const triton::arch::Register*> AArch64Cpu::getParentRegisters(void) const {
           std::set<const triton::arch::Register*> ret;

--- a/src/libtriton/arch/arm/arm32/arm32Cpu.cpp
+++ b/src/libtriton/arch/arm/arm32/arm32Cpu.cpp
@@ -181,6 +181,10 @@ namespace triton {
           return this->id2reg;
         }
 
+        const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& Arm32Cpu::getAllMemory(void) const {
+          return this->memory;
+        }
+
 
         std::set<const triton::arch::Register*> Arm32Cpu::getParentRegisters(void) const {
           std::set<const triton::arch::Register*> ret;

--- a/src/libtriton/arch/x86/x8664Cpu.cpp
+++ b/src/libtriton/arch/x86/x8664Cpu.cpp
@@ -394,6 +394,10 @@ namespace triton {
         return this->id2reg;
       }
 
+      const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& x8664Cpu::getAllMemory(void) const {
+        return this->memory;
+      }
+
 
       std::set<const triton::arch::Register*> x8664Cpu::getParentRegisters(void) const {
         std::set<const triton::arch::Register*> ret;

--- a/src/libtriton/arch/x86/x86Cpu.cpp
+++ b/src/libtriton/arch/x86/x86Cpu.cpp
@@ -323,6 +323,10 @@ namespace triton {
         return this->id2reg;
       }
 
+      const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& x86Cpu::getAllMemory(void) const {
+        return this->memory;
+      }
+
 
       std::set<const triton::arch::Register*> x86Cpu::getParentRegisters(void) const {
         std::set<const triton::arch::Register*> ret;

--- a/src/libtriton/context/context.cpp
+++ b/src/libtriton/context/context.cpp
@@ -349,6 +349,11 @@ namespace triton {
     return this->arch.getAllRegisters();
   }
 
+  const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& Context::getAllMemory(void) const {
+    this->checkArchitecture();
+    return this->arch.getAllMemory();
+  }
+
 
   std::set<const triton::arch::Register*> Context::getParentRegisters(void) const {
     this->checkArchitecture();

--- a/src/libtriton/includes/triton/aarch64Cpu.hpp
+++ b/src/libtriton/includes/triton/aarch64Cpu.hpp
@@ -261,6 +261,7 @@ namespace triton {
             TRITON_EXPORT bool isThumb(void) const;
             TRITON_EXPORT bool isMemoryExclusive(const triton::arch::MemoryAccess& mem) const;
             TRITON_EXPORT const std::unordered_map<triton::arch::register_e, const triton::arch::Register>& getAllRegisters(void) const;
+            TRITON_EXPORT const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& getAllMemory(void) const;
             TRITON_EXPORT const triton::arch::Register& getParentRegister(const triton::arch::Register& reg) const;
             TRITON_EXPORT const triton::arch::Register& getParentRegister(triton::arch::register_e id) const;
             TRITON_EXPORT const triton::arch::Register& getProgramCounter(void) const;

--- a/src/libtriton/includes/triton/architecture.hpp
+++ b/src/libtriton/includes/triton/architecture.hpp
@@ -118,6 +118,9 @@ namespace triton {
         //! Returns all registers.
         TRITON_EXPORT const std::unordered_map<triton::arch::register_e, const triton::arch::Register>& getAllRegisters(void) const;
 
+        //! Return all memory.
+        TRITON_EXPORT const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& getAllMemory(void) const;
+
         //! Returns all parent registers.
         TRITON_EXPORT std::set<const triton::arch::Register*> getParentRegisters(void) const;
 

--- a/src/libtriton/includes/triton/arm32Cpu.hpp
+++ b/src/libtriton/includes/triton/arm32Cpu.hpp
@@ -174,6 +174,7 @@ namespace triton {
             TRITON_EXPORT bool isThumb(void) const;
             TRITON_EXPORT bool isMemoryExclusive(const triton::arch::MemoryAccess& mem) const;
             TRITON_EXPORT const std::unordered_map<triton::arch::register_e, const triton::arch::Register>& getAllRegisters(void) const;
+            TRITON_EXPORT const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& getAllMemory(void) const;
             TRITON_EXPORT const triton::arch::Register& getParentRegister(const triton::arch::Register& reg) const;
             TRITON_EXPORT const triton::arch::Register& getParentRegister(triton::arch::register_e id) const;
             TRITON_EXPORT const triton::arch::Register& getProgramCounter(void) const;

--- a/src/libtriton/includes/triton/context.hpp
+++ b/src/libtriton/includes/triton/context.hpp
@@ -178,6 +178,9 @@ namespace triton {
         //! [**architecture api**] - Returns all registers. \sa triton::arch::x86::register_e.
         TRITON_EXPORT const std::unordered_map<triton::arch::register_e, const triton::arch::Register>& getAllRegisters(void) const;
 
+        //! [**architecture api**] - Returns all memory.
+        TRITON_EXPORT const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& getAllMemory(void) const;
+
         //! [**architecture api**] - Returns all parent registers. \sa triton::arch::x86::register_e.
         TRITON_EXPORT std::set<const triton::arch::Register*> getParentRegisters(void) const;
 

--- a/src/libtriton/includes/triton/cpuInterface.hpp
+++ b/src/libtriton/includes/triton/cpuInterface.hpp
@@ -86,6 +86,9 @@ namespace triton {
         //! Returns all registers.
         TRITON_EXPORT virtual const std::unordered_map<triton::arch::register_e, const triton::arch::Register>& getAllRegisters(void) const = 0;
 
+        //! Return all memory.
+        TRITON_EXPORT virtual const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& getAllMemory(void) const = 0;
+
         //! Returns parent register from a given one.
         TRITON_EXPORT virtual const triton::arch::Register& getParentRegister(const triton::arch::Register& reg) const = 0;
 

--- a/src/libtriton/includes/triton/x8664Cpu.hpp
+++ b/src/libtriton/includes/triton/x8664Cpu.hpp
@@ -331,6 +331,7 @@ namespace triton {
           TRITON_EXPORT bool isThumb(void) const;
           TRITON_EXPORT bool isMemoryExclusive(const triton::arch::MemoryAccess& mem) const;
           TRITON_EXPORT const std::unordered_map<triton::arch::register_e, const triton::arch::Register>& getAllRegisters(void) const;
+          TRITON_EXPORT const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& getAllMemory(void) const;
           TRITON_EXPORT const triton::arch::Register& getParentRegister(const triton::arch::Register& reg) const;
           TRITON_EXPORT const triton::arch::Register& getParentRegister(triton::arch::register_e id) const;
           TRITON_EXPORT const triton::arch::Register& getProgramCounter(void) const;

--- a/src/libtriton/includes/triton/x86Cpu.hpp
+++ b/src/libtriton/includes/triton/x86Cpu.hpp
@@ -264,6 +264,7 @@ namespace triton {
           TRITON_EXPORT bool isThumb(void) const;
           TRITON_EXPORT bool isMemoryExclusive(const triton::arch::MemoryAccess& mem) const;
           TRITON_EXPORT const std::unordered_map<triton::arch::register_e, const triton::arch::Register>& getAllRegisters(void) const;
+          TRITON_EXPORT const std::unordered_map<triton::uint64, triton::uint8, IdentityHash<triton::uint64>>& getAllMemory(void) const;
           TRITON_EXPORT const triton::arch::Register& getParentRegister(const triton::arch::Register& reg) const;
           TRITON_EXPORT const triton::arch::Register& getParentRegister(triton::arch::register_e id) const;
           TRITON_EXPORT const triton::arch::Register& getProgramCounter(void) const;


### PR DESCRIPTION
Currently there's no way to const copy cpu memory without invoking copy constructor. This pull request adds `getAllMemory` api which returns const reference to an existing std::unordered_map. 