### PR TITLE
Migrate off deprecated LLVM pointer and interinsic APIs

### DIFF
--- a/src/libtriton/ast/llvm/tritonToLLVM.cpp
+++ b/src/libtriton/ast/llvm/tritonToLLVM.cpp
@@ -151,6 +151,7 @@ namespace triton {
 
         case triton::ast::BSWAP_NODE: {
           llvm::Function* bswap = nullptr;
+#if LLVM_VERSION_MAJOR >= 20
           switch (node->getBitvectorSize()) {
             case triton::bitsize::byte:   bswap = llvm::Intrinsic::getOrInsertDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt8Ty(this->llvmContext));   break;
             case triton::bitsize::word:   bswap = llvm::Intrinsic::getOrInsertDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt16Ty(this->llvmContext));  break;
@@ -160,6 +161,17 @@ namespace triton {
             default:
               throw triton::exceptions::AstLifting("TritonToLLVM::do_convert(): Invalid bswap size.");
           }
+#else
+          switch (node->getBitvectorSize()) {
+            case triton::bitsize::byte:   bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt8Ty(this->llvmContext));   break;
+            case triton::bitsize::word:   bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt16Ty(this->llvmContext));  break;
+            case triton::bitsize::dword:  bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt32Ty(this->llvmContext));  break;
+            case triton::bitsize::qword:  bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt64Ty(this->llvmContext));  break;
+            case triton::bitsize::dqword: bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt128Ty(this->llvmContext)); break;
+            default:
+              throw triton::exceptions::AstLifting("TritonToLLVM::do_convert(): Invalid bswap size.");
+          }
+#endif
           return this->llvmIR.CreateCall(bswap, children[0]);
         }
 
@@ -345,14 +357,22 @@ namespace triton {
           return results->at(reinterpret_cast<triton::ast::ReferenceNode*>(node.get())->getSymbolicExpression()->getAst());
 
         case triton::ast::SELECT_NODE: {
+#if LLVM_VERSION_MAJOR >= 20
           auto* ptrTy = llvm::PointerType::get(this->llvmContext, 0);
           auto* ptr = this->llvmIR.CreateIntToPtr(children[1], ptrTy);
+#else
+          auto* ptr = this->llvmIR.CreateIntToPtr(children[1], llvm::Type::getInt8Ty(this->llvmContext)->getPointerTo());
+#endif
           return this->llvmIR.CreateLoad(llvm::Type::getInt8Ty(this->llvmContext), ptr);
         }
 
         case triton::ast::STORE_NODE: {
+#if LLVM_VERSION_MAJOR >= 20
           auto* ptrTy = llvm::PointerType::get(this->llvmContext, 0);
           auto* ptr = this->llvmIR.CreateIntToPtr(children[1], ptrTy);
+#else
+          auto* ptr = this->llvmIR.CreateIntToPtr(children[1], llvm::Type::getInt8Ty(this->llvmContext)->getPointerTo());
+#endif
           return this->llvmIR.CreateStore(children[2], ptr);
         }
 

--- a/src/libtriton/ast/llvm/tritonToLLVM.cpp
+++ b/src/libtriton/ast/llvm/tritonToLLVM.cpp
@@ -152,11 +152,11 @@ namespace triton {
         case triton::ast::BSWAP_NODE: {
           llvm::Function* bswap = nullptr;
           switch (node->getBitvectorSize()) {
-            case triton::bitsize::byte:   bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt8Ty(this->llvmContext));   break;
-            case triton::bitsize::word:   bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt16Ty(this->llvmContext));  break;
-            case triton::bitsize::dword:  bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt32Ty(this->llvmContext));  break;
-            case triton::bitsize::qword:  bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt64Ty(this->llvmContext));  break;
-            case triton::bitsize::dqword: bswap = llvm::Intrinsic::getDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt128Ty(this->llvmContext)); break;
+            case triton::bitsize::byte:   bswap = llvm::Intrinsic::getOrInsertDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt8Ty(this->llvmContext));   break;
+            case triton::bitsize::word:   bswap = llvm::Intrinsic::getOrInsertDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt16Ty(this->llvmContext));  break;
+            case triton::bitsize::dword:  bswap = llvm::Intrinsic::getOrInsertDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt32Ty(this->llvmContext));  break;
+            case triton::bitsize::qword:  bswap = llvm::Intrinsic::getOrInsertDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt64Ty(this->llvmContext));  break;
+            case triton::bitsize::dqword: bswap = llvm::Intrinsic::getOrInsertDeclaration(this->llvmModule.get(), llvm::Intrinsic::bswap, llvm::Type::getInt128Ty(this->llvmContext)); break;
             default:
               throw triton::exceptions::AstLifting("TritonToLLVM::do_convert(): Invalid bswap size.");
           }
@@ -345,12 +345,14 @@ namespace triton {
           return results->at(reinterpret_cast<triton::ast::ReferenceNode*>(node.get())->getSymbolicExpression()->getAst());
 
         case triton::ast::SELECT_NODE: {
-          auto* ptr = this->llvmIR.CreateIntToPtr(children[1], llvm::Type::getInt8Ty(this->llvmContext)->getPointerTo());
+          auto* ptrTy = llvm::PointerType::get(this->llvmContext, 0);
+          auto* ptr = this->llvmIR.CreateIntToPtr(children[1], ptrTy);
           return this->llvmIR.CreateLoad(llvm::Type::getInt8Ty(this->llvmContext), ptr);
         }
 
         case triton::ast::STORE_NODE: {
-          auto* ptr = this->llvmIR.CreateIntToPtr(children[1], llvm::Type::getInt8Ty(this->llvmContext)->getPointerTo());
+          auto* ptrTy = llvm::PointerType::get(this->llvmContext, 0);
+          auto* ptr = this->llvmIR.CreateIntToPtr(children[1], ptrTy);
           return this->llvmIR.CreateStore(children[2], ptr);
         }
 


### PR DESCRIPTION
Because `llvm::Intrinsic::getDeclaration()` was deprecated in LLVM 20 and was removed in [this pull](https://github.com/llvm/llvm-project/pull/152645), I was unable to build the lifter with the latest LLVM in my system. Replaced the calls with the new `getOrInsertDeclaration()`.

Also updated the pointers in `SELECT_NODE` and `STORE_NODE` in order to get rid of the deprecated `llvm::Type::getPointerTo()` ([also from LLVM 20](https://github.com/llvm/llvm-project/pull/113331)) in favour of the opaque pointers (`llvm::PointerType::get()`).