### PR TITLE
Run the Unicorn semantics tests on Windows too

### DIFF
--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -375,6 +375,10 @@ if(PYTHON_BINDINGS)
         install(FILES $<TARGET_FILE_DIR:triton>/triton${PYTHON_SUFFIX} DESTINATION ${PYTHON_SITE_PACKAGES})
     else()
         execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import version_info; print(f'lib/python{version_info[0]}.{version_info[1]}/site-packages')" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
-        install(FILES $<TARGET_FILE_DIR:triton>/triton${PYTHON_SUFFIX} DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_PACKAGES})
+        # PYTHON_SITE_PACKAGES is already relative here, and install() resolves a
+        # relative DESTINATION against CMAKE_INSTALL_PREFIX. Prefixing it again made
+        # the path absolute, which CMake >= 4 rejects under -Werror=dev and which
+        # also defeated `cmake --install --prefix <other>`.
+        install(FILES $<TARGET_FILE_DIR:triton>/triton${PYTHON_SUFFIX} DESTINATION ${PYTHON_SITE_PACKAGES})
     endif()
 endif()

--- a/src/libtriton/CMakeLists.txt
+++ b/src/libtriton/CMakeLists.txt
@@ -257,6 +257,13 @@ configure_file(
     IMMEDIATE @ONLY
 )
 
+# Endianness of the target, for triton/config.hpp. CMAKE_CXX_BYTE_ORDER exists
+# since CMake 3.20, which is already the minimum required version. Everything
+# Triton currently builds for is little-endian, so absence means little-endian.
+if(CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+    set(TRITON_BIG_ENDIAN ON)
+endif()
+
 # We generate the config header based on configuation of CMake
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/includes/triton/config.hpp.in

--- a/src/libtriton/arch/immediate.cpp
+++ b/src/libtriton/arch/immediate.cpp
@@ -10,11 +10,20 @@
 #include <triton/exceptions.hpp>
 #include <triton/softfloat.hpp>
 #include <triton/coreUtils.hpp>
+#include <triton/config.hpp>
 
-#ifdef LITTLE_ENDIAN // provided by CMake
-constexpr auto sys_endianness = triton::arch::LE_ENDIANNESS;
-#else
+/*
+ * Note: this used to test `#ifdef LITTLE_ENDIAN`, which never worked as an
+ * endianness check. POSIX <endian.h> defines LITTLE_ENDIAN and BIG_ENDIAN as
+ * *named constants* (1234 and 4321), so the macro is always defined there
+ * regardless of the actual byte order, and it is never defined under MSVC --
+ * which made every Windows build take the big-endian branch and byte-swap
+ * every floating-point immediate.
+ */
+#ifdef TRITON_BIG_ENDIAN
 constexpr auto sys_endianness = triton::arch::BE_ENDIANNESS;
+#else
+constexpr auto sys_endianness = triton::arch::LE_ENDIANNESS;
 #endif
 
 

--- a/src/libtriton/includes/triton/config.hpp.in
+++ b/src/libtriton/includes/triton/config.hpp.in
@@ -13,4 +13,7 @@
 #cmakedefine TRITON_LLVM_INTERFACE
 #cmakedefine TRITON_Z3_INTERFACE
 
+/* Set when the target is big-endian; absent means little-endian. */
+#cmakedefine TRITON_BIG_ENDIAN
+
 #endif // TRITON_CONFIG_HPP

--- a/src/testers/CMakeLists.txt
+++ b/src/testers/CMakeLists.txt
@@ -1,6 +1,8 @@
 # These following tests are used to test our semantics. It relies on Unicorn emulator.
-# We test our semantics on Linux and OSX only because the setup is easier.
-if((${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND PYTHON_BINDINGS)
+# Windows is included: unicorn and lief both publish win_amd64 wheels, none of
+# these scripts are platform specific, and running them there caught a real
+# Windows-only bug (see the FP-immediate endianness fix).
+if((${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR ${CMAKE_SYSTEM_NAME} MATCHES "Windows") AND PYTHON_BINDINGS)
     enable_testing()
 
     add_test(NAME UnicornAArch64Semantics  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/aarch64/unicorn_test_aarch64.py)


### PR DESCRIPTION
> **Stacked on #1457 and #1455.** The first two commits here are those PRs; please review
> only the third. #1457 fixes a pre-existing CMake 4 failure in the vcpkg workflow;
> #1455 is the bug this PR's test change uncovers.

### Summary

`src/testers/CMakeLists.txt` has gated the 39 semantics tests to Linux and Darwin since they were added, with the comment *"because the setup is easier."* That is no longer true, and the gate was concealing a real Windows-only correctness bug.

### Why the reason no longer holds

* `unicorn` (2.1.4) and `lief` (1.0.0) both publish `win_amd64` wheels.
* None of the 27 `unicorn_test*.py` scripts or the 12 lief-driven ARM32 crypto runners contain anything platform specific. Searching all of them for `mmap`, `fcntl`, `subprocess`, `os.uname` and `platform.system` matches only the `#!` line, and `ctest` invokes them through `${PYTHON_EXECUTABLE}` rather than the shebang.
* `.github/actions/install-triton-deps/windows` already runs `python -m pip install unicorn lief`, so Windows CI has been paying for the dependencies without using them.

### Measured

`windows-2022` as subject, `ubuntu-24.04` as control on an identical configuration — capstone 5.0.7, unicorn 2.1.4, lief 1.0.0, `LLVM_INTERFACE=OFF` on both, versions confirmed from the job logs:

| Leg | Result | Time |
|---|---|---|
| windows-x64 | 40 / 41 | 605.6s |
| ubuntu-24.04 (control) | 47 / 47 | 526.2s |

The totals differ because Windows does not register the C++ example tests and adds `DummyTest`.

38 of the 39 previously-gated tests pass on Windows unchanged. The single failure was:

```
[KO] fmov s0, #2.0
	v0: 0x40000000 (UC) != 0x40 (TT)
```

which is the bug fixed by #1455. With it applied, both platforms are green.

### Cost and benefit

Roughly ten minutes of Windows CI time. In exchange, the AArch64, ARM32, RISC-V and x86 semantics get cross-validated against a second emulator on Windows.

The Python unit tests cannot substitute for this. They check fixed expected values, so they only catch what someone thought to write down — `test_semantics.py` and `test_emulation.py` pass on Windows today and never touch `fmov` with an immediate. Differential testing against Unicorn is what found this, and it is the only thing in the tree that could have.
