### PR TITLE
Fix capstone 6 compatibility for ARM64

### DIFF
--- a/src/libtriton/includes/triton/externalLibs.hpp
+++ b/src/libtriton/includes/triton/externalLibs.hpp
@@ -34,6 +34,10 @@ namespace triton {
       #include <capstone/capstone.h>
       #include <capstone/riscv.h>
       #include <capstone/x86.h>
+
+      #if CS_API_MAJOR >= 6
+      constexpr auto CS_ARCH_ARM64 = CS_ARCH_AARCH64;
+      #endif
     /*! @} End of capstone namespace */
     };
 


### PR DESCRIPTION
Capstone 6 renamed CS_ARCH_ARM64 -> CS_ARCH_AARCH64. This adds a constexpr auto
alias inside the capstone namespace wrapper, gated by CS_API_MAJOR >= 6, to
maintain compatibility with both capstone 5 and 6.
