### PR TITLE
Fix Bitwuzla VARIABLE_NODE translation

### DIFF
--- a/src/libtriton/ast/bitwuzla/tritonToBitwuzla.cpp
+++ b/src/libtriton/ast/bitwuzla/tritonToBitwuzla.cpp
@@ -289,8 +289,20 @@ namespace triton {
             return bitwuzla_mk_bv_value(sort->second, triton::utils::toString(value).c_str(), 10);
           }
 
-          auto n = bitwuzla_mk_const(sort->second, symVar->getName().c_str());
-          variables[n] = symVar;
+          auto n = (BitwuzlaTerm) 0;
+          /* If we already translated the node, return that. */
+          for (auto it = variables.begin(); it != variables.end(); ++it) {
+            if (it->second == symVar) {
+              n = it->first;
+              break;
+            }
+          }
+
+          if (n == 0) {
+            n = bitwuzla_mk_const(sort->second, symVar->getName().c_str());
+            variables[n] = symVar;
+          }
+
           return n;
         }
 


### PR DESCRIPTION
This PR fix an issue with the in the Triton to Bitwuzla translation for `VARIABLE_NODE`. If a variable node appears more that once in an expression, different term for that node will be created. That means, `bitwuzla_mk_const` will return different `BitwuzlaTerm`s for the same symbol. The fix checks whether the term was already created and returns it, otherwise creates a new one.