### PR TITLE
aarch64: support RCpc instructions

### DIFF
--- a/src/libtriton/arch/arm/aarch64/aarch64Semantics.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Semantics.cpp
@@ -109,6 +109,12 @@ LDURH                         | Load Register Halfword (unscaled)
 LDURSB                        | Load Register Signed Byte (unscaled)
 LDURSH                        | Load Register Signed Halfword (unscaled)
 LDURSW                        | Load Register Signed Word (unscaled)
+LDAPUR                        | Load-Acquire RCpc Register (unscaled)
+LDAPURB                       | Load-Acquire RCpc Register Byte (unscaled)
+LDAPURH                       | Load-Acquire RCpc Register Halfword (unscaled)
+LDAPURSB                      | Load-Acquire RCpc Register Signed Byte (unscaled)
+LDAPURSH                      | Load-Acquire RCpc Register Signed Halfword (unscaled)
+LDAPURSW                      | Load-Acquire RCpc Register Signed Word (unscaled)
 LDXP                          | Load Exclusive Pair of Registers
 LDXR                          | Load Exclusive Register
 LDXRB                         | Load Exclusive Register Byte
@@ -156,6 +162,9 @@ SMULL                         | Signed Multiply Long: an alias of SMADDL
 STLR                          | Store-Release Register
 STLRB                         | Store-Release Register Byte
 STLRH                         | Store-Release Register Halfword
+STLUR                         | Store-Release Register (unscaled)
+STLURB                        | Store-Release Register Byte (unscaled)
+STLURH                        | Store-Release Register Halfword (unscaled)
 STLXR                         | Store-Release Exclusive Register
 STLXRB                        | Store-Release Exclusive Register Byte
 STLXRH                        | Store-Release Exclusive Register Halfword
