### PR TITLE
Add the XMM16-31 and YMM16-31 registers for x86_64

### DIFF
--- a/src/libtriton/arch/x86/x8664Cpu.cpp
+++ b/src/libtriton/arch/x86/x8664Cpu.cpp
@@ -331,7 +331,7 @@ namespace triton {
 
 
       bool x8664Cpu::isSSE(triton::arch::register_e regId) const {
-        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_XMM31) ? true : false);
+        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_XMM15) ? true : false);
       }
 
 
@@ -351,12 +351,16 @@ namespace triton {
 
 
       bool x8664Cpu::isAVX256(triton::arch::register_e regId) const {
-        return ((regId >= triton::arch::ID_REG_X86_YMM0 && regId <= triton::arch::ID_REG_X86_YMM31) ? true : false);
+        return ((regId >= triton::arch::ID_REG_X86_YMM0 && regId <= triton::arch::ID_REG_X86_YMM15) ? true : false);
       }
 
 
       bool x8664Cpu::isAVX512(triton::arch::register_e regId) const {
-        return ((regId >= triton::arch::ID_REG_X86_ZMM0 && regId <= triton::arch::ID_REG_X86_ZMM31) ? true : false);
+        return ((
+          (regId >= triton::arch::ID_REG_X86_ZMM0 && regId <= triton::arch::ID_REG_X86_ZMM31) ||
+          (regId >= triton::arch::ID_REG_X86_YMM16 && regId <= triton::arch::ID_REG_X86_YMM31) ||
+          (regId >= triton::arch::ID_REG_X86_XMM16 && regId <= triton::arch::ID_REG_X86_XMM31)
+        ) ? true : false);
       }
 
 

--- a/src/libtriton/arch/x86/x8664Cpu.cpp
+++ b/src/libtriton/arch/x86/x8664Cpu.cpp
@@ -331,7 +331,7 @@ namespace triton {
 
 
       bool x8664Cpu::isSSE(triton::arch::register_e regId) const {
-        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_XMM15) ? true : false);
+        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_XMM31) ? true : false);
       }
 
 
