### PR TITLE
Fixes improper sorting of function arguments when lifting to LLVM

### DIFF
--- a/src/libtriton/ast/llvm/tritonToLLVM.cpp
+++ b/src/libtriton/ast/llvm/tritonToLLVM.cpp
@@ -36,7 +36,11 @@ namespace triton {
       auto vars = triton::ast::search(node, triton::ast::VARIABLE_NODE);
 
       //! Sort symbolic variables
-      std::sort(vars.begin(), vars.end());
+      std::sort(vars.begin(), vars.end(), [](const triton::ast::SharedAbstractNode& a, const triton::ast::SharedAbstractNode& b) {
+        auto varA = reinterpret_cast<triton::ast::VariableNode*>(a.get())->getSymbolicVariable();
+        auto varB = reinterpret_cast<triton::ast::VariableNode*>(b.get())->getSymbolicVariable();
+        return *varA < *varB;
+      });
 
       // Each symbolic variable is a function argument
       std::vector<llvm::Type*> argsType;


### PR DESCRIPTION
When lifting a function to LLVM, the function arguments are incorrectly sorted because each one of them isn't getting dereferenced. This causes the `operator<` overload not getting called during comparison. If the address of the first pointer happens to be greater than the second one, the following will occur:

![image](https://github.com/user-attachments/assets/7e6915ee-9d50-4214-b1c8-bbdf62255780)