### PR TITLE
Make compatible to llvm version >= 17

### DIFF
--- a/src/libtriton/includes/triton/tritonToLLVM.hpp
+++ b/src/libtriton/includes/triton/tritonToLLVM.hpp
@@ -10,8 +10,6 @@
 
 #include <map>
 #include <memory>
-#include <ostream>
-#include <string>
 #include <unordered_map>
 
 #include <triton/ast.hpp>
@@ -19,9 +17,7 @@
 
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
-#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
-#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 
 
 


### PR DESCRIPTION
I ran into problem when building with newer llvm. It shows up that LLVM 17 removed the required header.

https://stackoverflow.com/questions/76989779/compiling-a-program-that-uses-passmanagerbuilder-with-llvm-17

Passed with all current tests. Not sure if this is correct.