@@ -351,7 +351,7 @@ namespace triton {
 
 
       bool x8664Cpu::isAVX256(triton::arch::register_e regId) const {
-        return ((regId >= triton::arch::ID_REG_X86_YMM0 && regId <= triton::arch::ID_REG_X86_YMM15) ? true : false);
+        return ((regId >= triton::arch::ID_REG_X86_YMM0 && regId <= triton::arch::ID_REG_X86_YMM31) ? true : false);
       }
 
 
@@ -777,6 +777,22 @@ namespace triton {
           case triton::arch::ID_REG_X86_XMM13: { return triton::utils::cast<triton::uint128>(this->zmm13); }
           case triton::arch::ID_REG_X86_XMM14: { return triton::utils::cast<triton::uint128>(this->zmm14); }
           case triton::arch::ID_REG_X86_XMM15: { return triton::utils::cast<triton::uint128>(this->zmm15); }
+          case triton::arch::ID_REG_X86_XMM16: { return triton::utils::cast<triton::uint128>(this->zmm16); }
+          case triton::arch::ID_REG_X86_XMM17: { return triton::utils::cast<triton::uint128>(this->zmm17); }
+          case triton::arch::ID_REG_X86_XMM18: { return triton::utils::cast<triton::uint128>(this->zmm18); }
+          case triton::arch::ID_REG_X86_XMM19: { return triton::utils::cast<triton::uint128>(this->zmm19); }
+          case triton::arch::ID_REG_X86_XMM20: { return triton::utils::cast<triton::uint128>(this->zmm20); }
+          case triton::arch::ID_REG_X86_XMM21: { return triton::utils::cast<triton::uint128>(this->zmm21); }
+          case triton::arch::ID_REG_X86_XMM22: { return triton::utils::cast<triton::uint128>(this->zmm22); }
+          case triton::arch::ID_REG_X86_XMM23: { return triton::utils::cast<triton::uint128>(this->zmm23); }
+          case triton::arch::ID_REG_X86_XMM24: { return triton::utils::cast<triton::uint128>(this->zmm24); }
+          case triton::arch::ID_REG_X86_XMM25: { return triton::utils::cast<triton::uint128>(this->zmm25); }
+          case triton::arch::ID_REG_X86_XMM26: { return triton::utils::cast<triton::uint128>(this->zmm26); }
+          case triton::arch::ID_REG_X86_XMM27: { return triton::utils::cast<triton::uint128>(this->zmm27); }
+          case triton::arch::ID_REG_X86_XMM28: { return triton::utils::cast<triton::uint128>(this->zmm28); }
+          case triton::arch::ID_REG_X86_XMM29: { return triton::utils::cast<triton::uint128>(this->zmm29); }
+          case triton::arch::ID_REG_X86_XMM30: { return triton::utils::cast<triton::uint128>(this->zmm30); }
+          case triton::arch::ID_REG_X86_XMM31: { return triton::utils::cast<triton::uint128>(this->zmm31); }
 
           case triton::arch::ID_REG_X86_YMM0:  { return triton::utils::cast<triton::uint256>(this->zmm0);  }
           case triton::arch::ID_REG_X86_YMM1:  { return triton::utils::cast<triton::uint256>(this->zmm1);  }
@@ -794,6 +810,22 @@ namespace triton {
           case triton::arch::ID_REG_X86_YMM13: { return triton::utils::cast<triton::uint256>(this->zmm13); }
           case triton::arch::ID_REG_X86_YMM14: { return triton::utils::cast<triton::uint256>(this->zmm14); }
           case triton::arch::ID_REG_X86_YMM15: { return triton::utils::cast<triton::uint256>(this->zmm15); }
+          case triton::arch::ID_REG_X86_YMM16: { return triton::utils::cast<triton::uint256>(this->zmm16); }
+          case triton::arch::ID_REG_X86_YMM17: { return triton::utils::cast<triton::uint256>(this->zmm17); }
+          case triton::arch::ID_REG_X86_YMM18: { return triton::utils::cast<triton::uint256>(this->zmm18); }
+          case triton::arch::ID_REG_X86_YMM19: { return triton::utils::cast<triton::uint256>(this->zmm19); }
+          case triton::arch::ID_REG_X86_YMM20: { return triton::utils::cast<triton::uint256>(this->zmm20); }
+          case triton::arch::ID_REG_X86_YMM21: { return triton::utils::cast<triton::uint256>(this->zmm21); }
+          case triton::arch::ID_REG_X86_YMM22: { return triton::utils::cast<triton::uint256>(this->zmm22); }
+          case triton::arch::ID_REG_X86_YMM23: { return triton::utils::cast<triton::uint256>(this->zmm23); }
+          case triton::arch::ID_REG_X86_YMM24: { return triton::utils::cast<triton::uint256>(this->zmm24); }
+          case triton::arch::ID_REG_X86_YMM25: { return triton::utils::cast<triton::uint256>(this->zmm25); }
+          case triton::arch::ID_REG_X86_YMM26: { return triton::utils::cast<triton::uint256>(this->zmm26); }
+          case triton::arch::ID_REG_X86_YMM27: { return triton::utils::cast<triton::uint256>(this->zmm27); }
+          case triton::arch::ID_REG_X86_YMM28: { return triton::utils::cast<triton::uint256>(this->zmm28); }
+          case triton::arch::ID_REG_X86_YMM29: { return triton::utils::cast<triton::uint256>(this->zmm29); }
+          case triton::arch::ID_REG_X86_YMM30: { return triton::utils::cast<triton::uint256>(this->zmm30); }
+          case triton::arch::ID_REG_X86_YMM31: { return triton::utils::cast<triton::uint256>(this->zmm31); }
 
           case triton::arch::ID_REG_X86_ZMM0:  { return triton::utils::cast<triton::uint512>(this->zmm0);  }
           case triton::arch::ID_REG_X86_ZMM1:  { return triton::utils::cast<triton::uint512>(this->zmm1);  }
@@ -1248,6 +1280,22 @@ namespace triton {
           case triton::arch::ID_REG_X86_XMM13: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm13); break; }
           case triton::arch::ID_REG_X86_XMM14: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm14); break; }
           case triton::arch::ID_REG_X86_XMM15: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm15); break; }
+          case triton::arch::ID_REG_X86_XMM16: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm16); break; }
+          case triton::arch::ID_REG_X86_XMM17: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm17); break; }
+          case triton::arch::ID_REG_X86_XMM18: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm18); break; }
+          case triton::arch::ID_REG_X86_XMM19: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm19); break; }
+          case triton::arch::ID_REG_X86_XMM20: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm20); break; }
+          case triton::arch::ID_REG_X86_XMM21: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm21); break; }
+          case triton::arch::ID_REG_X86_XMM22: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm22); break; }
+          case triton::arch::ID_REG_X86_XMM23: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm23); break; }
+          case triton::arch::ID_REG_X86_XMM24: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm24); break; }
+          case triton::arch::ID_REG_X86_XMM25: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm25); break; }
+          case triton::arch::ID_REG_X86_XMM26: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm26); break; }
+          case triton::arch::ID_REG_X86_XMM27: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm27); break; }
+          case triton::arch::ID_REG_X86_XMM28: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm28); break; }
+          case triton::arch::ID_REG_X86_XMM29: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm29); break; }
+          case triton::arch::ID_REG_X86_XMM30: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm30); break; }
+          case triton::arch::ID_REG_X86_XMM31: { triton::utils::fromUintToBuffer(static_cast<triton::uint128>(value), this->zmm31); break; }
 
           case triton::arch::ID_REG_X86_YMM0:  { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm0);  break; }
           case triton::arch::ID_REG_X86_YMM1:  { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm1);  break; }
