### PR TITLE
implement Aarch64 UMOV instruction semantics

### DIFF
--- a/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
@@ -168,12 +168,28 @@ namespace triton {
               tritonId = triton::arch::arm::ID_VAS_8B;
               break;
 
+            case triton::extlibs::capstone::ARM64_VAS_4B:
+              tritonId = triton::arch::arm::ID_VAS_4B;
+              break;
+
+            case triton::extlibs::capstone::ARM64_VAS_1B:
+              tritonId = triton::arch::arm::ID_VAS_1B;
+              break;
+
             case triton::extlibs::capstone::ARM64_VAS_8H:
               tritonId = triton::arch::arm::ID_VAS_8H;
               break;
 
             case triton::extlibs::capstone::ARM64_VAS_4H:
               tritonId = triton::arch::arm::ID_VAS_4H;
+              break;
+
+            case triton::extlibs::capstone::ARM64_VAS_2H:
+              tritonId = triton::arch::arm::ID_VAS_2H;
+              break;
+
+            case triton::extlibs::capstone::ARM64_VAS_1H:
+              tritonId = triton::arch::arm::ID_VAS_1H;
               break;
 
             case triton::extlibs::capstone::ARM64_VAS_4S:
@@ -184,12 +200,20 @@ namespace triton {
               tritonId = triton::arch::arm::ID_VAS_2S;
               break;
 
+            case triton::extlibs::capstone::ARM64_VAS_1S:
+              tritonId = triton::arch::arm::ID_VAS_1S;
+              break;
+
             case triton::extlibs::capstone::ARM64_VAS_2D:
               tritonId = triton::arch::arm::ID_VAS_2D;
               break;
 
             case triton::extlibs::capstone::ARM64_VAS_1D:
               tritonId = triton::arch::arm::ID_VAS_1D;
+              break;
+
+            case triton::extlibs::capstone::ARM64_VAS_1Q:
+              tritonId = triton::arch::arm::ID_VAS_1Q;
               break;
 
             default:

--- a/src/libtriton/arch/arm/armOperandProperties.cpp
+++ b/src/libtriton/arch/arm/armOperandProperties.cpp
@@ -86,12 +86,18 @@ namespace triton {
         switch (this->vasType) {
           case ID_VAS_16B: return "16B";
           case ID_VAS_8B:  return "8B";
+          case ID_VAS_4B:  return "4B";
+          case ID_VAS_1B:  return "1B";
           case ID_VAS_8H:  return "8H";
           case ID_VAS_4H:  return "4H";
+          case ID_VAS_2H:  return "2H";
+          case ID_VAS_1H:  return "1H";
           case ID_VAS_4S:  return "4S";
           case ID_VAS_2S:  return "2S";
+          case ID_VAS_1S:  return "1S";
           case ID_VAS_2D:  return "2D";
           case ID_VAS_1D:  return "1D";
+          case ID_VAS_1Q:  return "1Q";
           default:         return "invalid";
         }
       }
@@ -99,14 +105,21 @@ namespace triton {
 
       triton::uint32 ArmOperandProperties::getVASSize(void) const {
         switch (this->vasType) {
-          case ID_VAS_16B: return triton::size::dqword;
-          case ID_VAS_8H:  return triton::size::dqword;
-          case ID_VAS_4S:  return triton::size::dqword;
+          case ID_VAS_16B: [[fallthrough]];
+          case ID_VAS_8H:  [[fallthrough]];
+          case ID_VAS_4S:  [[fallthrough]];
           case ID_VAS_2D:  return triton::size::dqword;
-          case ID_VAS_8B:  return triton::size::qword;
-          case ID_VAS_4H:  return triton::size::qword;
-          case ID_VAS_2S:  return triton::size::qword;
-          case ID_VAS_1D:  return triton::size::qword;
+          case ID_VAS_8B:  [[fallthrough]];
+          case ID_VAS_4H:  [[fallthrough]];
+          case ID_VAS_2S:  [[fallthrough]];
+          case ID_VAS_1D:  [[fallthrough]];
+          case ID_VAS_1Q:  return triton::size::qword;
+          case ID_VAS_4B:  [[fallthrough]];
+          case ID_VAS_1S:  [[fallthrough]];
+          case ID_VAS_2H:  return triton::size::dword;
+          case ID_VAS_1H:  return triton::size::word;
+          case ID_VAS_1B:  return triton::size::byte;
+          
           default:         return 0;
         }
       }

--- a/src/libtriton/includes/triton/aarch64Semantics.hpp
+++ b/src/libtriton/includes/triton/aarch64Semantics.hpp
@@ -552,6 +552,9 @@ namespace triton {
             //! The UMADDL semantics.
             void umaddl_s(triton::arch::Instruction& inst);
 
+            //! The UMOV semantics.
+            void umov_s(triton::arch::Instruction& inst);
+
             //! The UMNEGL semantics.
             void umnegl_s(triton::arch::Instruction& inst);
 

--- a/src/libtriton/includes/triton/archEnums.hpp
+++ b/src/libtriton/includes/triton/archEnums.hpp
@@ -176,12 +176,18 @@ namespace triton {
         ID_VAS_INVALID = 0, //!< invalid
         ID_VAS_16B,         //!< 16 lanes, each containing an 8-bit element.
         ID_VAS_8B,          //!< 8 lanes, each containing an 8-bit element.
+        ID_VAS_4B,          //!< 4 lane, containing an 8-bit element.
+        ID_VAS_1B,          //!< 1 lane, containing an 8-bit element.
         ID_VAS_8H,          //!< 8 lanes, each containing a 16-bit element.
         ID_VAS_4H,          //!< 4 lanes, each containing a 16-bit element.
+        ID_VAS_2H,          //!< 2 lanes, each containing a 16-bit element.
+        ID_VAS_1H,          //!< 1 lane, containing an 16-bit element.
         ID_VAS_4S,          //!< 4 lanes, each containing a 32-bit element.
         ID_VAS_2S,          //!< 2 lanes, each containing a 32-bit element.
+        ID_VAS_1S,          //!< 1 lane, containing an 32-bit element.
         ID_VAS_2D,          //!< 2 lanes, each containing a 64-bit element.
         ID_VAS_1D,          //!< 1 lane containing a 64-bit element.
+        ID_VAS_1Q,          //!< 1 lane containing a 128-bit element.
         ID_VAS_LAST_ITEM,   //!< must be the last item.
       };
 


### PR DESCRIPTION
add more VAS types to correctly handle different cases which part of vector register should move to GPR register
add umov semantics in aarch64
instruction reference [here](https://developer.arm.com/documentation/dui0801/l/A64-SIMD-Vector-Instructions/UMOV--vector---A64-)

