### PR TITLE
Ensure getParentRegisters returns all the parent register.

### DIFF
--- a/src/libtriton/arch/arm/aarch64/aarch64Cpu.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Cpu.cpp
@@ -297,20 +297,28 @@ namespace triton {
             auto regId = kv.first;
             const auto& reg = kv.second;
 
-            /* Skip Vector and System registers */
-            if (this->isVectorRegister(regId) || this->isSystemRegister(regId))
+            /* Skip Vector registers */
+            if (this->isVectorRegister(regId))
               continue;
 
             /* Add GPR */
-            if (reg.getSize() == this->gprSize())
+            else if (this->isGPR(regId) && reg.getSize() == this->gprSize())
+              ret.insert(&reg);
+
+            /* Add SPSR */
+            else if (regId == ID_REG_AARCH64_SPSR)
               ret.insert(&reg);
 
             /* Add scalar register */
-            if (this->isScalarRegister(regId) && reg.getSize() == triton::bitsize::dqword)
+            else if (this->isScalarRegister(regId) && reg.getBitSize() == triton::bitsize::dqword)
               ret.insert(&reg);
 
             /* Add Flags */
             else if (this->isFlag(regId))
+              ret.insert(&reg);
+
+            /* Add System Registers */
+            else if (this->isSystemRegister(regId))
               ret.insert(&reg);
           }
 

--- a/src/libtriton/arch/x86/x8664Cpu.cpp
+++ b/src/libtriton/arch/x86/x8664Cpu.cpp
@@ -297,6 +297,7 @@ namespace triton {
           this->isGPR(regId)      ||
           this->isMMX(regId)      ||
           this->isSTX(regId)      ||
+          this->isSSECTL(regId)   ||
           this->isSSE(regId)      ||
           this->isFPU(regId)      ||
           this->isEFER(regId)     ||
@@ -330,8 +331,13 @@ namespace triton {
       }
 
 
+      bool x8664Cpu::isSSECTL(triton::arch::register_e regId) const {
+        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_MXCSR_MASK) ? true : false);
+      }
+
+
       bool x8664Cpu::isSSE(triton::arch::register_e regId) const {
-        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_XMM15) ? true : false);
+        return ((regId >= triton::arch::ID_REG_X86_XMM0 && regId <= triton::arch::ID_REG_X86_XMM15) ? true : false);
       }
 
 
@@ -363,6 +369,9 @@ namespace triton {
         ) ? true : false);
       }
 
