### PR TITLE
Fix GitHub workflows

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla
           cd bitwuzla
+          git checkout -b 19dd987a6e246990619751cca07996fac505fd0b 19dd987a6e246990619751cca07996fac505fd0b
           ./contrib/setup-cadical.sh
           ./contrib/setup-btor2tools.sh
           ./contrib/setup-symfpu.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla
           cd bitwuzla
+          git checkout -b 19dd987a6e246990619751cca07996fac505fd0b 19dd987a6e246990619751cca07996fac505fd0b
           ./contrib/setup-cadical.sh
           ./contrib/setup-btor2tools.sh
           ./contrib/setup-symfpu.sh

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Download and build GMP
         run: |
-          wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
+          wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz
           tar xvf gmp-6.2.1.tar.xz
           cd gmp-6.2.1/
           ./configure --with-pic
@@ -46,6 +46,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla.git
           cd bitwuzla
+          git checkout -b 19dd987a6e246990619751cca07996fac505fd0b 19dd987a6e246990619751cca07996fac505fd0b
           ./contrib/setup-cadical.sh
           ./contrib/setup-btor2tools.sh
           ./contrib/setup-symfpu.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,44 +12,43 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # FIXME
-      #- name: Create Docker image
-      #  run: bash ./src/scripts/docker/build-docker-image.sh
+      - name: Create Docker image
+        run: bash ./src/scripts/docker/build-docker-image.sh
 
-      #- name: Build Wheel packages
-      #  run: |
-      #    docker run \
-      #           --rm \
-      #           -v $GITHUB_WORKSPACE:/src \
-      #           build-triton-linux-x86_64 bash /src/src/scripts/docker/build-wheel-linux.sh
+      - name: Build Wheel packages
+        run: |
+         docker run \
+                --rm \
+                -v $GITHUB_WORKSPACE:/src \
+                build-triton-linux-x86_64 bash /src/src/scripts/docker/build-wheel-linux.sh
 
-      #- name: Upload Wheel packages (Python 3.8)
-      #  uses: actions/upload-artifact@v3
-      #  with:
-      #    name: triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_24_x86_64.whl
-      #    path: wheel-final/triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_24_x86_64.whl
-      #    if-no-files-found: warn
+      - name: Upload Wheel packages (Python 3.8)
+        uses: actions/upload-artifact@v3
+        with:
+          name: triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_24_x86_64.whl
+          path: wheel-final/triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_24_x86_64.whl
+          if-no-files-found: warn
 
-      #- name: Upload Wheel packages (Python 3.9)
-      #  uses: actions/upload-artifact@v3
-      #  with:
-      #    name: triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_24_x86_64.whl
-      #    path: wheel-final/triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_24_x86_64.whl
-      #    if-no-files-found: warn
+      - name: Upload Wheel packages (Python 3.9)
+        uses: actions/upload-artifact@v3
+        with:
+          name: triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_24_x86_64.whl
+          path: wheel-final/triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_24_x86_64.whl
+          if-no-files-found: warn
 
-      #- name: Upload Wheel packages (Python 3.10)
-      #  uses: actions/upload-artifact@v3
-      #  with:
-      #    name: triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_24_x86_64.whl
-      #    path: wheel-final/triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_24_x86_64.whl
-      #    if-no-files-found: warn
+      - name: Upload Wheel packages (Python 3.10)
+        uses: actions/upload-artifact@v3
+        with:
+          name: triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_24_x86_64.whl
+          path: wheel-final/triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_24_x86_64.whl
+          if-no-files-found: warn
 
-      #- name: Upload Wheel packages (Python 3.11)
-      #  uses: actions/upload-artifact@v3
-      #  with:
-      #    name: triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_24_x86_64.whl
-      #    path: wheel-final/triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_24_x86_64.whl
-      #    if-no-files-found: warn
+      - name: Upload Wheel packages (Python 3.11)
+        uses: actions/upload-artifact@v3
+        with:
+          name: triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_24_x86_64.whl
+          path: wheel-final/triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_24_x86_64.whl
+          if-no-files-found: warn
 
 
   # FIXME

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ RUN cd /tmp && \
     && ln -s /usr/lib/libcapstone.so.4 /usr/lib/x86_64-linux-gnu/libcapstone.so
 
 # libbitwuzla
