### PR TITLE
don't convert icmp to logical node; operator is applied to arguments of the wrong sort

### DIFF
--- a/src/libtriton/ast/llvm/llvmToTriton.cpp
+++ b/src/libtriton/ast/llvm/llvmToTriton.cpp
@@ -70,16 +70,16 @@ namespace triton {
             auto RHS = this->do_convert(instruction->getOperand(1));
             if (icmp != nullptr) {
               switch (icmp->getPredicate()) {
-                case llvm::ICmpInst::ICMP_EQ:   return this->actx->equal(LHS, RHS);
-                case llvm::ICmpInst::ICMP_NE:   return this->actx->distinct(LHS, RHS);
-                case llvm::ICmpInst::ICMP_UGE:  return this->actx->bvuge(LHS, RHS);
-                case llvm::ICmpInst::ICMP_UGT:  return this->actx->bvugt(LHS, RHS);
-                case llvm::ICmpInst::ICMP_ULE:  return this->actx->bvule(LHS, RHS);
-                case llvm::ICmpInst::ICMP_ULT:  return this->actx->bvult(LHS, RHS);
-                case llvm::ICmpInst::ICMP_SGE:  return this->actx->bvsge(LHS, RHS);
-                case llvm::ICmpInst::ICMP_SGT:  return this->actx->bvsgt(LHS, RHS);
-                case llvm::ICmpInst::ICMP_SLE:  return this->actx->bvsle(LHS, RHS);
-                case llvm::ICmpInst::ICMP_SLT:  return this->actx->bvslt(LHS, RHS);
+                case llvm::ICmpInst::ICMP_EQ:   return this->actx->ite(this->actx->equal(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_NE:   return this->actx->ite(this->actx->distinct(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_UGE:  return this->actx->ite(this->actx->bvuge(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_UGT:  return this->actx->ite(this->actx->bvugt(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_ULE:  return this->actx->ite(this->actx->bvule(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_ULT:  return this->actx->ite(this->actx->bvult(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_SGE:  return this->actx->ite(this->actx->bvsge(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_SGT:  return this->actx->ite(this->actx->bvsgt(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_SLE:  return this->actx->ite(this->actx->bvsle(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_SLT:  return this->actx->ite(this->actx->bvslt(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
                 default:
                   break;
               }

--- a/src/libtriton/ast/llvm/llvmToTriton.cpp
+++ b/src/libtriton/ast/llvm/llvmToTriton.cpp
@@ -70,16 +70,16 @@ namespace triton {
             auto RHS = this->do_convert(instruction->getOperand(1));
             if (icmp != nullptr) {
               switch (icmp->getPredicate()) {
-                case llvm::ICmpInst::ICMP_EQ:   return this->actx->ite(this->actx->equal(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_NE:   return this->actx->ite(this->actx->distinct(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_UGE:  return this->actx->ite(this->actx->bvuge(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_UGT:  return this->actx->ite(this->actx->bvugt(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_ULE:  return this->actx->ite(this->actx->bvule(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_ULT:  return this->actx->ite(this->actx->bvult(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_SGE:  return this->actx->ite(this->actx->bvsge(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_SGT:  return this->actx->ite(this->actx->bvsgt(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_SLE:  return this->actx->ite(this->actx->bvsle(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
-                case llvm::ICmpInst::ICMP_SLT:  return this->actx->ite(this->actx->bvslt(LHS, RHS), this->actx->bvtrue(), this->actx->bvfalse());
+                case llvm::ICmpInst::ICMP_EQ:   return this->actx->equal(LHS, RHS);
+                case llvm::ICmpInst::ICMP_NE:   return this->actx->distinct(LHS, RHS);
+                case llvm::ICmpInst::ICMP_UGE:  return this->actx->bvuge(LHS, RHS);
+                case llvm::ICmpInst::ICMP_UGT:  return this->actx->bvugt(LHS, RHS);
+                case llvm::ICmpInst::ICMP_ULE:  return this->actx->bvule(LHS, RHS);
+                case llvm::ICmpInst::ICMP_ULT:  return this->actx->bvult(LHS, RHS);
+                case llvm::ICmpInst::ICMP_SGE:  return this->actx->bvsge(LHS, RHS);
+                case llvm::ICmpInst::ICMP_SGT:  return this->actx->bvsgt(LHS, RHS);
+                case llvm::ICmpInst::ICMP_SLE:  return this->actx->bvsle(LHS, RHS);
+                case llvm::ICmpInst::ICMP_SLT:  return this->actx->bvslt(LHS, RHS);
                 default:
                   break;
               }
@@ -123,6 +123,12 @@ namespace triton {
             /* Final size */
             auto size = instruction->getType()->getIntegerBitWidth();
             auto node = this->do_convert(instruction->getOperand(0));
+
+            /* Handle the case where node is logical */
+            if (node->isLogical()) {
+              node = this->actx->ite(node, this->actx->bvtrue(), this->actx->bvfalse());
+            }
+
             /* Size of the child */
             auto csze = instruction->getOperand(0)->getType()->getIntegerBitWidth();
             return this->actx->sx(size - csze, node);
@@ -195,6 +201,12 @@ namespace triton {
             /* Final size */
             auto size = instruction->getType()->getIntegerBitWidth();
             auto node = this->do_convert(instruction->getOperand(0));
+
+            /* Handle the case where node is logical */
+            if (node->isLogical()) {
+              node = this->actx->ite(node, this->actx->bvtrue(), this->actx->bvfalse());
+            }
+
             /* Size of the child */
             auto csze = instruction->getOperand(0)->getType()->getIntegerBitWidth();
             return this->actx->zx(size - csze, node);


### PR DESCRIPTION
```
terminate called after throwing an instance of 'triton::exceptions::SolverEngine'
  what():  Z3Solver::getModels(): operator is applied to arguments of the wrong sort
```

Hello. I encountered a bug when trying to lift llvm ir to triton and then to z3 expression.
llvm:
```
%a = trunc i64 %rdx to i32
%b = icmp eq %a, 0
%c = zext i1 %b to i64
ret i64 %c
```
Invalid z3 expression:
```
((_ zero_extend 63) (distinct ((_ extract 31 0) rdx) (_ bv0 32)))
```
I'm not z3 expert but not using logical node in `icmp` handler fixes this error.