### PR TITLE
Update osx workflow

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -85,8 +85,8 @@ jobs:
           Z3_INCLUDE_DIRS: ${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/include
           Z3_LIBRARIES: ${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/bin/libz3.a
 
-     # NOTE Tests will fail because currently they only pass with Unicorn
-     # v2.0.0. However, Unicorn v2.0.0 does not build on the macos-14 runner.
      - name: Unittests
-       run: |
+       run:
+         # NOTE Tests will fail because currently they only pass with Unicorn
+         # v2.0.0. However, Unicorn v2.0.0 does not build on the macos-14 runner.
          DYLD_LIBRARY_PATH=/usr/local/lib/ ctest --test-dir build --output-on-failure

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     # macos-13 = x86
     # macos-14 = arm (M1)
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,9 +27,13 @@ jobs:
 
       - name: Install Z3
         run: |
-          wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.17/z3-4.8.17-x64-osx-10.16.zip
-          unzip z3-4.8.17-x64-osx-10.16.zip
-          sudo python -m pip install z3-solver==4.8.17.0
+          wget https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-arm64-osx-13.7.zip
+          unzip z3-4.13.3-arm64-osx-13.7.zip
+          sudo python -m pip install z3-solver==4.13.3.0
+
+      - name: Install Deps
+        run: |
+          brew install gmp pkgconfig ninja
 
       - name: Install Meson
         run: |
@@ -39,7 +43,7 @@ jobs:
         run: |
           git clone https://github.com/bitwuzla/bitwuzla.git
           cd bitwuzla
-          git checkout -b 0.4.0 0.4.0
+          git checkout -b 0.7.0 0.7.0
           python ./configure.py --shared --prefix $(pwd)/install
           cd build
           sudo ninja install
@@ -47,16 +51,16 @@ jobs:
 
       - name: Install Capstone
         run: |
-          wget https://github.com/aquynh/capstone/archive/5.0.1.tar.gz
-          tar -xf ./5.0.1.tar.gz
-          cd ./capstone-5.0.1
+          wget https://github.com/aquynh/capstone/archive/5.0.3.tar.gz
+          tar -xf ./5.0.3.tar.gz
+          cd ./capstone-5.0.3
           bash ./make.sh
           sudo make install
           cd ../
 
       - name: Install Unicorn
         run: |
-          sudo python -m pip install unicorn==2.0.1
+          sudo python -m pip install unicorn
 
       - name: Install LIEF
         run: |
@@ -68,8 +72,8 @@ jobs:
           cd ./build
           cmake ..
           cmake -DZ3_INTERFACE=ON \
-                -DZ3_INCLUDE_DIRS=${{ github.workspace }}/z3-4.8.17-x64-osx-10.16/include \
-                -DZ3_LIBRARIES=${{ github.workspace }}/z3-4.8.17-x64-osx-10.16/bin/libz3.a \
+                -DZ3_INCLUDE_DIRS=${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/include \
+                -DZ3_LIBRARIES=${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/bin/libz3.a \
                 -DBITWUZLA_INTERFACE=ON \
                 -DBITWUZLA_INCLUDE_DIRS=${{ github.workspace }}/bitwuzla/install/include \
                 -DBITWUZLA_LIBRARIES=${{ github.workspace }}/bitwuzla/install/lib/libbitwuzla.dylib \
@@ -78,9 +82,11 @@ jobs:
                 -DBOOST_INTERFACE=OFF ..
           sudo make -j3 install
         env:
-          Z3_INCLUDE_DIRS: ${{ github.workspace }}/z3-4.8.17-x64-osx-10.16/include
-          Z3_LIBRARIES: ${{ github.workspace }}/z3-4.8.17-x64-osx-10.16/bin/libz3.a
+          Z3_INCLUDE_DIRS: ${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/include
+          Z3_LIBRARIES: ${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/bin/libz3.a
 
-      - name: Unittests
-        run: |
-          ctest --test-dir build --output-on-failure
+     # NOTE Tests will fail because currently they only pass with Unicorn
+     # v2.0.0. However, Unicorn v2.0.0 does not build on the macos-14 runner.
+     - name: Unittests
+       run: |
+         DYLD_LIBRARY_PATH=/usr/local/lib/ ctest --test-dir build --output-on-failure

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -85,8 +85,8 @@ jobs:
           Z3_INCLUDE_DIRS: ${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/include
           Z3_LIBRARIES: ${{ github.workspace }}/z3-4.13.3-arm64-osx-13.7/bin/libz3.a
 
-     - name: Unittests
-       run:
-         # NOTE Tests will fail because currently they only pass with Unicorn
-         # v2.0.0. However, Unicorn v2.0.0 does not build on the macos-14 runner.
-         DYLD_LIBRARY_PATH=/usr/local/lib/ ctest --test-dir build --output-on-failure
+      # NOTE Tests will fail because currently they only pass with Unicorn
+      # v2.0.0. However, Unicorn v2.0.0 does not build on the macos-14 runner.
+      - name: Unittests
+        run:
+          DYLD_LIBRARY_PATH=/usr/local/lib/ ctest --test-dir build --output-on-failure


### PR DESCRIPTION
This PR updates the OSX workflow (runner and deps). Note that tests will fail because currently they only pass with Unicorn v2.0.0. However, Unicorn v2.0.0 does not build on the macos-14 runner.