-RUN cd /tmp && \ 
+RUN cd /tmp && \
     git clone https://github.com/bitwuzla/bitwuzla && \
     cd bitwuzla && \
+    git checkout -b 19dd987a6e246990619751cca07996fac505fd0b 19dd987a6e246990619751cca07996fac505fd0b && \
     ./contrib/setup-cadical.sh && \
     ./contrib/setup-btor2tools.sh && \
     ./contrib/setup-symfpu.sh && \
@@ -28,14 +29,14 @@ RUN cd /tmp && \
 RUN cd /tmp && \
     curl -o z3.tgz -L https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.14.tar.gz && \
     tar zxf z3.tgz && cd z3-z3-4.8.14 && mkdir build && cd build && \
-    CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4 && make install && \ 
+    CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4 && make install && \
     pip3 install z3-solver && rm -rf /tmp/z3*
 
 # Triton (LLVM for lifting; z3 or bitwuzla as SMT solver)
 RUN git clone https://github.com/JonathanSalwan/Triton && cd Triton && mkdir build && cd build && cmake -DLLVM_INTERFACE=ON -DCMAKE_PREFIX_PATH=$(/usr/lib/llvm-12/bin/llvm-config --prefix) -DZ3_INTERFACE=ON -DBITWUZLA_INTERFACE=ON .. && make -j4 && make install
 
 RUN PYV=`python3 -c "import platform;print(platform.python_version()[:3])"` && \
-    PYP="/usr/lib/python$PYV/site-packages" && \ 
+    PYP="/usr/lib/python$PYV/site-packages" && \
     echo export PYTHONPATH="$PYP:\$PYTHONPATH" >> /etc/bash.bashrc && \
     python3 -c "import z3; print('Z3 version:', z3.get_version_string())" && \
     # Next command fails if Triton has no z3 or bitwuzla support

--- a/src/scripts/docker/Dockerfile
+++ b/src/scripts/docker/Dockerfile
@@ -2,6 +2,11 @@ ARG BASE_IMG
 
 FROM $BASE_IMG
 
+# Update sources.list (as Debian Stretch is now archived). 
+RUN echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian/ stretch-proposed-updates main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
+
 # Download and install basic dependencies.
 RUN apt-get update
 

--- a/src/scripts/docker/build-wheel-linux.sh
+++ b/src/scripts/docker/build-wheel-linux.sh
@@ -19,7 +19,7 @@ mkdir -p deps
 cd deps
 
 # Download and build GMP.
-wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
+wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz
 tar xvf gmp-6.2.1.tar.xz
 cd gmp-6.2.1/
 ./configure --enable-cxx
@@ -28,9 +28,13 @@ make check
 make install
 cd ..
 
+# NOTE Temporarily use an old Bitwuzla version. On Jun 30th Bitwuzla changed
+# its code and building system to a new one. The new version does not compile
+# in this image (manylinux_2_24_x86_64).
 # Download and build Bitwuzla.
 git clone https://github.com/bitwuzla/bitwuzla.git
 cd bitwuzla
+git checkout -b 19dd987a6e246990619751cca07996fac505fd0b 19dd987a6e246990619751cca07996fac505fd0b
 ./contrib/setup-cadical.sh
 ./contrib/setup-btor2tools.sh
 ./contrib/setup-symfpu.sh


### PR DESCRIPTION
This is a temporary fix so the workflows work again. 

We need to upgrade the docker image we use to build the Python Wheel package from `manylinux_2_24` to `manylinux_2_28`. 

There is a new Bitwuzla version which requires some changes in Triton. There has been some changes in the API and there is a new build system (which requires changes in our CI scripts).

These changes will be addressed in different PRs.