### PR TITLE
Fix isSymbolic computation for IteNode

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -2716,8 +2716,14 @@ namespace triton {
       /* Init children and spread information */
       for (triton::uint32 index = 0; index < this->children.size(); index++) {
         this->children[index]->setParent(this);
-        this->symbolized |= this->children[index]->isSymbolized();
         this->level = std::max(this->children[index]->getLevel() + 1, this->level);
+      }
+
+      /* Spread symbolic information */
+      if (!this->children[0]->isSymbolized()) {
+        this->symbolized = this->children[0]->evaluate() ? this->children[1]->isSymbolized() : this->children[2]->isSymbolized();
+      } else {
+        this->symbolized = true;
       }
 
       /* Init parents if needed */


### PR DESCRIPTION
This PR fixes how `isSymbolic` is computed for ITE nodes. The following code shows the issue:

```python
from triton import *

ctx = TritonContext(ARCH.X86_64)

ast_ctx = ctx.getAstContext()

x = ctx.newSymbolicVariable(32)

ite_node = ast_ctx.ite(
                ast_ctx.equal(ast_ctx.bv(1, 1), ast_ctx.bv(1, 1)),
                ast_ctx.bv(0x12345678, 32),
                ast_ctx.variable(x))

print(f'[+] ITE node: {ite_node}')
print(f'[+] ITE node is symbolic? {ite_node.isSymbolized()}')
```

It will output that `ite_node` is symbolic when it is not:

```
[+] ITE node: (ite (= (_ bv1 1) (_ bv1 1)) (_ bv305419896 32) SymVar_0)
[+] ITE node is symbolic? True
```

Now we check that first whether the `IfExpr` of the ITE node is symbolic. If it is, it marks the whole node as symbolic otherwise checks each children.

Note that the problem above is not present if either `MODE.AST_OPTIMIZATIONS` or `MODE.CONSTANT_FOLDING` is set, since the optimization basically does the same as the proposed fix ([here](https://github.com/JonathanSalwan/Triton/blob/dev-v1.0/src/libtriton/ast/astContext.cpp#L866)).