@@ -1265,6 +1313,22 @@ namespace triton {
           case triton::arch::ID_REG_X86_YMM13: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm13); break; }
           case triton::arch::ID_REG_X86_YMM14: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm14); break; }
           case triton::arch::ID_REG_X86_YMM15: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm15); break; }
+          case triton::arch::ID_REG_X86_YMM16: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm16); break; }
+          case triton::arch::ID_REG_X86_YMM17: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm17); break; }
+          case triton::arch::ID_REG_X86_YMM18: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm18); break; }
+          case triton::arch::ID_REG_X86_YMM19: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm19); break; }
+          case triton::arch::ID_REG_X86_YMM20: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm20); break; }
+          case triton::arch::ID_REG_X86_YMM21: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm21); break; }
+          case triton::arch::ID_REG_X86_YMM22: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm22); break; }
+          case triton::arch::ID_REG_X86_YMM23: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm23); break; }
+          case triton::arch::ID_REG_X86_YMM24: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm24); break; }
+          case triton::arch::ID_REG_X86_YMM25: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm25); break; }
+          case triton::arch::ID_REG_X86_YMM26: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm26); break; }
+          case triton::arch::ID_REG_X86_YMM27: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm27); break; }
+          case triton::arch::ID_REG_X86_YMM28: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm28); break; }
+          case triton::arch::ID_REG_X86_YMM29: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm29); break; }
+          case triton::arch::ID_REG_X86_YMM30: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm30); break; }
+          case triton::arch::ID_REG_X86_YMM31: { triton::utils::fromUintToBuffer(static_cast<triton::uint256>(value), this->zmm31); break; }
 
           case triton::arch::ID_REG_X86_ZMM0:  { triton::utils::fromUintToBuffer(static_cast<triton::uint512>(value), this->zmm0);  break; }
           case triton::arch::ID_REG_X86_ZMM1:  { triton::utils::fromUintToBuffer(static_cast<triton::uint512>(value), this->zmm1);  break; }

--- a/src/libtriton/bindings/python/objects/pyTritonContext.cpp
+++ b/src/libtriton/bindings/python/objects/pyTritonContext.cpp
@@ -533,12 +533,13 @@ namespace triton {
                 /* Call the callback */
                 PyObject* ret = PyObject_CallObject(cb, args);
 
+                /* Release args */
+                Py_DECREF(args);
+
                 /* Check the call */
                 if (ret == nullptr) {
                   throw triton::exceptions::PyCallbacks();
                 }
-
-                Py_DECREF(args);
                 /********* End of lambda *********/
               }, cb));
               break;
@@ -565,12 +566,13 @@ namespace triton {
                 /* Call the callback */
                 PyObject* ret = PyObject_CallObject(cb, args);
 
+                /* Release args */
+                Py_DECREF(args);
+
                 /* Check the call */
                 if (ret == nullptr) {
                   throw triton::exceptions::PyCallbacks();
                 }
-
-                Py_DECREF(args);
                 /********* End of lambda *********/
               }, cb));
               break;
@@ -599,12 +601,13 @@ namespace triton {
                 /* Call the callback */
                 PyObject* ret = PyObject_CallObject(cb, args);
 
+                /* Release args */
+                Py_DECREF(args);
+
                 /* Check the call */
                 if (ret == nullptr) {
                   throw triton::exceptions::PyCallbacks();
                 }
-
-                Py_DECREF(args);
                 /********* End of lambda *********/
               }, cb));
               break;
@@ -633,12 +636,13 @@ namespace triton {
                 /* Call the callback */
                 PyObject* ret = PyObject_CallObject(cb, args);
 
+                /* Release args */
+                Py_DECREF(args);
+
                 /* Check the call */
                 if (ret == nullptr) {
                   throw triton::exceptions::PyCallbacks();
                 }
-
-                Py_DECREF(args);
                 /********* End of lambda *********/
               }, cb));
               break;
