### PR TITLE
Upgrade Bitwuzla to version 0.2.0

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla.git
           cd bitwuzla
-          git checkout -b 0.1.0 0.1.0
+          git checkout -b 0.2.0 0.2.0
           python ./configure.py --shared
           cd build
           sudo ninja install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla.git
           cd bitwuzla
-          git checkout -b 0.1.0 0.1.0
+          git checkout -b 0.2.0 0.2.0
           python ./configure.py --shared
           cd build
           sudo ninja install

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla.git
           cd bitwuzla
-          git checkout -b 0.1.0 0.1.0
+          git checkout -b 0.2.0 0.2.0
           python ./configure.py --shared --prefix $(pwd)/install
           cd build
           sudo ninja install

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla.git
           cd bitwuzla
-          git checkout -b 0.1.0 0.1.0
+          git checkout -b 0.2.0 0.2.0
           python ./configure.py --shared --prefix $(pwd)/install
           cd build
           sudo ninja install

--- a/src/libtriton/engines/solver/bitwuzla/bitwuzlaSolver.cpp
+++ b/src/libtriton/engines/solver/bitwuzla/bitwuzlaSolver.cpp
@@ -142,7 +142,7 @@ namespace triton {
           // Parse model.
           std::unordered_map<triton::usize, SolverModel> model;
           for (const auto& it : bzlaAst.getVariables()) {
-            const char* svalue = bitwuzla_term_value_get_str(bitwuzla_get_value(bzla, it.first), 2);
+            const char* svalue = bitwuzla_term_value_get_str_fmt(bitwuzla_get_value(bzla, it.first), 2);
             auto value = this->fromBvalueToUint512(svalue);
             auto m = SolverModel(it.second, value);
             model[m.getId()] = m;
@@ -231,7 +231,7 @@ namespace triton {
         if (bitwuzla_term_is_bool(term_value)) {
           res = bitwuzla_term_value_get_bool(term_value);
         } else {
-          res = triton::uint512{bitwuzla_term_value_get_str(term_value, 10)};
+          res = triton::uint512{bitwuzla_term_value_get_str_fmt(term_value, 10)};
         }
 
         bitwuzla_delete(bzla);

--- a/src/scripts/docker/Dockerfile
+++ b/src/scripts/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN echo "[+] Download, build and install Bitwuzla" && \
     cd $DEPENDENCIES_DIR && \
     git clone https://github.com/bitwuzla/bitwuzla.git && \
     cd bitwuzla && \
-    git checkout -b 0.1.0 0.1.0 && \
+    git checkout -b 0.2.0 0.2.0 && \
     CC=clang CXX=clang++ PATH=$PATH:/opt/_internal/cpython-3.10.13/bin python3.10 ./configure.py --shared --prefix $(pwd)/install && \
     cd build && \
     PATH=$PATH:/opt/_internal/cpython-3.10.13/bin ninja install


### PR DESCRIPTION
This PR upgrades Bitwuzla to version 0.2.0.

The only remaining file to update is `Dockerfile` which will upgrade once `master` syncs with `dev-v1.0`.