### PR TITLE
+ Reference node's children

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -3012,6 +3012,7 @@ namespace triton {
     ReferenceNode::ReferenceNode(const triton::engines::symbolic::SharedSymbolicExpression& expr)
       : AbstractNode(REFERENCE_NODE, expr->getAst()->getContext())
       , expr(expr) {
+        this->addChild(expr->getAst());
     }
 
 


### PR DESCRIPTION
According to Issue #1356 a child for reference node obviously exists on AST graph, but it doesn't exists in vector with children, so it looks like incorrect work of API for interacting with ASTs.

There were two ways to solve this:
1.) I always have to cast SharedAbstractNode to ReferenceNode then getSymbolicExpresssion from it and then getAst from it again to finally get a real node with children.
2.) Use  AstContext::unroll(ast_node) to get a real node with children.

In this PR I add a real node with its children as a child of Reference node in Constructor. The lifetime of a real node will not change from this, and the API will become consistent and convenient without unnecessary static_cast.