@@ -665,6 +669,9 @@ namespace triton {
                 /* Call the callback */
                 PyObject* ret = PyObject_CallObject(cb, args);
 
+                /* Release args */
+                Py_DECREF(args);
+
                 /* Check the call */
                 if (ret == nullptr) {
                   throw triton::exceptions::PyCallbacks();
@@ -676,7 +683,6 @@ namespace triton {
 
                 /* Update node */
                 node = PyAstNode_AsAstNode(ret);
-                Py_DECREF(args);
                 return node;
                 /********* End of lambda *********/
               }, cb));

--- a/src/libtriton/bindings/python/utils.cpp
+++ b/src/libtriton/bindings/python/utils.cpp
@@ -26,14 +26,14 @@
   #define tt_GET_OB_DIGIT(obj) obj->ob_digit
   #define tt_SET_OB_DIGIT(obj, n) Py_SET_SIZE(obj, n)
   #define tt_PyLong_IsNegative(obj) (Py_SIZE(obj) < 0)
-  #define tt_PyLong_DigitCount(obj) (_PyLong_IsNegative(obj) ? -Py_SIZE(obj) : Py_SIZE(obj))
+  #define tt_PyLong_DigitCount(obj) (tt_PyLong_IsNegative(obj) ? -Py_SIZE(obj) : Py_SIZE(obj))
 
 #else
 
   #define tt_GET_OB_DIGIT(obj) obj->ob_digit
   #define tt_SET_OB_DIGIT(obj, n) Py_SIZE(obj) = n
   #define tt_PyLong_IsNegative(obj) (Py_SIZE(obj) < 0)
-  #define tt_PyLong_DigitCount(obj) (_PyLong_IsNegative(obj) ? -Py_SIZE(obj) : Py_SIZE(obj))
+  #define tt_PyLong_DigitCount(obj) (tt_PyLong_IsNegative(obj) ? -Py_SIZE(obj) : Py_SIZE(obj))
 
 #endif
 