+      bool x8664Cpu::isAVX512Parent(triton::arch::register_e regId) const {
+        return ((regId >= triton::arch::ID_REG_X86_ZMM0 && regId <= triton::arch::ID_REG_X86_ZMM31) ? true : false);
+      }
 
       bool x8664Cpu::isControl(triton::arch::register_e regId) const {
         return ((regId >= triton::arch::ID_REG_X86_CR0 && regId <= triton::arch::ID_REG_X86_CR15) ? true : false);
@@ -411,7 +420,7 @@ namespace triton {
           const auto& reg = kv.second;
 
           /* Add GPR */
-          if (reg.getSize() == this->gprSize())
+          if (this->isGPR(regId) && reg.getSize() == this->gprSize())
             ret.insert(&reg);
 
           /* Add Flags */
@@ -420,10 +429,6 @@ namespace triton {
 
           /* Add STX */
           else if (this->isSTX(regId))
-            ret.insert(&reg);
-
-          /* Add SSE */
-          else if (this->isSSE(regId))
             ret.insert(&reg);
 
           /* Add FPU */
@@ -438,12 +443,11 @@ namespace triton {
           else if (this->isTSC(regId))
             ret.insert(&reg);
 
-          /* Add AVX-256 */
-          else if (this->isAVX256(regId))
+          else if (this->isSSECTL(regId))
             ret.insert(&reg);
 
           /* Add AVX-512 */
-          else if (this->isAVX512(regId))
+          else if (this->isAVX512Parent(regId))
             ret.insert(&reg);
 
           /* Add Control */

--- a/src/libtriton/arch/x86/x86Cpu.cpp
+++ b/src/libtriton/arch/x86/x86Cpu.cpp
@@ -264,7 +264,12 @@ namespace triton {
 
 
       bool x86Cpu::isSSE(triton::arch::register_e regId) const {
-        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_XMM7) ? true : false);
+        return ((regId >= triton::arch::ID_REG_X86_XMM0 && regId <= triton::arch::ID_REG_X86_XMM7) ? true : false);
+      }
+
+
+      bool x86Cpu::isSSECTL(triton::arch::register_e regId) const {
+        return ((regId >= triton::arch::ID_REG_X86_MXCSR && regId <= triton::arch::ID_REG_X86_MXCSR_MASK) ? true : false);
       }
 
 
@@ -336,7 +341,7 @@ namespace triton {
           const auto& reg = kv.second;
 
           /* Add GPR */
-          if (reg.getSize() == this->gprSize())
+          if (this->isGPR(regId) && reg.getSize() == this->gprSize())
             ret.insert(&reg);
 
           /* Add Flags */
@@ -345,10 +350,6 @@ namespace triton {
 
           /* Add STX */
           else if (this->isSTX(regId))
-            ret.insert(&reg);
-
-          /* Add SSE */
-          else if (this->isSSE(regId))
             ret.insert(&reg);
 
           /* Add FPU */
@@ -361,6 +362,9 @@ namespace triton {
 
           /* Add TSC */
           else if (this->isTSC(regId))
+            ret.insert(&reg);
+
+          else if (this->isSSECTL(regId))
             ret.insert(&reg);
 
           /* Add AVX-256 */

--- a/src/libtriton/arch/x86/x86Cpu.cpp
+++ b/src/libtriton/arch/x86/x86Cpu.cpp
@@ -232,6 +232,7 @@ namespace triton {
           this->isMMX(regId)      ||
           this->isSTX(regId)      ||
           this->isSSE(regId)      ||
+          this->isSSECTL(regId)   ||
           this->isFPU(regId)      ||
           this->isEFER(regId)     ||
           this->isTSC(regId)      ||

--- a/src/libtriton/includes/triton/x86.spec
+++ b/src/libtriton/includes/triton/x86.spec
@@ -339,16 +339,16 @@ REG_SPEC_NO_CAPSTONE(FSW_B,   fsw_b,   0, 0, FSW_B,   0, 0, FSW_B,   true)  // b
 
 /* EFER */
 
-REG_SPEC_NO_CAPSTONE(EFER, efer, triton::bitsize::qword-1, 0, EFER, triton::bitsize::qword-1, 0, EFER, true) // efer
+REG_SPEC_NO_CAPSTONE(EFER, efer, triton::bitsize::qword-1, 0, EFER, triton::bitsize::qword-1, 0, EFER, false) // efer
 
-REG_SPEC_NO_CAPSTONE(EFER_TCE,   efer_tce,   0, 0, EFER_TCE,   0, 0, EFER_TCE,   true) // efer_tce
-REG_SPEC_NO_CAPSTONE(EFER_FFXSR, efer_ffxsr, 0, 0, EFER_FFXSR, 0, 0, EFER_FFXSR, true) // efer_ffxsr
-REG_SPEC_NO_CAPSTONE(EFER_LMSLE, efer_lmsle, 0, 0, EFER_LMSLE, 0, 0, EFER_LMSLE, true) // efer_lmsle
-REG_SPEC_NO_CAPSTONE(EFER_SVME,  efer_svme,  0, 0, EFER_SVME,  0, 0, EFER_SVME,  true) // efer_svme
-REG_SPEC_NO_CAPSTONE(EFER_NXE,   efer_nxe,   0, 0, EFER_NXE,   0, 0, EFER_NXE,   true) // efer_nxe
-REG_SPEC_NO_CAPSTONE(EFER_LMA,   efer_lma,   0, 0, EFER_LMA,   0, 0, EFER_LMA,   true) // efer_lma
-REG_SPEC_NO_CAPSTONE(EFER_LME,   efer_lme,   0, 0, EFER_LME,   0, 0, EFER_LME,   true) // efer_lme
-REG_SPEC_NO_CAPSTONE(EFER_SCE,   efer_sce,   0, 0, EFER_SCE,   0, 0, EFER_SCE,   true) // efer_sce
+REG_SPEC_NO_CAPSTONE(EFER_TCE,   efer_tce,   0, 0, EFER_TCE,   0, 0, EFER_TCE,   false) // efer_tce
+REG_SPEC_NO_CAPSTONE(EFER_FFXSR, efer_ffxsr, 0, 0, EFER_FFXSR, 0, 0, EFER_FFXSR, false) // efer_ffxsr
+REG_SPEC_NO_CAPSTONE(EFER_LMSLE, efer_lmsle, 0, 0, EFER_LMSLE, 0, 0, EFER_LMSLE, false) // efer_lmsle
+REG_SPEC_NO_CAPSTONE(EFER_SVME,  efer_svme,  0, 0, EFER_SVME,  0, 0, EFER_SVME,  false) // efer_svme
+REG_SPEC_NO_CAPSTONE(EFER_NXE,   efer_nxe,   0, 0, EFER_NXE,   0, 0, EFER_NXE,   false) // efer_nxe
+REG_SPEC_NO_CAPSTONE(EFER_LMA,   efer_lma,   0, 0, EFER_LMA,   0, 0, EFER_LMA,   false) // efer_lma
+REG_SPEC_NO_CAPSTONE(EFER_LME,   efer_lme,   0, 0, EFER_LME,   0, 0, EFER_LME,   false) // efer_lme
+REG_SPEC_NO_CAPSTONE(EFER_SCE,   efer_sce,   0, 0, EFER_SCE,   0, 0, EFER_SCE,   false) // efer_sce
 
 /* Segments */
 

--- a/src/libtriton/includes/triton/x8664Cpu.hpp
+++ b/src/libtriton/includes/triton/x8664Cpu.hpp
@@ -297,6 +297,9 @@ namespace triton {
           //! Returns true if regId is a STX register.
           TRITON_EXPORT bool isSTX(triton::arch::register_e regId) const;
 
+          //! Returns true if regId is a SSE Contol register.
+          TRITON_EXPORT bool isSSECTL(triton::arch::register_e regId) const;
+
           //! Returns true if regId is a SSE register.
           TRITON_EXPORT bool isSSE(triton::arch::register_e regId) const;
 
@@ -312,8 +315,11 @@ namespace triton {
           //! Returns true if regId is a AVX-256 (YMM) register.
           TRITON_EXPORT bool isAVX256(triton::arch::register_e regId) const;
 
-          //! Returns true if regId is a AVX-512 (ZMM) register.
+          //! Returns true if regId is a AVX-512 (ZMM) register, or XMM and YMM registers after 15.
           TRITON_EXPORT bool isAVX512(triton::arch::register_e regId) const;
+
+          //! Returns true if regId is a AVX-512 (ZMM) register.
+          TRITON_EXPORT bool isAVX512Parent(triton::arch::register_e regId) const;
 
           //! Returns true if regId is a control (cr) register.
           TRITON_EXPORT bool isControl(triton::arch::register_e regId) const;

--- a/src/libtriton/includes/triton/x86Cpu.hpp
+++ b/src/libtriton/includes/triton/x86Cpu.hpp
@@ -233,6 +233,9 @@ namespace triton {
           //! Returns true if regId is a STX register.
           TRITON_EXPORT bool isSTX(triton::arch::register_e regId) const;
 
+          //! Returns true if regId is a SSE Contol register.
+          TRITON_EXPORT bool isSSECTL(triton::arch::register_e regId) const;
+
           //! Returns true if regId is a SSE register.
           TRITON_EXPORT bool isSSE(triton::arch::register_e regId) const;
 

--- a/src/testers/unittests/test_concrete_value.py
+++ b/src/testers/unittests/test_concrete_value.py
@@ -21,11 +21,11 @@ class TestX86ConcreteRegisterValue(unittest.TestCase):
 
     def test_all_registers(self):
         """Check all registers"""
-        self.assertEqual(len(self.ar), 166)
+        self.assertEqual(len(self.ar), 157)
 
     def test_parent_registers(self):
         """Check parent registers"""
-        self.assertEqual(len(self.pr), 129)
+        self.assertEqual(len(self.pr), 120)
 
     def test_set_get_concrete_value(self):
         """Check setting concrete values"""
@@ -99,7 +99,7 @@ class TestX8664ConcreteRegisterValue(unittest.TestCase):
 
     def test_parent_registers(self):
         """Check parent registers"""
-        self.assertEqual(len(self.pr), 233)
+        self.assertEqual(len(self.pr), 161)
 
     def test_set_get_concrete_value(self):
         """Check setting concrete values"""

--- a/src/testers/unittests/test_registers.py
+++ b/src/testers/unittests/test_registers.py
@@ -266,3 +266,23 @@ class TestRegisterObject(unittest.TestCase):
         self.assertEqual(self.x64.registers.rax, self.x64.getRegister('RaX'))
         self.assertEqual(self.arm.registers.r0, self.arm.getRegister('R0'))
         self.assertEqual(self.aarch.registers.x9, self.aarch.getRegister('x9'))
+
+class TestRegisterParents(unittest.TestCase):
+    """Test register Parent Register List"""
+
+    def setUp(self):
+        """Define the arch list"""
+        self.archctx = []
+        self.archctx.append(TritonContext(ARCH.X86))
+        self.archctx.append(TritonContext(ARCH.X86_64))
+        self.archctx.append(TritonContext(ARCH.ARM32))
+        self.archctx.append(TritonContext(ARCH.AARCH64))
+
+    def test_reg_parents(self):
+        for ctx in self.archctx:
+            parents = ctx.getParentRegisters()
+            for pr in parents:
+                self.assertEqual(pr, ctx.getParentRegister(pr))
+
+            for r in ctx.getAllRegisters():
+                self.assertIn(ctx.getParentRegister(r), parents)


### PR DESCRIPTION
Adds a new test and updates the getParentRegisters implementations so that all parent register are returned, and sub-registers are not.
See https://github.com/JonathanSalwan/Triton/issues/1335