### PR TITLE
Improve python workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,35 +19,35 @@ jobs:
         run: |
          docker run \
                 --rm \
-                -v $GITHUB_WORKSPACE:/src \
+                --volume $GITHUB_WORKSPACE:/src \
                 build-triton-linux-x86_64 bash /src/src/scripts/docker/build-wheel-linux.sh
 
       - name: Upload Wheel packages (Python 3.8)
         uses: actions/upload-artifact@v3
         with:
-          name: triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_24_x86_64.whl
-          path: wheel-final/triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_24_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_28_x86_64.whl
+          path: wheelhouse/manylinux_2_28_x86_64/triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_28_x86_64.whl
           if-no-files-found: warn
 
       - name: Upload Wheel packages (Python 3.9)
         uses: actions/upload-artifact@v3
         with:
-          name: triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_24_x86_64.whl
-          path: wheel-final/triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_24_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_28_x86_64.whl
+          path: wheelhouse/manylinux_2_28_x86_64/triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_28_x86_64.whl
           if-no-files-found: warn
 
       - name: Upload Wheel packages (Python 3.10)
         uses: actions/upload-artifact@v3
         with:
-          name: triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_24_x86_64.whl
-          path: wheel-final/triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_24_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_28_x86_64.whl
+          path: wheelhouse/manylinux_2_28_x86_64/triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_28_x86_64.whl
           if-no-files-found: warn
 
       - name: Upload Wheel packages (Python 3.11)
         uses: actions/upload-artifact@v3
         with:
-          name: triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_24_x86_64.whl
-          path: wheel-final/triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_24_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_28_x86_64.whl
+          path: wheelhouse/manylinux_2_28_x86_64/triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_28_x86_64.whl
           if-no-files-found: warn
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ private/*
 .vscode
 dist/
 *.egg-info/
+wheelhouse/

--- a/src/scripts/docker/Dockerfile
+++ b/src/scripts/docker/Dockerfile
@@ -12,3 +12,50 @@ RUN yum install -y \
         wget
 
 RUN python3.10 -m pip install meson
+
+ENV DEPENDENCIES_DIR=/tmp/triton-dependencies
+ENV SOURCE_DIR=/src
+
+# Create directory for dependencies.
+RUN mkdir -p $DEPENDENCIES_DIR
+
+# Download, build and install GMP.
+RUN echo "[+] Download, build and install GMP" && \
+    cd $DEPENDENCIES_DIR  && \
+    wget -q https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz && \
+    tar -xf gmp-6.2.1.tar.xz && \
+    cd gmp-6.2.1 && \
+    ./configure --enable-cxx && \
+    make && \
+    make install
+
+# Download, build and install Bitwuzla.
+RUN echo "[+] Download, build and install Bitwuzla" && \
+    cd $DEPENDENCIES_DIR && \
+    git clone https://github.com/bitwuzla/bitwuzla.git && \
+    cd bitwuzla && \
+    git checkout -b 0.1.0 0.1.0 && \
+    CC=clang CXX=clang++ PATH=$PATH:/opt/_internal/cpython-3.10.12/bin python3.10 ./configure.py --shared --prefix $(pwd)/install && \
+    cd build && \
+    PATH=$PATH:/opt/_internal/cpython-3.10.12/bin ninja install
+
+# Download Z3.
+RUN echo "[+] Download Z3" && \
+cd $DEPENDENCIES_DIR && \
+wget -q https://github.com/Z3Prover/z3/releases/download/z3-4.8.17/z3-4.8.17-x64-glibc-2.31.zip && \
+unzip z3-4.8.17-x64-glibc-2.31.zip
+
+# Download, build and install Capstone.
+RUN echo "[+] Download, build and install Capstone" && \
+    cd $DEPENDENCIES_DIR && \
+    wget -q https://github.com/aquynh/capstone/archive/4.0.2.tar.gz -O capstone-4.0.2.tar.gz && \
+    tar -xf capstone-4.0.2.tar.gz && \
+    cd capstone-4.0.2 && \
+    bash ./make.sh && \
+    sudo make install
+
+# Download LLVM.
+RUN echo "[+] Download LLVM" && \
+    cd $DEPENDENCIES_DIR && \
+    wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \
+    tar -xf clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz


### PR DESCRIPTION
This PR:
- moves the building of Triton's dependencies to the Dockerfile (it improves performance in local builds and deps are only build once). 
- switch from `setup.py` to `pypa/build` to build the wheel package (`setup.py` is deprecated for this).
- Fixes filenames in the workflow script. 