### PR TITLE
add cstdint include

### DIFF
--- a/src/libtriton/includes/triton/modesEnums.hpp
+++ b/src/libtriton/includes/triton/modesEnums.hpp
@@ -8,6 +8,7 @@
 #ifndef TRITON_MODES_HPP
 #define TRITON_MODES_HPP
 
+#include <cstdint>
 
 
 //! The Triton namespace


### PR DESCRIPTION
Fix for compilation issue (ie. on fedora 42 with gcc-15):

``` 
src/libtriton/includes/triton/modesEnums.hpp:51:64: error: ‘uint64_t’ was not declared in this scope
```