@@ -301,6 +310,12 @@ namespace triton {
             case ID_INS_LDURSB:    this->ldursb_s(inst);        break;
             case ID_INS_LDURSH:    this->ldursh_s(inst);        break;
             case ID_INS_LDURSW:    this->ldursw_s(inst);        break;
+            case ID_INS_LDAPUR:    this->ldapur_s(inst);        break;
+            case ID_INS_LDAPURB:   this->ldapurb_s(inst);       break;
+            case ID_INS_LDAPURH:   this->ldapurh_s(inst);       break;
+            case ID_INS_LDAPURSB:  this->ldapursb_s(inst);      break;
+            case ID_INS_LDAPURSH:  this->ldapursh_s(inst);      break;
+            case ID_INS_LDAPURSW:  this->ldapursw_s(inst);      break;
             case ID_INS_LDXP:      this->ldxp_s(inst);          break;
             case ID_INS_LDXR:      this->ldxr_s(inst);          break;
             case ID_INS_LDXRB:     this->ldxrb_s(inst);         break;
@@ -340,6 +355,9 @@ namespace triton {
             case ID_INS_STLR:      this->stlr_s(inst);          break;
             case ID_INS_STLRB:     this->stlrb_s(inst);         break;
             case ID_INS_STLRH:     this->stlrh_s(inst);         break;
+            case ID_INS_STLUR:     this->stlur_s(inst);         break;
+            case ID_INS_STLURB:    this->stlurb_s(inst);        break;
+            case ID_INS_STLURH:    this->stlurh_s(inst);        break;
             case ID_INS_STLXR:     this->stlxr_s(inst);         break;
             case ID_INS_STLXRB:    this->stlxrb_s(inst);        break;
             case ID_INS_STLXRH:    this->stlxrh_s(inst);        break;
@@ -3691,6 +3709,129 @@ namespace triton {
         }
 
 
+        void AArch64Semantics::ldapur_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create the semantics of the LOAD */
+          auto node = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPUR operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldapurb_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->zx(dst.getBitSize() - 8, op);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPURB operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldapurh_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->zx(dst.getBitSize() - 16, op);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPURH operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldapursb_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->sx(dst.getBitSize() - 8, op);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPURSB operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldapursh_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->sx(dst.getBitSize() - 16, op);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPURSH operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldapursw_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->sx(dst.getBitSize() - 32, op);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPURSW operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
         void AArch64Semantics::ldur_s(triton::arch::Instruction& inst) {
           triton::arch::OperandWrapper& dst = inst.operands[0];
           triton::arch::OperandWrapper& src = inst.operands[1];
@@ -5252,6 +5393,66 @@ namespace triton {
 
           /* Create symbolic expression */
           auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STTRH operation");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::stlur_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& src = inst.operands[0];
+          triton::arch::OperandWrapper& dst = inst.operands[1];
+
+          /* Create the semantics of the STORE */
+          auto node = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STLUR operation");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::stlurb_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& src = inst.operands[0];
+          triton::arch::OperandWrapper& dst = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->extract(7, 0, op);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STLURB operation");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::stlurh_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& src = inst.operands[0];
+          triton::arch::OperandWrapper& dst = inst.operands[1];
+
+          /* Create symbolic operands */
+          auto op = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create the semantics */
+          auto node = this->astCtxt->extract(15, 0, op);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "STLURH operation");
 
           /* Spread taint */
           expr->isTainted = this->taintEngine->taintAssignment(dst, src);

--- a/src/libtriton/arch/arm/aarch64/aarch64Semantics.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Semantics.cpp
@@ -74,6 +74,9 @@ LD4R                          | Load single 4-element structure and Replicate to
 LDAR                          | Load-Acquire Register
 LDARB                         | Load-Acquire Register Byte
 LDARH                         | Load-Acquire Register Halfword
+LDAPR                         | Load-Acquire RCpc Register
+LDAPRB                        | Load-Acquire RCpc Register Byte
+LDAPRH                        | Load-Acquire RCpc Register Halfword
 LDAXR                         | Load-Acquire Exclusive Register
 LDAXRB                        | Load-Acquire Exclusive Register Byte
 LDAXRH                        | Load-Acquire Exclusive Register Halfword
@@ -271,6 +274,9 @@ namespace triton {
             case ID_INS_LDAR:      this->ldar_s(inst);          break;
             case ID_INS_LDARB:     this->ldarb_s(inst);         break;
             case ID_INS_LDARH:     this->ldarh_s(inst);         break;
+            case ID_INS_LDAPR:     this->ldapr_s(inst);         break;
+            case ID_INS_LDAPRB:    this->ldaprb_s(inst);        break;
+            case ID_INS_LDAPRH:    this->ldaprh_s(inst);        break;
             case ID_INS_LDAXR:     this->ldaxr_s(inst);         break;
             case ID_INS_LDAXRB:    this->ldaxrb_s(inst);        break;
             case ID_INS_LDAXRH:    this->ldaxrh_s(inst);        break;
@@ -2957,6 +2963,60 @@ namespace triton {
 
           /* Create symbolic expression */
           auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDARH operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldapr_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create the semantics of the LOAD */
+          auto node = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPR operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldaprb_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create the semantics of the LOAD */
+          auto node = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPRB operation - LOAD access");
+
+          /* Spread taint */
+          expr->isTainted = this->taintEngine->taintAssignment(dst, src);
+
+          /* Update the symbolic control flow */
+          this->controlFlow_s(inst);
+        }
+
+
+        void AArch64Semantics::ldaprh_s(triton::arch::Instruction& inst) {
+          triton::arch::OperandWrapper& dst = inst.operands[0];
+          triton::arch::OperandWrapper& src = inst.operands[1];
+
+          /* Create the semantics of the LOAD */
+          auto node = this->symbolicEngine->getOperandAst(inst, src);
+
+          /* Create symbolic expression */
+          auto expr = this->symbolicEngine->createSymbolicExpression(inst, node, dst, "LDAPRH operation - LOAD access");
 
           /* Spread taint */
           expr->isTainted = this->taintEngine->taintAssignment(dst, src);

--- a/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
@@ -1061,6 +1061,30 @@ namespace triton {
               tritonId = triton::arch::arm::aarch64::ID_INS_LDURSW;
               break;
 
+            case triton::extlibs::capstone::ARM64_INS_LDAPUR:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPUR;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_LDAPURB:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPURB;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_LDAPURH:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPURH;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_LDAPURSB:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPURSB;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_LDAPURSH:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPURSH;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_LDAPURSW:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPURSW;
+              break;
+
             case triton::extlibs::capstone::ARM64_INS_LDXP:
               tritonId = triton::arch::arm::aarch64::ID_INS_LDXP;
               break;
@@ -1627,6 +1651,18 @@ namespace triton {
               tritonId = triton::arch::arm::aarch64::ID_INS_STLR;
               break;
 
+            case triton::extlibs::capstone::ARM64_INS_STLURB:
+              tritonId = triton::arch::arm::aarch64::ID_INS_STLURB;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_STLURH:
+              tritonId = triton::arch::arm::aarch64::ID_INS_STLURH;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_STLUR:
+              tritonId = triton::arch::arm::aarch64::ID_INS_STLUR;
+              break;
+
             case triton::extlibs::capstone::ARM64_INS_STLXP:
               tritonId = triton::arch::arm::aarch64::ID_INS_STLXP;
               break;
@@ -2187,8 +2223,11 @@ namespace triton {
             case ID_INS_LDTRSB:
             case ID_INS_LDURB:
             case ID_INS_LDURSB:
+            case ID_INS_LDAPURB:
+            case ID_INS_LDAPURSB:
             case ID_INS_LDXRB:
             case ID_INS_STLRB:
+            case ID_INS_STLURB:
             case ID_INS_STLXRB:
             case ID_INS_STRB:
             case ID_INS_STTRB:
@@ -2204,8 +2243,11 @@ namespace triton {
             case ID_INS_LDTRSH:
             case ID_INS_LDURH:
             case ID_INS_LDURSH:
+            case ID_INS_LDAPURH:
+            case ID_INS_LDAPURSH:
             case ID_INS_LDXRH:
             case ID_INS_STLRH:
+            case ID_INS_STLURH:
             case ID_INS_STLXRH:
             case ID_INS_STRH:
             case ID_INS_STTRH:
@@ -2215,6 +2257,7 @@ namespace triton {
             case ID_INS_LDRSW:
             case ID_INS_LDTRSW:
             case ID_INS_LDURSW:
+            case ID_INS_LDAPURSW:
               return 4;
             default:
               return 0;

--- a/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
+++ b/src/libtriton/arch/arm/aarch64/aarch64Specifications.cpp
@@ -949,6 +949,18 @@ namespace triton {
               tritonId = triton::arch::arm::aarch64::ID_INS_LDAR;
               break;
 
+            case triton::extlibs::capstone::ARM64_INS_LDAPR:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPR;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_LDAPRB:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPRB;
+              break;
+
+            case triton::extlibs::capstone::ARM64_INS_LDAPRH:
+              tritonId = triton::arch::arm::aarch64::ID_INS_LDAPRH;
+              break;
+
             case triton::extlibs::capstone::ARM64_INS_LDAXP:
               tritonId = triton::arch::arm::aarch64::ID_INS_LDAXP;
               break;
@@ -2167,6 +2179,7 @@ namespace triton {
         triton::uint32 AArch64Specifications::getMemoryOperandSpecialSize(triton::uint32 id) const {
           switch (id) {
             case ID_INS_LDARB:
+            case ID_INS_LDAPRB:
             case ID_INS_LDAXRB:
             case ID_INS_LDRB:
             case ID_INS_LDRSB:
@@ -2183,6 +2196,7 @@ namespace triton {
             case ID_INS_STXRB:
               return 1;
             case ID_INS_LDARH:
+            case ID_INS_LDAPRH:
             case ID_INS_LDAXRH:
             case ID_INS_LDRH:
             case ID_INS_LDRSH:

--- a/src/libtriton/bindings/python/namespaces/initOpcodesNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initOpcodesNamespace.cpp
@@ -1927,6 +1927,9 @@ According to the CPU architecture, the OPCODE namespace contains all kinds of op
 - **OPCODE.AARCH64.LDAR**<br>
 - **OPCODE.AARCH64.LDARB**<br>
 - **OPCODE.AARCH64.LDARH**<br>
+- **OPCODE.AARCH64.LDAPR**<br>
+- **OPCODE.AARCH64.LDAPRB**<br>
+- **OPCODE.AARCH64.LDAPRH**<br>
 - **OPCODE.AARCH64.LDAXP**<br>
 - **OPCODE.AARCH64.LDAXR**<br>
 - **OPCODE.AARCH64.LDAXRB**<br>
@@ -3866,6 +3869,9 @@ namespace triton {
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAR));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDARB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDARB));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDARH", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDARH));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPR));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPRB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPRB));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPRH", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPRH));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAXP", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAXP));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAXR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAXR));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAXRB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAXRB));

--- a/src/libtriton/bindings/python/namespaces/initOpcodesNamespace.cpp
+++ b/src/libtriton/bindings/python/namespaces/initOpcodesNamespace.cpp
@@ -1930,6 +1930,12 @@ According to the CPU architecture, the OPCODE namespace contains all kinds of op
 - **OPCODE.AARCH64.LDAPR**<br>
 - **OPCODE.AARCH64.LDAPRB**<br>
 - **OPCODE.AARCH64.LDAPRH**<br>
+- **OPCODE.AARCH64.LDAPUR**<br>
+- **OPCODE.AARCH64.LDAPURB**<br>
+- **OPCODE.AARCH64.LDAPURH**<br>
+- **OPCODE.AARCH64.LDAPURSB**<br>
+- **OPCODE.AARCH64.LDAPURSH**<br>
+- **OPCODE.AARCH64.LDAPURSW**<br>
 - **OPCODE.AARCH64.LDAXP**<br>
 - **OPCODE.AARCH64.LDAXR**<br>
 - **OPCODE.AARCH64.LDAXRB**<br>
@@ -2105,6 +2111,9 @@ According to the CPU architecture, the OPCODE namespace contains all kinds of op
 - **OPCODE.AARCH64.STLR**<br>
 - **OPCODE.AARCH64.STLRB**<br>
 - **OPCODE.AARCH64.STLRH**<br>
+- **OPCODE.AARCH64.STLUR**<br>
+- **OPCODE.AARCH64.STLURB**<br>
+- **OPCODE.AARCH64.STLURH**<br>
 - **OPCODE.AARCH64.STLXP**<br>
 - **OPCODE.AARCH64.STLXR**<br>
 - **OPCODE.AARCH64.STLXRB**<br>
@@ -3872,6 +3881,12 @@ namespace triton {
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPR));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPRB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPRB));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPRH", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPRH));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPUR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPUR));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPURB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPURB));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPURH", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPURH));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPURSB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPURSB));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPURSH", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPURSH));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "LDAPURSW", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAPURSW));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAXP", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAXP));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAXR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAXR));
         xPyDict_SetItemString(Aarch64OpcodesDict, "LDAXRB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_LDAXRB));
@@ -4047,6 +4062,9 @@ namespace triton {
         xPyDict_SetItemString(Aarch64OpcodesDict, "STLR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLR));
         xPyDict_SetItemString(Aarch64OpcodesDict, "STLRB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLRB));
         xPyDict_SetItemString(Aarch64OpcodesDict, "STLRH", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLRH));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "STLUR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLUR));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "STLURB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLURB));
+        xPyDict_SetItemString(Aarch64OpcodesDict, "STLURH", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLURH));
         xPyDict_SetItemString(Aarch64OpcodesDict, "STLXP", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLXP));
         xPyDict_SetItemString(Aarch64OpcodesDict, "STLXR", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLXR));
         xPyDict_SetItemString(Aarch64OpcodesDict, "STLXRB", PyLong_FromUint32(triton::arch::arm::aarch64::ID_INS_STLXRB));