--- a/src/libtriton/includes/triton/x86.spec
+++ b/src/libtriton/includes/triton/x86.spec
@@ -156,6 +156,23 @@ REG_SPEC(XMM13, xmm13, triton::bitsize::dqword-1, 0, ZMM13, 0,                  
 REG_SPEC(XMM14, xmm14, triton::bitsize::dqword-1, 0, ZMM14, 0,                         0, XMM14, false) // xmm14
 REG_SPEC(XMM15, xmm15, triton::bitsize::dqword-1, 0, ZMM15, 0,                         0, XMM15, false) // xmm15
 
+REG_SPEC(XMM16, xmm16, triton::bitsize::dqword-1, 0, ZMM16, 0,                         0, XMM16, false) // xmm16
+REG_SPEC(XMM17, xmm17, triton::bitsize::dqword-1, 0, ZMM17, 0,                         0, XMM17, false) // xmm17
+REG_SPEC(XMM18, xmm18, triton::bitsize::dqword-1, 0, ZMM18, 0,                         0, XMM18, false) // xmm18
+REG_SPEC(XMM19, xmm19, triton::bitsize::dqword-1, 0, ZMM19, 0,                         0, XMM19, false) // xmm19
+REG_SPEC(XMM20, xmm20, triton::bitsize::dqword-1, 0, ZMM20, 0,                         0, XMM20, false) // xmm20
+REG_SPEC(XMM21, xmm21, triton::bitsize::dqword-1, 0, ZMM21, 0,                         0, XMM21, false) // xmm21
+REG_SPEC(XMM22, xmm22, triton::bitsize::dqword-1, 0, ZMM22, 0,                         0, XMM22, false) // xmm22
+REG_SPEC(XMM23, xmm23, triton::bitsize::dqword-1, 0, ZMM23, 0,                         0, XMM23, false) // xmm23
+REG_SPEC(XMM24, xmm24, triton::bitsize::dqword-1, 0, ZMM24, 0,                         0, XMM24, false) // xmm24
+REG_SPEC(XMM25, xmm25, triton::bitsize::dqword-1, 0, ZMM25, 0,                         0, XMM25, false) // xmm25
+REG_SPEC(XMM26, xmm26, triton::bitsize::dqword-1, 0, ZMM26, 0,                         0, XMM26, false) // xmm26
+REG_SPEC(XMM27, xmm27, triton::bitsize::dqword-1, 0, ZMM27, 0,                         0, XMM27, false) // xmm27
+REG_SPEC(XMM28, xmm28, triton::bitsize::dqword-1, 0, ZMM28, 0,                         0, XMM28, false) // xmm28
+REG_SPEC(XMM29, xmm29, triton::bitsize::dqword-1, 0, ZMM29, 0,                         0, XMM29, false) // xmm29
+REG_SPEC(XMM30, xmm30, triton::bitsize::dqword-1, 0, ZMM30, 0,                         0, XMM30, false) // xmm30
+REG_SPEC(XMM31, xmm31, triton::bitsize::dqword-1, 0, ZMM31, 0,                         0, XMM31, false) // xmm31
+
 /* AVX-256 */
 
 REG_SPEC(YMM0,  ymm0,  triton::bitsize::qqword-1, 0, ZMM0,  triton::bitsize::qqword-1, 0, YMM0,  true)  // ymm0
@@ -174,6 +191,23 @@ REG_SPEC(YMM12, ymm12, triton::bitsize::qqword-1, 0, ZMM12, 0,                  
 REG_SPEC(YMM13, ymm13, triton::bitsize::qqword-1, 0, ZMM13, 0,                         0, YMM13, false) // ymm13
 REG_SPEC(YMM14, ymm14, triton::bitsize::qqword-1, 0, ZMM14, 0,                         0, YMM14, false) // ymm14
 REG_SPEC(YMM15, ymm15, triton::bitsize::qqword-1, 0, ZMM15, 0,                         0, YMM15, false) // ymm15
+
+REG_SPEC(YMM16, ymm16, triton::bitsize::qqword-1, 0, ZMM16, 0,                         0, YMM16, false) // ymm16
+REG_SPEC(YMM17, ymm17, triton::bitsize::qqword-1, 0, ZMM17, 0,                         0, YMM17, false) // ymm17
+REG_SPEC(YMM18, ymm18, triton::bitsize::qqword-1, 0, ZMM18, 0,                         0, YMM18, false) // ymm18
+REG_SPEC(YMM19, ymm19, triton::bitsize::qqword-1, 0, ZMM19, 0,                         0, YMM19, false) // ymm19
+REG_SPEC(YMM20, ymm20, triton::bitsize::qqword-1, 0, ZMM20, 0,                         0, YMM20, false) // ymm20
+REG_SPEC(YMM21, ymm21, triton::bitsize::qqword-1, 0, ZMM21, 0,                         0, YMM21, false) // ymm21
+REG_SPEC(YMM22, ymm22, triton::bitsize::qqword-1, 0, ZMM22, 0,                         0, YMM22, false) // ymm22
+REG_SPEC(YMM23, ymm23, triton::bitsize::qqword-1, 0, ZMM23, 0,                         0, YMM23, false) // ymm23
+REG_SPEC(YMM24, ymm24, triton::bitsize::qqword-1, 0, ZMM24, 0,                         0, YMM24, false) // ymm24
+REG_SPEC(YMM25, ymm25, triton::bitsize::qqword-1, 0, ZMM25, 0,                         0, YMM25, false) // ymm25
+REG_SPEC(YMM26, ymm26, triton::bitsize::qqword-1, 0, ZMM26, 0,                         0, YMM26, false) // ymm26
+REG_SPEC(YMM27, ymm27, triton::bitsize::qqword-1, 0, ZMM27, 0,                         0, YMM27, false) // ymm27
+REG_SPEC(YMM28, ymm28, triton::bitsize::qqword-1, 0, ZMM28, 0,                         0, YMM28, false) // ymm28
+REG_SPEC(YMM29, ymm29, triton::bitsize::qqword-1, 0, ZMM29, 0,                         0, YMM29, false) // ymm29
+REG_SPEC(YMM30, ymm30, triton::bitsize::qqword-1, 0, ZMM30, 0,                         0, YMM30, false) // ymm30
+REG_SPEC(YMM31, ymm31, triton::bitsize::qqword-1, 0, ZMM31, 0,                         0, YMM31, false) // ymm31
 
 /* AVX-512 */
 

--- a/src/testers/unittests/test_concrete_value.py
+++ b/src/testers/unittests/test_concrete_value.py
@@ -95,11 +95,11 @@ class TestX8664ConcreteRegisterValue(unittest.TestCase):
 
     def test_all_registers(self):
         """Check all registers"""
-        self.assertEqual(len(self.ar), 255)
+        self.assertEqual(len(self.ar), 287)
 
     def test_parent_registers(self):
         """Check parent registers"""
-        self.assertEqual(len(self.pr), 201)
+        self.assertEqual(len(self.pr), 233)
 
     def test_set_get_concrete_value(self):
         """Check setting concrete values"""


### PR DESCRIPTION
This adds the missing registers used to index into the lower portions of the AVX-512 registers. Here I have only added the registers, as well as adjust the get/set concrete register value function to use the correct parent registers. It is a simple change, and adds support for instructions using these registers.