### PR TITLE
Update Python versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         boost-interface: ['ON', 'OFF']
         capstone-version: ['5.0.3']
     steps:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,13 +29,6 @@ jobs:
                 --volume ${{env.LLVM_PATH}}:/llvm \
                 build-triton-linux-x86_64 bash /src/src/scripts/docker/build-wheel-linux.sh
 
-      - name: Upload Wheel packages (Python 3.8)
-        uses: actions/upload-artifact@v4
-        with:
-          name: triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_31_x86_64.whl
-          path: wheelhouse/manylinux_2_31_x86_64/triton_library-${{ env.package-version }}-cp38-cp38-manylinux_2_31_x86_64.whl
-          if-no-files-found: warn
-
       - name: Upload Wheel packages (Python 3.9)
         uses: actions/upload-artifact@v4
         with:
@@ -75,11 +68,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         include:
-          - python-version: 3.8
-            pycp: cp38-cp38
-            pylib: python38.lib
           - python-version: 3.9
             pycp: cp39-cp39
             pylib: python39.lib

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,36 +32,36 @@ jobs:
       - name: Upload Wheel packages (Python 3.9)
         uses: actions/upload-artifact@v4
         with:
-          name: triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_31_x86_64.whl
-          path: wheelhouse/manylinux_2_31_x86_64/triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_31_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_34_x86_64.whl
+          path: wheelhouse/manylinux_2_34_x86_64/triton_library-${{ env.package-version }}-cp39-cp39-manylinux_2_34_x86_64.whl
           if-no-files-found: warn
 
       - name: Upload Wheel packages (Python 3.10)
         uses: actions/upload-artifact@v4
         with:
-          name: triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_31_x86_64.whl
-          path: wheelhouse/manylinux_2_31_x86_64/triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_31_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_34_x86_64.whl
+          path: wheelhouse/manylinux_2_34_x86_64/triton_library-${{ env.package-version }}-cp310-cp310-manylinux_2_34_x86_64.whl
           if-no-files-found: warn
 
       - name: Upload Wheel packages (Python 3.11)
         uses: actions/upload-artifact@v4
         with:
-          name: triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_31_x86_64.whl
-          path: wheelhouse/manylinux_2_31_x86_64/triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_31_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_34_x86_64.whl
+          path: wheelhouse/manylinux_2_34_x86_64/triton_library-${{ env.package-version }}-cp311-cp311-manylinux_2_34_x86_64.whl
           if-no-files-found: warn
 
       - name: Upload Wheel packages (Python 3.12)
         uses: actions/upload-artifact@v4
         with:
-          name: triton_library-${{ env.package-version }}-cp312-cp312-manylinux_2_31_x86_64.whl
-          path: wheelhouse/manylinux_2_31_x86_64/triton_library-${{ env.package-version }}-cp312-cp312-manylinux_2_31_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp312-cp312-manylinux_2_34_x86_64.whl
+          path: wheelhouse/manylinux_2_34_x86_64/triton_library-${{ env.package-version }}-cp312-cp312-manylinux_2_34_x86_64.whl
           if-no-files-found: warn
 
       - name: Upload Wheel packages (Python 3.13)
         uses: actions/upload-artifact@v4
         with:
-          name: triton_library-${{ env.package-version }}-cp313-cp313-manylinux_2_31_x86_64.whl
-          path: wheelhouse/manylinux_2_31_x86_64/triton_library-${{ env.package-version }}-cp313-cp313-manylinux_2_31_x86_64.whl
+          name: triton_library-${{ env.package-version }}-cp313-cp313-manylinux_2_34_x86_64.whl
+          path: wheelhouse/manylinux_2_34_x86_64/triton_library-${{ env.package-version }}-cp313-cp313-manylinux_2_34_x86_64.whl
           if-no-files-found: warn
 
   build-windows:

--- a/src/scripts/docker/build-wheel-linux.sh
+++ b/src/scripts/docker/build-wheel-linux.sh
@@ -39,17 +39,6 @@ export BITWUZLA_LIBRARIES=$DEPENDENCIES_DIR/bitwuzla/install/lib64/libbitwuzla.s
 export LLVM_INTERFACE=ON
 export CMAKE_PREFIX_PATH=$LLVM_DIR
 
-# Build Triton Python wheel package for Python 3.8.
-echo "[+] Build Triton wheel package for Python 3.8"
-cd $SOURCE_DIR
-rm -rf $SOURCE_DIR/build
-rm -rf $SOURCE_DIR/triton_library.egg-info
-export PYTHON_BINARY=/opt/_internal/cpython-3.8.*/bin/python
-export PYTHON_INCLUDE_DIRS=$($PYTHON_BINARY -c "from sysconfig import get_paths; print(get_paths()['include'])")
-export PYTHON_LIBRARY=$($PYTHON_BINARY -c "from sysconfig import get_paths; print(get_paths()['include'])")
-
-$PYTHON_BINARY -m build --wheel --outdir $WHEEL_DIR/linux_x86_64
-
 # Build Triton Python wheel package for Python 3.9.
 echo "[+] Build Triton wheel package for Python 3.9"
 cd $SOURCE_DIR


### PR DESCRIPTION
This PR updates the Python versions of some of the CI, and drops support for Python 3.8 as the end of life was 2024-10-07.