### PR TITLE
Fix unsupported instruction for some bics variant

### DIFF
--- a/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
@@ -405,6 +405,7 @@ namespace triton {
               break;
 
             case triton::extlibs::capstone::ARM64_INS_BIC:
+            case triton::extlibs::capstone::ARM64_INS_BICS:
               tritonId = triton::arch::arm::aarch64::ID_INS_BIC;
               break;
 

--- a/src/testers/aarch64/unicorn_test_aarch64.py
+++ b/src/testers/aarch64/unicorn_test_aarch64.py
@@ -2071,6 +2071,9 @@ CODE  = [
     (b"\x22\x70\x1d\x72", "bics w2, w1, #7"),
     (b"\x22\x78\x1c\x72", "bics w2, w1, #8"),
 
+    (b"\x02\x00\x21\x6a", "bics w2, w0, w1"),
+    (b"\x1f\x00\x21\x6a", "bics wzr, w0, w1"),
+
     (b"\x28\x00\x00\x37", "tbnz w8, #0, #4"),
     (b"\x48\x00\x00\x36", "tbz w8, #0, #0"),
 


### PR DESCRIPTION
hola o/ 

Just a tiny fix to address some variant of bics instruction, like `bics wzr, w23, w17`, which were not recognized. 

Lo;
