### PR TITLE
Fix Z3 dependency inconsistency and missing dependencies in Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,5 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Set Timestamp Variable
+      run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag triton-docker:$(date +%s)
+      run: docker build . --file Dockerfile --tag triton-docker:$TIMESTAMP
+    - name: Run test cases
+      run: docker run --entrypoint /bin/bash --rm triton-docker:$TIMESTAMP -c 'ctest --test-dir /tmp/triton-build/ --output-on-failure'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM --platform=linux/amd64 ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
+COPY . /Triton
+
 # libboost >= 1.68
 # libpython >= 3.6
 # llvm >= 12
@@ -23,15 +25,13 @@ RUN cd /tmp && \
     ninja install && \
     ldconfig
 
+# To test pre-releases 'pip install' the corresponding .whl from https://github.com/Z3Prover/z3/releases/tag/Nightly
 # libz3 >= 4.6.0
-RUN cd /tmp && \
-    curl -o z3.tgz -L https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.14.tar.gz && \
-    tar zxf z3.tgz && cd z3-z3-4.8.14 && mkdir build && cd build && \
-    CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4 && make install && \
-    pip3 install z3-solver && rm -rf /tmp/z3*
+RUN pip3 install z3-solver==4.12.2
 
-# Triton (LLVM for lifting; z3 or bitwuzla as SMT solver)
-RUN git clone https://github.com/JonathanSalwan/Triton && cd Triton && mkdir build && cd build && cmake -DLLVM_INTERFACE=ON -DCMAKE_PREFIX_PATH=$(/usr/lib/llvm-12/bin/llvm-config --prefix) -DZ3_INTERFACE=ON -DBITWUZLA_INTERFACE=ON  -DBITWUZLA_INCLUDE_DIRS=/usr/local/include -DBITWUZLA_LIBRARIES=/usr/local/lib/x86_64-linux-gnu/libbitwuzla.so .. && make -j4 && make install
+RUN PYV=`python3 -c "import platform;print(platform.python_version()[:3])"` && \
+    # Triton (LLVM for lifting; z3 or bitwuzla as SMT solver)
+    cd /Triton && mkdir /tmp/triton-build && cd /tmp/triton-build && cmake -DLLVM_INTERFACE=ON -DCMAKE_PREFIX_PATH=$(/usr/lib/llvm-12/bin/llvm-config --prefix) -DZ3_INTERFACE=ON -DZ3_INCLUDE_DIRS=/usr/local/lib/python$PYV/dist-packages/z3/include/ -DZ3_LIBRARIES=/usr/local/lib/python$PYV/dist-packages/z3/lib/libz3.so -DBITWUZLA_INTERFACE=ON  -DBITWUZLA_INCLUDE_DIRS=/usr/local/include -DBITWUZLA_LIBRARIES=/usr/local/lib/x86_64-linux-gnu/libbitwuzla.so /Triton && make -j$(nproc) && make install
 
 RUN PYV=`python3 -c "import platform;print(platform.python_version()[:3])"` && \
     PYP="/usr/lib/python$PYV/site-packages" && \
@@ -39,5 +39,8 @@ RUN PYV=`python3 -c "import platform;print(platform.python_version()[:3])"` && \
     python3 -c "import z3; print('Z3 version:', z3.get_version_string())" && \
     # Next command fails if Triton has no z3 or bitwuzla support
     PYTHONPATH="$PYP" python3 -c "from triton import *; ctx=TritonContext(ARCH.X86_64); ctx.setSolver(SOLVER.Z3); ctx.setSolver(SOLVER.BITWUZLA);"
+
+# Dependencies required for testing
+RUN pip install unicorn==2.0.0 lief
 
 ENTRYPOINT /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cd /tmp && \
 
 # To test pre-releases 'pip install' the corresponding .whl from https://github.com/Z3Prover/z3/releases/tag/Nightly
 # libz3 >= 4.6.0
-RUN pip3 install z3-solver==4.12.2
+RUN pip3 install z3-solver==4.8.14
 
 RUN PYV=`python3 -c "import platform;print(platform.python_version()[:3])"` && \
     # Triton (LLVM for lifting; z3 or bitwuzla as SMT solver)


### PR DESCRIPTION
Hi :wave: 

I've noticed some difficulties while building Triton from sources using the available Dockerfile. This PR aims to fix them.

1. Now, Z3 is installed only once using pip to get rid of crashes like #1136. This also decreases the time taken to build the Docker image.
2. The test suite was not executed for the Docker image, which is now.
3. Some dependencies were missing for the test suite to run successfully.
4. The Dockerfile was cloning the source code. This prevented us from testing the changes in the CI when working on a branch other than master.

Best regards,
Manuel.
