### PR TITLE
Fix addCallback binding

### DIFF
--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -503,13 +503,10 @@ namespace triton {
         if (PyMethod_Check(function)) {
           cb_self = PyMethod_GET_SELF(function);
           cb = PyMethod_GET_FUNCTION(function);
-
-          Py_INCREF(cb_self);
         }
         else {
           cb = function;
         }
-        Py_INCREF(cb);
 
         try {
           switch (static_cast<triton::callbacks::callback_e>(PyLong_AsUint32(mode))) {
@@ -2619,11 +2616,6 @@ namespace triton {
         }
         catch (const triton::exceptions::Exception& e) {
           return PyErr_Format(PyExc_TypeError, "%s", e.what());
-        }
-
-        Py_DECREF(cb);
-        if (cb_self != nullptr) {
-          Py_DECREF(cb_self);
         }
 
         Py_INCREF(Py_None);


### PR DESCRIPTION
Fix PR fixes a small memory leak in the `addCallback` function. This issue was spotted than to LIEF and their new nanobind implementation of its Python bindings (ref [here](https://nanobind.readthedocs.io/en/latest/faq.html#why-am-i-getting-errors-about-leaked-functions-and-types)).  