### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+BasedOnStyle: Webkit
+IndentWidth: 2
+Standard: Cpp11
+UseTab: Never
+TabWidth: 2
+MaxEmptyLinesToKeep: 1
+ColumnLimit: 120
+BreakBeforeBraces: Attach
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+IndentCaseLabels: true
+CompactNamespaces: false
+NamespaceIndentation: All
+AlignOperands: Align
+AlignConsecutiveAssignments: AcrossComments
+BinPackArguments: false
+PointerAlignment: Left
+ReferenceAlignment: Left
+BreakBeforeBinaryOperators: None
+AllowShortCaseLabelsOnASingleLine: true
+FixNamespaceComments: true
+AlignAfterOpenBracket: Align
+AlignTrailingComments: true
+IndentPPDirectives: BeforeHash
+IndentAccessModifiers: true
+...

--- a/src/libtriton/arch/basicBlock.cpp
+++ b/src/libtriton/arch/basicBlock.cpp
@@ -5,10 +5,8 @@
 **  This program is under the terms of the Apache License 2.0.
 */
 
-#include <triton/exceptions.hpp>
 #include <triton/basicBlock.hpp>
-
-
+#include <triton/exceptions.hpp>
 
 namespace triton {
   namespace arch {
@@ -16,27 +14,22 @@ namespace triton {
     BasicBlock::BasicBlock() {
     }
 
-
     BasicBlock::BasicBlock(const std::vector<triton::arch::Instruction>& instructions) {
       this->instructions = instructions;
     }
 
-
     BasicBlock::BasicBlock(const BasicBlock& other) {
       this->instructions = other.instructions;
     }
-
 
     BasicBlock& BasicBlock::operator=(const BasicBlock& other) {
       this->instructions = other.instructions;
       return *this;
     }
 
-
     BasicBlock::~BasicBlock() {
       this->instructions.clear();
     }
-
 
     void BasicBlock::add(const Instruction& instruction) {
       Instruction copy = instruction;
@@ -46,7 +39,6 @@ namespace triton {
       this->instructions.push_back(copy);
     }
 
-
     bool BasicBlock::remove(triton::uint32 position) {
       if (this->instructions.size() <= position)
         return false;
@@ -54,16 +46,13 @@ namespace triton {
       return true;
     }
 
-
     std::vector<triton::arch::Instruction>& BasicBlock::getInstructions(void) {
       return this->instructions;
     }
 
-
     triton::usize BasicBlock::getSize(void) const {
       return this->instructions.size();
     }
-
 
     triton::uint64 BasicBlock::getFirstAddress(void) const {
       if (this->instructions.size() == 0)
@@ -71,13 +60,11 @@ namespace triton {
       return this->instructions.front().getAddress();
     }
 
-
     triton::uint64 BasicBlock::getLastAddress(void) const {
       if (this->instructions.size() == 0)
         throw triton::exceptions::BasicBlock("BasicBlock::getLastAddress(): No instruction in the block.");
       return this->instructions.back().getAddress();
     }
-
 
     std::ostream& operator<<(std::ostream& stream, BasicBlock& block) {
       triton::usize size = block.getSize();
@@ -90,11 +77,10 @@ namespace triton {
       return stream;
     }
 
-
     std::ostream& operator<<(std::ostream& stream, BasicBlock* block) {
       stream << *block;
       return stream;
     }
 
-  };
-};
+  }; // namespace arch
+};   // namespace triton

--- a/src/libtriton/arch/instruction.cpp
+++ b/src/libtriton/arch/instruction.cpp
@@ -12,47 +12,41 @@
 #include <triton/immediate.hpp>
 #include <triton/instruction.hpp>
 
-
-
 namespace triton {
   namespace arch {
 
     Instruction::Instruction() {
-      this->address         = 0;
-      this->arch            = triton::arch::ARCH_INVALID;
-      this->branch          = false;
-      this->codeCondition   = triton::arch::arm::ID_CONDITION_INVALID;
-      this->conditionTaken  = 0;
-      this->controlFlow     = false;
-      this->prefix          = triton::arch::x86::ID_PREFIX_INVALID;
-      this->size            = 0;
-      this->tainted         = false;
-      this->thumb           = false;
-      this->tid             = 0;
-      this->type            = 0;
-      this->updateFlag      = false;
-      this->writeBack       = false;
+      this->address        = 0;
+      this->arch           = triton::arch::ARCH_INVALID;
+      this->branch         = false;
+      this->codeCondition  = triton::arch::arm::ID_CONDITION_INVALID;
+      this->conditionTaken = 0;
+      this->controlFlow    = false;
+      this->prefix         = triton::arch::x86::ID_PREFIX_INVALID;
+      this->size           = 0;
+      this->tainted        = false;
+      this->thumb          = false;
+      this->tid            = 0;
+      this->type           = 0;
+      this->updateFlag     = false;
+      this->writeBack      = false;
 
       std::memset(this->opcode, 0x00, sizeof(this->opcode));
     }
 
-
     Instruction::Instruction(const void* opcode, triton::uint32 opSize)
-      : Instruction::Instruction() {
+        : Instruction::Instruction() {
       this->setOpcode(opcode, opSize);
     }
 
-
     Instruction::Instruction(triton::uint64 addr, const void* opcode, triton::uint32 opSize)
-      : Instruction::Instruction(opcode, opSize) {
+        : Instruction::Instruction(opcode, opSize) {
       this->setAddress(addr);
     }
-
 
     Instruction::Instruction(const Instruction& other) {
       this->copy(other);
     }
-
 
     Instruction::~Instruction() {
       /* See #828: Release ownership before calling container destructor */
@@ -64,12 +58,10 @@ namespace triton {
       this->writtenRegisters.clear();
     }
 
-
     Instruction& Instruction::operator=(const Instruction& other) {
       this->copy(other);
       return *this;
     }
-
 
     void Instruction::copy(const Instruction& other) {
       this->address             = other.address;
@@ -100,109 +92,92 @@ namespace triton {
       this->disassembly.str(other.disassembly.str());
     }
 
-
     triton::uint32 Instruction::getThreadId(void) const {
       return this->tid;
     }
-
 
     void Instruction::setThreadId(triton::uint32 tid) {
       this->tid = tid;
     }
 
-
     triton::uint64 Instruction::getAddress(void) const {
       return this->address;
     }
-
 
     triton::uint64 Instruction::getNextAddress(void) const {
       return this->address + this->size;
     }
 
-
     void Instruction::setAddress(triton::uint64 addr) {
       this->address = addr;
     }
-
 
     std::string Instruction::getDisassembly(void) const {
       return this->disassembly.str();
     }
 
-
     const triton::uint8* Instruction::getOpcode(void) const {
       return this->opcode;
     }
 
-
     void Instruction::setOpcode(const void* opcode, triton::uint32 size) {
       if (size > sizeof(this->opcode))
-       throw triton::exceptions::Instruction("Instruction::setOpcode(): Invalid size (too big).");
+        throw triton::exceptions::Instruction("Instruction::setOpcode(): Invalid size (too big).");
       std::memcpy(this->opcode, opcode, size);
       this->size = size;
     }
-
 
     triton::uint32 Instruction::getSize(void) const {
       return this->size;
     }
 
-
     triton::uint32 Instruction::getType(void) const {
       return this->type;
     }
-
 
     triton::arch::architecture_e Instruction::getArchitecture(void) const {
       return this->arch;
     }
 
-
     triton::arch::x86::prefix_e Instruction::getPrefix(void) const {
       return this->prefix;
     }
-
 
     triton::arch::arm::condition_e Instruction::getCodeCondition(void) const {
       return this->codeCondition;
     }
 
-
     std::set<std::pair<triton::arch::MemoryAccess, triton::ast::SharedAbstractNode>>& Instruction::getLoadAccess(void) {
       return this->loadAccess;
     }
 
-
-    std::set<std::pair<triton::arch::MemoryAccess, triton::ast::SharedAbstractNode>>& Instruction::getStoreAccess(void) {
+    std::set<std::pair<triton::arch::MemoryAccess, triton::ast::SharedAbstractNode>>&
+    Instruction::getStoreAccess(void) {
       return this->storeAccess;
     }
-
 
     std::set<std::pair<triton::arch::Register, triton::ast::SharedAbstractNode>>& Instruction::getReadRegisters(void) {
       return this->readRegisters;
     }
 
-
-    std::set<std::pair<triton::arch::Register, triton::ast::SharedAbstractNode>>& Instruction::getWrittenRegisters(void) {
+    std::set<std::pair<triton::arch::Register, triton::ast::SharedAbstractNode>>&
+    Instruction::getWrittenRegisters(void) {
       return this->writtenRegisters;
     }
 
-
-    std::set<std::pair<triton::arch::Immediate, triton::ast::SharedAbstractNode>>& Instruction::getReadImmediates(void) {
+    std::set<std::pair<triton::arch::Immediate, triton::ast::SharedAbstractNode>>&
+    Instruction::getReadImmediates(void) {
       return this->readImmediates;
     }
-
 
     std::set<triton::arch::Register>& Instruction::getUndefinedRegisters(void) {
       return this->undefinedRegisters;
     }
 
-
-    void Instruction::setLoadAccess(const triton::arch::MemoryAccess& mem, const triton::ast::SharedAbstractNode& node) {
+    void Instruction::setLoadAccess(const triton::arch::MemoryAccess& mem,
+                                    const triton::ast::SharedAbstractNode& node) {
       this->loadAccess.insert(std::make_pair(mem, node));
     }
-
 
     void Instruction::removeLoadAccess(const triton::arch::MemoryAccess& mem) {
       auto it = this->loadAccess.begin();
@@ -215,11 +190,10 @@ namespace triton {
       }
     }
 
-
-    void Instruction::setStoreAccess(const triton::arch::MemoryAccess& mem, const triton::ast::SharedAbstractNode& node) {
+    void Instruction::setStoreAccess(const triton::arch::MemoryAccess& mem,
+                                     const triton::ast::SharedAbstractNode& node) {
       this->storeAccess.insert(std::make_pair(mem, node));
     }
-
 
     void Instruction::removeStoreAccess(const triton::arch::MemoryAccess& mem) {
       auto it = this->storeAccess.begin();
@@ -232,11 +206,9 @@ namespace triton {
       }
     }
 
-
     void Instruction::setReadRegister(const triton::arch::Register& reg, const triton::ast::SharedAbstractNode& node) {
       this->readRegisters.insert(std::make_pair(reg, node));
     }
-
 
     void Instruction::removeReadRegister(const triton::arch::Register& reg) {
       auto it = this->readRegisters.begin();
@@ -249,11 +221,10 @@ namespace triton {
       }
     }
 
-
-    void Instruction::setWrittenRegister(const triton::arch::Register& reg, const triton::ast::SharedAbstractNode& node) {
+    void Instruction::setWrittenRegister(const triton::arch::Register& reg,
+                                         const triton::ast::SharedAbstractNode& node) {
       this->writtenRegisters.insert(std::make_pair(reg, node));
     }
-
 
     void Instruction::removeWrittenRegister(const triton::arch::Register& reg) {
       auto it = this->writtenRegisters.begin();
@@ -266,11 +237,10 @@ namespace triton {
       }
     }
 
-
-    void Instruction::setReadImmediate(const triton::arch::Immediate& imm, const triton::ast::SharedAbstractNode& node) {
+    void Instruction::setReadImmediate(const triton::arch::Immediate& imm,
+                                       const triton::ast::SharedAbstractNode& node) {
       this->readImmediates.insert(std::make_pair(imm, node));
     }
-
 
     void Instruction::removeReadImmediate(const triton::arch::Immediate& imm) {
       auto it = this->readImmediates.begin();
@@ -283,67 +253,54 @@ namespace triton {
       }
     }
 
-
     void Instruction::setUndefinedRegister(const triton::arch::Register& reg) {
       this->undefinedRegisters.insert(reg);
     }
-
 
     void Instruction::removeUndefinedRegister(const triton::arch::Register& reg) {
       this->undefinedRegisters.erase(reg);
     }
 
-
     void Instruction::setArchitecture(triton::arch::architecture_e arch) {
       this->arch = arch;
     }
-
 
     void Instruction::setSize(triton::uint32 size) {
       this->size = size;
     }
 
-
     void Instruction::setType(triton::uint32 type) {
       this->type = type;
     }
-
 
     void Instruction::setPrefix(triton::arch::x86::prefix_e prefix) {
       this->prefix = prefix;
     }
 
-
     void Instruction::setWriteBack(bool state) {
       this->writeBack = state;
     }
-
 
     void Instruction::setUpdateFlag(bool state) {
       this->updateFlag = state;
     }
 
-
     void Instruction::setCodeCondition(triton::arch::arm::condition_e codeCondition) {
       this->codeCondition = codeCondition;
     }
 
-
     void Instruction::setThumb(bool state) {
       this->thumb = state;
     }
-
 
     void Instruction::setDisassembly(const std::string& str) {
       this->disassembly.clear();
       this->disassembly.str(str);
     }
 
-
     void Instruction::setTaint(bool state) {
       this->tainted = state;
     }
-
 
     void Instruction::setTaint(void) {
       for (auto it = this->symbolicExpressions.begin(); it != this->symbolicExpressions.end(); it++) {
@@ -354,7 +311,6 @@ namespace triton {
       }
     }
 
-
     void Instruction::addSymbolicExpression(const triton::engines::symbolic::SharedSymbolicExpression& expr) {
       if (expr == nullptr)
         throw triton::exceptions::Instruction("Instruction::addSymbolicExpression(): Cannot add a null expression.");
@@ -363,26 +319,21 @@ namespace triton {
       this->symbolicExpressions.push_back(expr);
     }
 
-
     bool Instruction::isBranch(void) const {
       return this->branch;
     }
-
 
     bool Instruction::isControlFlow(void) const {
       return this->controlFlow;
     }
 
-
     bool Instruction::isConditionTaken(void) const {
       return this->conditionTaken;
     }
 
-
     bool Instruction::isTainted(void) const {
       return this->tainted;
     }
-
 
     bool Instruction::isSymbolized(void) const {
       for (auto it = this->symbolicExpressions.begin(); it != this->symbolicExpressions.end(); it++) {
@@ -392,13 +343,11 @@ namespace triton {
       return false;
     }
 
-
     bool Instruction::isMemoryRead(void) const {
       if (this->loadAccess.size() >= 1)
         return true;
       return false;
     }
-
 
     bool Instruction::isMemoryWrite(void) const {
       if (this->storeAccess.size() >= 1)
@@ -406,9 +355,8 @@ namespace triton {
       return false;
     }
 
-
     bool Instruction::isReadFrom(const triton::arch::OperandWrapper& target) const {
-      switch(target.getType()) {
+      switch (target.getType()) {
 
         case triton::arch::OP_IMM:
           for (auto&& pair : this->readImmediates) {
@@ -437,19 +385,16 @@ namespace triton {
           }
           break;
 
-        default:
-          throw triton::exceptions::Instruction("Instruction::isReadFrom(): Invalid type operand.");
+        default: throw triton::exceptions::Instruction("Instruction::isReadFrom(): Invalid type operand.");
       }
 
       return false;
     }
 
-
     bool Instruction::isWriteTo(const triton::arch::OperandWrapper& target) const {
-      switch(target.getType()) {
+      switch (target.getType()) {
 
-        case triton::arch::OP_IMM:
-          break;
+        case triton::arch::OP_IMM: break;
 
         case triton::arch::OP_MEM:
           for (auto&& pair : this->storeAccess) {
@@ -471,13 +416,11 @@ namespace triton {
           }
           break;
 
-        default:
-          throw triton::exceptions::Instruction("Instruction::isWriteTo(): Invalid type operand.");
+        default: throw triton::exceptions::Instruction("Instruction::isWriteTo(): Invalid type operand.");
       }
 
       return false;
     }
-
 
     bool Instruction::isPrefixed(void) const {
       if (this->prefix == triton::arch::x86::ID_PREFIX_INVALID)
@@ -485,50 +428,43 @@ namespace triton {
       return true;
     }
 
-
     bool Instruction::isWriteBack(void) const {
       return this->writeBack;
     }
-
 
     bool Instruction::isUpdateFlag(void) const {
       return this->updateFlag;
     }
 
-
     bool Instruction::isThumb(void) const {
       return this->thumb;
     }
-
 
     void Instruction::setBranch(bool flag) {
       this->branch = flag;
     }
 
-
     void Instruction::setControlFlow(bool flag) {
       this->controlFlow = flag;
     }
-
 
     void Instruction::setConditionTaken(bool flag) {
       this->conditionTaken = flag;
     }
 
-
     void Instruction::clear(void) {
-      this->address         = 0;
-      this->branch          = false;
-      this->codeCondition   = triton::arch::arm::ID_CONDITION_INVALID;
-      this->conditionTaken  = 0;
-      this->controlFlow     = false;
-      this->prefix          = triton::arch::x86::ID_PREFIX_INVALID;
-      this->size            = 0;
-      this->tainted         = false;
-      this->tid             = 0;
-      this->type            = 0;
-      this->updateFlag      = false;
-      this->writeBack       = false;
+      this->address        = 0;
+      this->branch         = false;
+      this->codeCondition  = triton::arch::arm::ID_CONDITION_INVALID;
+      this->conditionTaken = 0;
+      this->controlFlow    = false;
+      this->prefix         = triton::arch::x86::ID_PREFIX_INVALID;
+      this->size           = 0;
+      this->tainted        = false;
+      this->tid            = 0;
+      this->type           = 0;
+      this->updateFlag     = false;
+      this->writeBack      = false;
 
       /* Clear the stringstream (See #975) */
       std::stringstream().swap(this->disassembly);
@@ -544,18 +480,17 @@ namespace triton {
       std::memset(this->opcode, 0x00, sizeof(this->opcode));
     }
 
-
     std::ostream& operator<<(std::ostream& stream, const Instruction& inst) {
       std::string dis = inst.getDisassembly();
-      stream << "0x" << std::hex << inst.getAddress() << ": " << (!dis.empty() ? dis : "<not disassembled>") << std::dec;
+      stream << "0x" << std::hex << inst.getAddress() << ": " << (!dis.empty() ? dis : "<not disassembled>")
+             << std::dec;
       return stream;
     }
-
 
     std::ostream& operator<<(std::ostream& stream, const Instruction* inst) {
       stream << *inst;
       return stream;
     }
 
-  };
-};
+  }; // namespace arch
+};   // namespace triton

--- a/src/libtriton/includes/triton/ast.hpp
+++ b/src/libtriton/includes/triton/ast.hpp
@@ -24,14 +24,12 @@
 #include <triton/exceptions.hpp>
 #include <triton/tritonTypes.hpp>
 
-
-
 //! The Triton namespace
 namespace triton {
-/*!
- *  \addtogroup triton
- *  @{
- */
+  /*!
+   *  \addtogroup triton
+   *  @{
+   */
 
   /* Forward declarations */
   namespace engines {
@@ -41,16 +39,16 @@ namespace triton {
 
       class SymbolicVariable;
       using SharedSymbolicVariable = std::shared_ptr<triton::engines::symbolic::SymbolicVariable>;
-    };
-  };
+    }; // namespace symbolic
+  };   // namespace engines
 
   //! The AST namespace
   namespace ast {
-  /*!
-   *  \ingroup triton
-   *  \addtogroup ast
-   *  @{
-   */
+    /*!
+     *  \ingroup triton
+     *  \addtogroup ast
+     *  @{
+     */
 
     class AstContext;
     class AbstractNode;
@@ -185,9 +183,8 @@ namespace triton {
         TRITON_EXPORT std::string str(void) const;
 
         //! Init properties of the node. If withParents is true, init also properties of parents
-        TRITON_EXPORT virtual void init(bool withParents=false) = 0;
+        TRITON_EXPORT virtual void init(bool withParents = false) = 0;
     };
-
 
     //! `(Array (_ BitVec indexSize) (_ BitVec 8))` node
     class ArrayNode : public AbstractNode {
@@ -205,7 +202,7 @@ namespace triton {
 
       public:
         TRITON_EXPORT ArrayNode(triton::uint32 indexSize, const SharedAstContext& ctxt);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
 
         //! Stores a concrete value into the memory array
         TRITON_EXPORT void store(triton::uint64 addr, triton::uint8 value);
@@ -226,7 +223,6 @@ namespace triton {
         TRITON_EXPORT triton::uint32 getIndexSize(void) const;
     };
 
-
     //! `(assert <expr>)` node
     class AssertNode : public AbstractNode {
       private:
@@ -234,9 +230,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT AssertNode(const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bswap <expr>)` node
     class BswapNode : public AbstractNode {
@@ -245,9 +240,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BswapNode(const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvadd <expr1> <expr2>)` node
     class BvaddNode : public AbstractNode {
@@ -256,9 +250,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvaddNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvand <expr1> <expr2>)` node
     class BvandNode : public AbstractNode {
@@ -267,9 +260,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvandNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvashr <expr1> <expr2>)` node
     class BvashrNode : public AbstractNode {
@@ -278,9 +270,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvashrNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvlshr <expr1> <expr2>)` node
     class BvlshrNode : public AbstractNode {
@@ -289,9 +280,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvlshrNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvmul <expr1> <expr2>)` node
     class BvmulNode : public AbstractNode {
@@ -300,9 +290,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvmulNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvnand <expr1> <expr2>)` node
     class BvnandNode : public AbstractNode {
@@ -311,9 +300,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvnandNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvneg <expr>)` node
     class BvnegNode : public AbstractNode {
@@ -322,9 +310,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvnegNode(const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvnor <expr1> <expr2>)` node
     class BvnorNode : public AbstractNode {
@@ -333,9 +320,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvnorNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvnot <expr>)` node
     class BvnotNode : public AbstractNode {
@@ -344,9 +330,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvnotNode(const SharedAbstractNode& expr1);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvor <expr1> <expr2>)` node
     class BvorNode : public AbstractNode {
@@ -355,9 +340,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvorNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `((_ rotate_left rot) <expr>)` node
     class BvrolNode : public AbstractNode {
@@ -367,9 +351,8 @@ namespace triton {
       public:
         TRITON_EXPORT BvrolNode(const SharedAbstractNode& expr, triton::uint32 rot);
         TRITON_EXPORT BvrolNode(const SharedAbstractNode& expr, const SharedAbstractNode& rot);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `((_ rotate_right rot) <expr>)` node
     class BvrorNode : public AbstractNode {
@@ -379,9 +362,8 @@ namespace triton {
       public:
         TRITON_EXPORT BvrorNode(const SharedAbstractNode& expr, triton::uint32 rot);
         TRITON_EXPORT BvrorNode(const SharedAbstractNode& expr, const SharedAbstractNode& rot);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvsdiv <expr1> <expr2>)` node
     class BvsdivNode : public AbstractNode {
@@ -390,9 +372,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsdivNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvsge <expr1> <expr2>)` node
     class BvsgeNode : public AbstractNode {
@@ -401,9 +382,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsgeNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvsgt <expr1> <expr2>)` node
     class BvsgtNode : public AbstractNode {
@@ -412,9 +392,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsgtNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvshl <expr1> <expr2>)` node
     class BvshlNode : public AbstractNode {
@@ -423,9 +402,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvshlNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvsle <expr1> <expr2>)` node
     class BvsleNode : public AbstractNode {
@@ -434,9 +412,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsleNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvslt <expr1> <expr2>)` node
     class BvsltNode : public AbstractNode {
@@ -445,9 +422,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsltNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvsmod <expr1> <expr2>)` node
     class BvsmodNode : public AbstractNode {
@@ -456,9 +432,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsmodNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvsrem <expr1> <expr2>)` node
     class BvsremNode : public AbstractNode {
@@ -467,9 +442,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsremNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvsub <expr1> <expr2>)` node
     class BvsubNode : public AbstractNode {
@@ -478,9 +452,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvsubNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvudiv <expr1> <expr2>)` node
     class BvudivNode : public AbstractNode {
@@ -489,9 +462,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvudivNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvuge <expr1> <expr2>)` node
     class BvugeNode : public AbstractNode {
@@ -500,9 +472,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvugeNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvugt <expr1> <expr2>)` node
     class BvugtNode : public AbstractNode {
@@ -511,9 +482,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvugtNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvule <expr1> <expr2>)` node
     class BvuleNode : public AbstractNode {
@@ -522,9 +492,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvuleNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvult <expr1> <expr2>)` node
     class BvultNode : public AbstractNode {
@@ -533,9 +502,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvultNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvurem <expr1> <expr2>)` node
     class BvuremNode : public AbstractNode {
@@ -544,9 +512,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvuremNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvxnor <expr1> <expr2>)` node
     class BvxnorNode : public AbstractNode {
@@ -555,9 +522,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvxnorNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(bvxor <expr1> <expr2>)` node
     class BvxorNode : public AbstractNode {
@@ -566,9 +532,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvxorNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(_ bv<value> <size>)` node
     class BvNode : public AbstractNode {
@@ -577,9 +542,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT BvNode(const triton::uint512& value, triton::uint32 size, const SharedAstContext& ctxt);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `[<expr1> <expr2> <expr3> ...]` node
     class CompoundNode : public AbstractNode {
@@ -587,15 +551,15 @@ namespace triton {
         TRITON_EXPORT void initHash(void);
 
       public:
-        template <typename T> CompoundNode(const T& exprs, const SharedAstContext& ctxt)
-          : AbstractNode(COMPOUND_NODE, ctxt) {
+        template <typename T>
+        CompoundNode(const T& exprs, const SharedAstContext& ctxt)
+            : AbstractNode(COMPOUND_NODE, ctxt) {
           for (auto expr : exprs)
             this->addChild(expr);
         }
 
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(concat <expr1> <expr2> ...)` node
     class ConcatNode : public AbstractNode {
@@ -603,16 +567,16 @@ namespace triton {
         TRITON_EXPORT void initHash(void);
 
       public:
-        template <typename T> ConcatNode(const T& exprs, const SharedAstContext& ctxt)
-          : AbstractNode(CONCAT_NODE, ctxt) {
+        template <typename T>
+        ConcatNode(const T& exprs, const SharedAstContext& ctxt)
+            : AbstractNode(CONCAT_NODE, ctxt) {
           for (auto expr : exprs)
             this->addChild(expr);
         }
 
         TRITON_EXPORT ConcatNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(declare-fun <var_name> () (_ BitVec <var_size>))` node
     class DeclareNode : public AbstractNode {
@@ -621,9 +585,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT DeclareNode(const SharedAbstractNode& var);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(distinct <expr1> <expr2> ...)` node
     class DistinctNode : public AbstractNode {
@@ -632,9 +595,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT DistinctNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(= <expr1> <expr2> ...)` node
     class EqualNode : public AbstractNode {
@@ -643,9 +605,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT EqualNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `((_ extract <high> <low>) <expr>)` node
     class ExtractNode : public AbstractNode {
@@ -654,9 +615,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT ExtractNode(triton::uint32 high, triton::uint32 low, const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(forall ((x (_ BitVec <size>)), ...) body)`
     class ForallNode : public AbstractNode {
@@ -664,16 +624,16 @@ namespace triton {
         TRITON_EXPORT void initHash(void);
 
       public:
-        template <typename T> ForallNode(const T& vars, const SharedAbstractNode& body)
-          : AbstractNode(FORALL_NODE, body->getContext()) {
+        template <typename T>
+        ForallNode(const T& vars, const SharedAbstractNode& body)
+            : AbstractNode(FORALL_NODE, body->getContext()) {
           for (auto var : vars)
             this->addChild(var);
           this->addChild(body);
         }
 
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(iff <expr1> <expr2>)`
     class IffNode : public AbstractNode {
@@ -682,9 +642,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT IffNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! Integer node
     class IntegerNode : public AbstractNode {
@@ -696,10 +655,9 @@ namespace triton {
 
       public:
         TRITON_EXPORT IntegerNode(const triton::uint512& value, const SharedAstContext& ctxt);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
         TRITON_EXPORT triton::uint512 getInteger(void);
     };
-
 
     //! `(ite <ifExpr> <thenExpr> <elseExpr>)`
     class IteNode : public AbstractNode {
@@ -707,10 +665,10 @@ namespace triton {
         TRITON_EXPORT void initHash(void);
 
       public:
-        TRITON_EXPORT IteNode(const SharedAbstractNode& ifExpr, const SharedAbstractNode& thenExpr, const SharedAbstractNode& elseExpr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT IteNode(const SharedAbstractNode& ifExpr, const SharedAbstractNode& thenExpr,
+                              const SharedAbstractNode& elseExpr);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(and <expr1> <expr2>)`
     class LandNode : public AbstractNode {
@@ -718,16 +676,16 @@ namespace triton {
         TRITON_EXPORT void initHash(void);
 
       public:
-        template <typename T> LandNode(const T& exprs, const SharedAstContext& ctxt)
-          : AbstractNode(LAND_NODE, ctxt) {
+        template <typename T>
+        LandNode(const T& exprs, const SharedAstContext& ctxt)
+            : AbstractNode(LAND_NODE, ctxt) {
           for (auto expr : exprs)
             this->addChild(expr);
         }
 
         TRITON_EXPORT LandNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(let ((<alias> <expr2>)) <expr3>)`
     class LetNode : public AbstractNode {
@@ -736,9 +694,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT LetNode(std::string alias, const SharedAbstractNode& expr2, const SharedAbstractNode& expr3);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(lnot <expr>)`
     class LnotNode : public AbstractNode {
@@ -747,9 +704,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT LnotNode(const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(or <expr1> <expr2>)`
     class LorNode : public AbstractNode {
@@ -757,16 +713,16 @@ namespace triton {
         TRITON_EXPORT void initHash(void);
 
       public:
-        template <typename T> LorNode(const T& exprs, const SharedAstContext& ctxt)
-          : AbstractNode(LOR_NODE, ctxt) {
+        template <typename T>
+        LorNode(const T& exprs, const SharedAstContext& ctxt)
+            : AbstractNode(LOR_NODE, ctxt) {
           for (auto expr : exprs)
             this->addChild(expr);
         }
 
         TRITON_EXPORT LorNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(xor <expr1> <expr2>)`
     class LxorNode : public AbstractNode {
@@ -774,16 +730,16 @@ namespace triton {
         TRITON_EXPORT void initHash(void);
 
       public:
-        template <typename T> LxorNode(const T& exprs, const SharedAstContext& ctxt)
-          : AbstractNode(LXOR_NODE, ctxt) {
+        template <typename T>
+        LxorNode(const T& exprs, const SharedAstContext& ctxt)
+            : AbstractNode(LXOR_NODE, ctxt) {
           for (auto expr : exprs)
             this->addChild(expr);
         }
 
         TRITON_EXPORT LxorNode(const SharedAbstractNode& expr1, const SharedAbstractNode& expr2);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! Reference node
     class ReferenceNode : public AbstractNode {
@@ -795,10 +751,9 @@ namespace triton {
 
       public:
         TRITON_EXPORT ReferenceNode(const triton::engines::symbolic::SharedSymbolicExpression& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
         TRITON_EXPORT const triton::engines::symbolic::SharedSymbolicExpression& getSymbolicExpression(void) const;
     };
-
 
     //! `(select array index)`
     class SelectNode : public AbstractNode {
@@ -808,9 +763,8 @@ namespace triton {
       public:
         TRITON_EXPORT SelectNode(const SharedAbstractNode& array, triton::usize index);
         TRITON_EXPORT SelectNode(const SharedAbstractNode& array, const SharedAbstractNode& index);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! `(store array index expr)`
     class StoreNode : public AbstractNode {
@@ -828,8 +782,9 @@ namespace triton {
 
       public:
         TRITON_EXPORT StoreNode(const SharedAbstractNode& array, triton::usize index, const SharedAbstractNode& expr);
-        TRITON_EXPORT StoreNode(const SharedAbstractNode& array, const SharedAbstractNode& index, const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT StoreNode(const SharedAbstractNode& array, const SharedAbstractNode& index,
+                                const SharedAbstractNode& expr);
+        TRITON_EXPORT void init(bool withParents = false);
 
         //! Select a concrete value into the memory array
         TRITON_EXPORT triton::uint8 select(triton::uint64 addr) const;
@@ -847,7 +802,6 @@ namespace triton {
         TRITON_EXPORT triton::uint32 getIndexSize(void) const;
     };
 
-
     //! String node
     class StringNode : public AbstractNode {
       private:
@@ -858,10 +812,9 @@ namespace triton {
 
       public:
         TRITON_EXPORT StringNode(std::string value, const SharedAstContext& ctxt);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
         TRITON_EXPORT std::string getString(void);
     };
-
 
     //! `((_ sign_extend sizeExt) <expr>)` node
     class SxNode : public AbstractNode {
@@ -870,9 +823,8 @@ namespace triton {
 
       public:
         TRITON_EXPORT SxNode(triton::uint32 sizeExt, const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
-
 
     //! Variable node
     class VariableNode : public AbstractNode {
@@ -883,11 +835,11 @@ namespace triton {
         triton::engines::symbolic::SharedSymbolicVariable symVar;
 
       public:
-        TRITON_EXPORT VariableNode(const triton::engines::symbolic::SharedSymbolicVariable& symVar, const SharedAstContext& ctxt);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT VariableNode(const triton::engines::symbolic::SharedSymbolicVariable& symVar,
+                                   const SharedAstContext& ctxt);
+        TRITON_EXPORT void init(bool withParents = false);
         TRITON_EXPORT const triton::engines::symbolic::SharedSymbolicVariable& getSymbolicVariable(void);
     };
-
 
     //! `((_ zero_extend sizeExt) <expr>)` node
     class ZxNode : public AbstractNode {
@@ -897,7 +849,7 @@ namespace triton {
       public:
         //! Create a zero extend of expr to sizeExt bits
         TRITON_EXPORT ZxNode(triton::uint32 sizeExt, const SharedAbstractNode& expr);
-        TRITON_EXPORT void init(bool withParents=false);
+        TRITON_EXPORT void init(bool withParents = false);
     };
 
     //! Custom hash2n function for hash routine.
@@ -913,19 +865,23 @@ namespace triton {
     TRITON_EXPORT std::ostream& operator<<(std::ostream& stream, AbstractNode* node);
 
     //! AST C++ API - Duplicates the AST
-    TRITON_EXPORT SharedAbstractNode newInstance(AbstractNode* node, bool unroll=false);
+    TRITON_EXPORT SharedAbstractNode newInstance(AbstractNode* node, bool unroll = false);
 
     //! AST C++ API - Unrolls the SSA form of a given AST.
     TRITON_EXPORT SharedAbstractNode unroll(const SharedAbstractNode& node);
 
-    //! Returns node and all its children of an AST sorted topologically. If `unroll` is true, references are unrolled. If `revert` is true, children are on top of list.
-    TRITON_EXPORT std::vector<SharedAbstractNode> childrenExtraction(const SharedAbstractNode& node, bool unroll, bool revert);
+    //! Returns node and all its children of an AST sorted topologically. If `unroll` is true, references are unrolled.
+    //! If `revert` is true, children are on top of list.
+    TRITON_EXPORT std::vector<SharedAbstractNode> childrenExtraction(const SharedAbstractNode& node, bool unroll,
+                                                                     bool revert);
 
-    //! Returns node and all its parents of an AST sorted topologically. If `revert` is true, oldest parents are on top of list.
+    //! Returns node and all its parents of an AST sorted topologically. If `revert` is true, oldest parents are on top
+    //! of list.
     TRITON_EXPORT std::vector<SharedAbstractNode> parentsExtraction(const SharedAbstractNode& node, bool revert);
 
     //! Returns a deque of collected matched nodes via a depth-first pre order traversal.
-    TRITON_EXPORT std::deque<SharedAbstractNode> search(const SharedAbstractNode& node, triton::ast::ast_e match=ANY_NODE);
+    TRITON_EXPORT std::deque<SharedAbstractNode> search(const SharedAbstractNode& node,
+                                                        triton::ast::ast_e match = ANY_NODE);
 
     //! Returns the first non referene node encountered.
     TRITON_EXPORT SharedAbstractNode dereference(const SharedAbstractNode& node);
@@ -949,9 +905,9 @@ namespace triton {
       throw triton::exceptions::Ast("triton::ast::getInteger(): You must provide an INTEGER_NODE.");
     }
 
-  /*! @} End of ast namespace */
-  };
-/*! @} End of triton namespace */
-};
+    /*! @} End of ast namespace */
+  }; // namespace ast
+  /*! @} End of triton namespace */
+}; // namespace triton
 
 #endif /* TRITON_AST_H */

--- a/src/libtriton/includes/triton/astEnums.hpp
+++ b/src/libtriton/includes/triton/astEnums.hpp
@@ -8,105 +8,103 @@
 #ifndef TRITON_ASTENUMS_HPP
 #define TRITON_ASTENUMS_HPP
 
-
-
 //! The Triton namespace
 namespace triton {
-/*!
- *  \addtogroup triton
- *  @{
- */
-
-  //! The AST namespace
-  namespace ast {
   /*!
-   *  \ingroup triton
-   *  \addtogroup ast
+   *  \addtogroup triton
    *  @{
    */
 
+  //! The AST namespace
+  namespace ast {
+    /*!
+     *  \ingroup triton
+     *  \addtogroup ast
+     *  @{
+     */
+
     /*! Enumerates all types of node. Must be prime numbers. */
     enum ast_e {
-      INVALID_NODE = 0,               /*!< Invalid node */
-      ANY_NODE = 0,                   /*!< Any node */
-      ASSERT_NODE = 3,                /*!< (assert x) */
-      BSWAP_NODE = 5,                 /*!< (bswap x) */
-      BVADD_NODE = 7,                 /*!< (bvadd x y) */
-      BVAND_NODE = 13,                /*!< (bvand x y) */
-      BVASHR_NODE = 17,               /*!< (bvashr x y) */
-      BVLSHR_NODE = 19,               /*!< (bvlshr x y) */
-      BVMUL_NODE = 23,                /*!< (bvmul x y) */
-      BVNAND_NODE = 29,               /*!< (bvnand x y) */
-      BVNEG_NODE = 31,                /*!< (bvneg x) */
-      BVNOR_NODE = 37,                /*!< (bvnor x y) */
-      BVNOT_NODE = 41,                /*!< (bvnot x) */
-      BVOR_NODE = 43,                 /*!< (bvor x y) */
-      BVROL_NODE = 47,                /*!< ((_ rotate_left x) y) */
-      BVROR_NODE = 53,                /*!< ((_ rotate_right x) y) */
-      BVSDIV_NODE = 59,               /*!< (bvsdiv x y) */
-      BVSGE_NODE = 61,                /*!< (bvsge x y) */
-      BVSGT_NODE = 67,                /*!< (bvsgt x y) */
-      BVSHL_NODE = 71,                /*!< (bvshl x y) */
-      BVSLE_NODE = 73,                /*!< (bvsle x y) */
-      BVSLT_NODE = 79,                /*!< (bvslt x y) */
-      BVSMOD_NODE = 83,               /*!< (bvsmod x y) */
-      BVSREM_NODE = 89,               /*!< (bvsrem x y) */
-      BVSUB_NODE = 97,                /*!< (bvsub x y) */
-      BVUDIV_NODE = 101,              /*!< (bvudiv x y) */
-      BVUGE_NODE = 103,               /*!< (bvuge x y) */
-      BVUGT_NODE = 107,               /*!< (bvugt x y) */
-      BVULE_NODE = 109,               /*!< (bvule x y) */
-      BVULT_NODE = 113,               /*!< (bvult x y) */
-      BVUREM_NODE = 127,              /*!< (bvurem x y) */
-      BVXNOR_NODE = 131,              /*!< (bvxnor x y) */
-      BVXOR_NODE = 137,               /*!< (bvxor x y) */
-      BV_NODE = 139,                  /*!< (_ bvx y) */
-      COMPOUND_NODE = 149,            /*!< A compound of nodes */
-      CONCAT_NODE = 151,              /*!< (concat x y z ...) */
-      DECLARE_NODE = 157,             /*!< (declare-fun <var_name> () (_ BitVec <var_size>)) */
-      DISTINCT_NODE = 163,            /*!< (distinct x y) */
-      EQUAL_NODE = 167,               /*!< (= x y) */
-      EXTRACT_NODE = 173,             /*!< ((_ extract x y) z) */
-      FORALL_NODE = 179,              /*!< (forall ((x (_ BitVec <size>)), ...) body) */
-      IFF_NODE = 181,                 /*!< (iff x y) */
-      INTEGER_NODE = 191,             /*!< Integer node */
-      ITE_NODE = 193,                 /*!< (ite x y z) */
-      LAND_NODE = 197,                /*!< (and x y) */
-      LET_NODE = 199,                 /*!< (let ((x y)) z) */
-      LNOT_NODE = 211,                /*!< (and x y) */
-      LOR_NODE = 223,                 /*!< (or x y) */
-      LXOR_NODE = 227,                /*!< (xor x y) */
-      REFERENCE_NODE = 229,           /*!< Reference node */
-      STRING_NODE = 233,              /*!< String node */
-      SX_NODE = 239,                  /*!< ((_ sign_extend x) y) */
-      VARIABLE_NODE = 241,            /*!< Variable node */
-      ZX_NODE = 251,                  /*!< ((_ zero_extend x) y) */
-      ARRAY_NODE = 257,               /*!< (Array (_ BitVec addrSize) (_ BitVec 8)) */
-      SELECT_NODE = 263,              /*!< (select array index) */
-      STORE_NODE = 269,               /*!< (store array index expr) */
+      INVALID_NODE   = 0,   /*!< Invalid node */
+      ANY_NODE       = 0,   /*!< Any node */
+      ASSERT_NODE    = 3,   /*!< (assert x) */
+      BSWAP_NODE     = 5,   /*!< (bswap x) */
+      BVADD_NODE     = 7,   /*!< (bvadd x y) */
+      BVAND_NODE     = 13,  /*!< (bvand x y) */
+      BVASHR_NODE    = 17,  /*!< (bvashr x y) */
+      BVLSHR_NODE    = 19,  /*!< (bvlshr x y) */
+      BVMUL_NODE     = 23,  /*!< (bvmul x y) */
+      BVNAND_NODE    = 29,  /*!< (bvnand x y) */
+      BVNEG_NODE     = 31,  /*!< (bvneg x) */
+      BVNOR_NODE     = 37,  /*!< (bvnor x y) */
+      BVNOT_NODE     = 41,  /*!< (bvnot x) */
+      BVOR_NODE      = 43,  /*!< (bvor x y) */
+      BVROL_NODE     = 47,  /*!< ((_ rotate_left x) y) */
+      BVROR_NODE     = 53,  /*!< ((_ rotate_right x) y) */
+      BVSDIV_NODE    = 59,  /*!< (bvsdiv x y) */
+      BVSGE_NODE     = 61,  /*!< (bvsge x y) */
+      BVSGT_NODE     = 67,  /*!< (bvsgt x y) */
+      BVSHL_NODE     = 71,  /*!< (bvshl x y) */
+      BVSLE_NODE     = 73,  /*!< (bvsle x y) */
+      BVSLT_NODE     = 79,  /*!< (bvslt x y) */
+      BVSMOD_NODE    = 83,  /*!< (bvsmod x y) */
+      BVSREM_NODE    = 89,  /*!< (bvsrem x y) */
+      BVSUB_NODE     = 97,  /*!< (bvsub x y) */
+      BVUDIV_NODE    = 101, /*!< (bvudiv x y) */
+      BVUGE_NODE     = 103, /*!< (bvuge x y) */
+      BVUGT_NODE     = 107, /*!< (bvugt x y) */
+      BVULE_NODE     = 109, /*!< (bvule x y) */
+      BVULT_NODE     = 113, /*!< (bvult x y) */
+      BVUREM_NODE    = 127, /*!< (bvurem x y) */
+      BVXNOR_NODE    = 131, /*!< (bvxnor x y) */
+      BVXOR_NODE     = 137, /*!< (bvxor x y) */
+      BV_NODE        = 139, /*!< (_ bvx y) */
+      COMPOUND_NODE  = 149, /*!< A compound of nodes */
+      CONCAT_NODE    = 151, /*!< (concat x y z ...) */
+      DECLARE_NODE   = 157, /*!< (declare-fun <var_name> () (_ BitVec <var_size>)) */
+      DISTINCT_NODE  = 163, /*!< (distinct x y) */
+      EQUAL_NODE     = 167, /*!< (= x y) */
+      EXTRACT_NODE   = 173, /*!< ((_ extract x y) z) */
+      FORALL_NODE    = 179, /*!< (forall ((x (_ BitVec <size>)), ...) body) */
+      IFF_NODE       = 181, /*!< (iff x y) */
+      INTEGER_NODE   = 191, /*!< Integer node */
+      ITE_NODE       = 193, /*!< (ite x y z) */
+      LAND_NODE      = 197, /*!< (and x y) */
+      LET_NODE       = 199, /*!< (let ((x y)) z) */
+      LNOT_NODE      = 211, /*!< (and x y) */
+      LOR_NODE       = 223, /*!< (or x y) */
+      LXOR_NODE      = 227, /*!< (xor x y) */
+      REFERENCE_NODE = 229, /*!< Reference node */
+      STRING_NODE    = 233, /*!< String node */
+      SX_NODE        = 239, /*!< ((_ sign_extend x) y) */
+      VARIABLE_NODE  = 241, /*!< Variable node */
+      ZX_NODE        = 251, /*!< ((_ zero_extend x) y) */
+      ARRAY_NODE     = 257, /*!< (Array (_ BitVec addrSize) (_ BitVec 8)) */
+      SELECT_NODE    = 263, /*!< (select array index) */
+      STORE_NODE     = 269, /*!< (store array index expr) */
     };
 
     //! The Representations namespace
     namespace representations {
-    /*!
-     *  \ingroup ast
-     *  \addtogroup representations
-     *  @{
-     */
+      /*!
+       *  \ingroup ast
+       *  \addtogroup representations
+       *  @{
+       */
 
       //! All types of representation mode.
       enum mode_e {
-        SMT_REPRESENTATION = 0,     /*!< SMT representation */
-        PYTHON_REPRESENTATION = 1,  /*!< Python representation */
-        PCODE_REPRESENTATION = 2,   /*!< Pseudo Code representation */
-        LAST_REPRESENTATION = 3,    /*!< Must be the last item */
+        SMT_REPRESENTATION    = 0, /*!< SMT representation */
+        PYTHON_REPRESENTATION = 1, /*!< Python representation */
+        PCODE_REPRESENTATION  = 2, /*!< Pseudo Code representation */
+        LAST_REPRESENTATION   = 3, /*!< Must be the last item */
       };
 
-    /*! @} End of representations namespace */
-    };
-  /*! @} End of ast namespace */
-  };
-/*! @} End of triton namespace */
-};
+      /*! @} End of representations namespace */
+    }; // namespace representations
+    /*! @} End of ast namespace */
+  }; // namespace ast
+  /*! @} End of triton namespace */
+}; // namespace triton
 
 #endif /* TRITON_ASTENUMS_HPP */


### PR DESCRIPTION
I've tried to minimize the diff but also didn't want to exactly match it to get somewhere in the middle of readability and consistency. I also enabled the option to auto comment the end of the namespace, this is a bit inconsistent at the moment and we should either turn that option off or remove the ones that don't fit, I personally think its best to let clang-format do the commenting so it won't be missed and it will be consistent across the board.

Probably need a few more files I should look into, clang-format can get quite notorious about tables.