--- a/src/libtriton/includes/triton/aarch64Semantics.hpp
+++ b/src/libtriton/includes/triton/aarch64Semantics.hpp
@@ -285,6 +285,15 @@ namespace triton {
             //! The LDARH semantics.
             void ldarh_s(triton::arch::Instruction& inst);
 
+            //! The LDAPR semantics.
+            void ldapr_s(triton::arch::Instruction& inst);
+
+            //! The LDAPRB semantics.
+            void ldaprb_s(triton::arch::Instruction& inst);
+
+            //! The LDAPRH semantics.
+            void ldaprh_s(triton::arch::Instruction& inst);
+
             //! The LDAXR semantics.
             void ldaxr_s(triton::arch::Instruction& inst);
 

--- a/src/libtriton/includes/triton/aarch64Semantics.hpp
+++ b/src/libtriton/includes/triton/aarch64Semantics.hpp
@@ -294,6 +294,24 @@ namespace triton {
             //! The LDAPRH semantics.
             void ldaprh_s(triton::arch::Instruction& inst);
 
+            //! The LDAPUR semantics.
+            void ldapur_s(triton::arch::Instruction& inst);
+
+            //! The LDAPURB semantics.
+            void ldapurb_s(triton::arch::Instruction& inst);
+
+            //! The LDAPURH semantics.
+            void ldapurh_s(triton::arch::Instruction& inst);
+
+            //! The LDAPURSB semantics.
+            void ldapursb_s(triton::arch::Instruction& inst);
+
+            //! The LDAPURSH semantics.
+            void ldapursh_s(triton::arch::Instruction& inst);
+
+            //! The LDAPURSW semantics.
+            void ldapursw_s(triton::arch::Instruction& inst);
+
             //! The LDAXR semantics.
             void ldaxr_s(triton::arch::Instruction& inst);
 
@@ -479,6 +497,15 @@ namespace triton {
 
             //! The STLRH semantics.
             void stlrh_s(triton::arch::Instruction& inst);
+
+            //! The STLUR semantics.
+            void stlur_s(triton::arch::Instruction& inst);
+
+            //! The STLURB semantics.
+            void stlurb_s(triton::arch::Instruction& inst);
+
+            //! The STLURH semantics.
+            void stlurh_s(triton::arch::Instruction& inst);
 
             //! The STLXR semantics.
             void stlxr_s(triton::arch::Instruction& inst);

--- a/src/libtriton/includes/triton/aarch64Specifications.hpp
+++ b/src/libtriton/includes/triton/aarch64Specifications.hpp
@@ -242,6 +242,9 @@ namespace triton {
           ID_INS_LDARB, //!< ldarb
           ID_INS_LDARH, //!< ldarh
           ID_INS_LDAR, //!< ldar
+          ID_INS_LDAPR, //!< ldapr
+          ID_INS_LDAPRB, //!< ldaprb
+          ID_INS_LDAPRH, //!< ldaprh
           ID_INS_LDAXP, //!< ldaxp
           ID_INS_LDAXRB, //!< ldaxrb
           ID_INS_LDAXRH, //!< ldaxrh

--- a/src/libtriton/includes/triton/aarch64Specifications.hpp
+++ b/src/libtriton/includes/triton/aarch64Specifications.hpp
@@ -245,6 +245,12 @@ namespace triton {
           ID_INS_LDAPR, //!< ldapr
           ID_INS_LDAPRB, //!< ldaprb
           ID_INS_LDAPRH, //!< ldaprh
+          ID_INS_LDAPUR, //!< ldapur
+          ID_INS_LDAPURB, //!< ldapurb
+          ID_INS_LDAPURH, //!< ldapurh
+          ID_INS_LDAPURSB, //!< ldapursb
+          ID_INS_LDAPURSH, //!< ldapursh
+          ID_INS_LDAPURSW, //!< ldapursw
           ID_INS_LDAXP, //!< ldaxp
           ID_INS_LDAXRB, //!< ldaxrb
           ID_INS_LDAXRH, //!< ldaxrh
@@ -410,6 +416,9 @@ namespace triton {
           ID_INS_STLRB, //!< stlrb
           ID_INS_STLRH, //!< stlrh
           ID_INS_STLR, //!< stlr
+          ID_INS_STLURB, //!< stlurb
+          ID_INS_STLURH, //!< stlurh
+          ID_INS_STLUR, //!< stlur
           ID_INS_STLXP, //!< stlxp
           ID_INS_STLXRB, //!< stlxrb
           ID_INS_STLXRH, //!< stlxrh

--- a/src/testers/aarch64/unicorn_test_aarch64.py
+++ b/src/testers/aarch64/unicorn_test_aarch64.py
@@ -1941,6 +1941,18 @@ CODE  = [
 
     (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
     (b"\x02\x02\x80\xd2", "movz x2, #16"),
+    (b"\x25\xc0\xbf\xf8", "ldapr x5, [x1]"),
+
+    (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
+    (b"\x02\x02\x80\xd2", "movz x2, #16"),
+    (b"\x25\xc0\xbf\x38", "ldaprb w5, [x1]"),
+
+    (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
+    (b"\x02\x02\x80\xd2", "movz x2, #16"),
+    (b"\x25\xc0\xbf\x78", "ldaprh w5, [x1]"),
+
+    (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
+    (b"\x02\x02\x80\xd2", "movz x2, #16"),
     (b"\x25\xfc\x5f\xc8", "ldaxr x5, [x1]"),
     (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
     (b"\x29\xfc\x5f\xc8", "ldaxr x9, [x1]"),

--- a/src/testers/aarch64/unicorn_test_aarch64.py
+++ b/src/testers/aarch64/unicorn_test_aarch64.py
@@ -1941,18 +1941,6 @@ CODE  = [
 
     (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
     (b"\x02\x02\x80\xd2", "movz x2, #16"),
-    (b"\x25\xc0\xbf\xf8", "ldapr x5, [x1]"),
-
-    (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
-    (b"\x02\x02\x80\xd2", "movz x2, #16"),
-    (b"\x25\xc0\xbf\x38", "ldaprb w5, [x1]"),
-
-    (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
-    (b"\x02\x02\x80\xd2", "movz x2, #16"),
-    (b"\x25\xc0\xbf\x78", "ldaprh w5, [x1]"),
-
-    (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
-    (b"\x02\x02\x80\xd2", "movz x2, #16"),
     (b"\x25\xfc\x5f\xc8", "ldaxr x5, [x1]"),
     (b"\x01\x06\xa0\xd2", "movz x1, #0x30, lsl #16"), # HEAP address
     (b"\x29\xfc\x5f\xc8", "ldaxr x9, [x1]"),

--- a/src/testers/unittests/test_semantics.py
+++ b/src/testers/unittests/test_semantics.py
@@ -477,6 +477,67 @@ class TestCustomIR(unittest.TestCase):
                 found = True
         self.assertTrue(found)
 
+    def test_rcpc_loads_aarch64(self):
+        ctx = TritonContext(ARCH.AARCH64)
+
+        ctx.setConcreteRegisterValue(ctx.registers.x1, 0x1000)
+        ctx.setConcreteMemoryAreaValue(0x1000, b"\x11\x22\x33\x44\x55\x66\x77\x88")
+
+        ctx.processing(Instruction(b"\x25\xc0\xbf\xf8")) # ldapr x5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.x5), 0x8877665544332211)
+
+        ctx.processing(Instruction(b"\x25\xc0\xbf\x38")) # ldaprb w5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.w5), 0x11)
+
+        ctx.processing(Instruction(b"\x25\xc0\xbf\x78")) # ldaprh w5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.w5), 0x2211)
+
+        ctx.processing(Instruction(b"\x25\x00\x40\xd9")) # ldapur x5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.x5), 0x8877665544332211)
+
+        ctx.processing(Instruction(b"\x25\x00\x40\x19")) # ldapurb w5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.w5), 0x11)
+
+        ctx.processing(Instruction(b"\x25\x00\x40\x59")) # ldapurh w5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.w5), 0x2211)
+
+        ctx.setConcreteRegisterValue(ctx.registers.x1, 0x1100)
+        ctx.setConcreteMemoryAreaValue(0x1100, b"\x80")
+        ctx.processing(Instruction(b"\x25\x00\xc0\x19")) # ldapursb w5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.w5), 0xffffff80)
+
+        ctx.setConcreteRegisterValue(ctx.registers.x1, 0x1110)
+        ctx.setConcreteMemoryAreaValue(0x1110, b"\x01\x80")
+        ctx.processing(Instruction(b"\x25\x00\xc0\x59")) # ldapursh w5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.w5), 0xffff8001)
+
+        ctx.setConcreteRegisterValue(ctx.registers.x1, 0x1120)
+        ctx.setConcreteMemoryAreaValue(0x1120, b"\x01\x00\x00\x80")
+        ctx.processing(Instruction(b"\x25\x00\x80\x99")) # ldapursw x5, [x1]
+        self.assertEqual(ctx.getConcreteRegisterValue(ctx.registers.x5), 0xffffffff80000001)
+
+    def test_rcpc_stores_aarch64(self):
+        ctx = TritonContext(ARCH.AARCH64)
+
+        ctx.setConcreteRegisterValue(ctx.registers.x5, 0x1122334455667788)
+        ctx.setConcreteRegisterValue(ctx.registers.w6, 0xaabbccdd)
+        ctx.setConcreteRegisterValue(ctx.registers.w7, 0x11223344)
+
+        ctx.setConcreteRegisterValue(ctx.registers.x1, 0x2000)
+        ctx.setConcreteMemoryAreaValue(0x2000, b"\x00" * 8)
+        ctx.processing(Instruction(b"\x25\x00\x00\xd9")) # stlur x5, [x1]
+        self.assertEqual(ctx.getConcreteMemoryAreaValue(0x2000, 8), b"\x88\x77\x66\x55\x44\x33\x22\x11")
+
+        ctx.setConcreteRegisterValue(ctx.registers.x1, 0x2010)
+        ctx.setConcreteMemoryAreaValue(0x2010, b"\x00")
+        ctx.processing(Instruction(b"\x26\x00\x00\x19")) # stlurb w6, [x1]
+        self.assertEqual(ctx.getConcreteMemoryAreaValue(0x2010, 1), b"\xdd")
+
+        ctx.setConcreteRegisterValue(ctx.registers.x1, 0x2020)
+        ctx.setConcreteMemoryAreaValue(0x2020, b"\x00\x00")
+        ctx.processing(Instruction(b"\x27\x00\x00\x59")) # stlurh w7, [x1]
+        self.assertEqual(ctx.getConcreteMemoryAreaValue(0x2020, 2), b"\x44\x33")
+
     def test_fpu_x86(self):
         ctx = TritonContext()
         ctx.setArchitecture(ARCH.X86_64)


### PR DESCRIPTION
these instructions are appearing in binaries, and triton does not support them. this patch adds support.