### PR TITLE
Enable parallel builds for msvc

### DIFF
--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -290,6 +290,11 @@ if(MSVC AND MSVC_STATIC)
     set_property(TARGET triton PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
+# Enable parallel building for msvc.
+if(MSVC)
+    target_compile_options(triton PRIVATE /MP)
+endif()
+
 if(WIN32 AND BUILD_SHARED_LIBS)
     target_compile_definitions(triton PRIVATE BUILDING_DLL)
 endif()


### PR DESCRIPTION
While working on the issue #532 I noticed that the build is not done in parallel as the default for parallel builds is off, see https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-170

This PR adds /MP to the compile options for msvc which significantly improves the build times.

Before:
`========== Rebuild started at 12:28 AM and took 01:25.727 minutes ==========`
After:
`========== Rebuild started at 12:30 AM and took 14.323 seconds ==========`