### PR TITLE
Fix/ast parent lifetime

### DIFF
--- a/src/libtriton/ast/ast.cpp
+++ b/src/libtriton/ast/ast.cpp
@@ -42,6 +42,13 @@ namespace triton {
 
 
     AbstractNode::~AbstractNode() {
+      /* Expired weak parents retain control blocks until they are removed. */
+      for (const auto& child : this->children) {
+        if (child) {
+          /* Remove every occurrence of this parent, including repeated init(). */
+          child->parents.erase(this);
+        }
+      }
       /* See #828: Release ownership before calling container destructor */
       this->children.clear();
     }

--- a/src/testers/CMakeLists.txt
+++ b/src/testers/CMakeLists.txt
@@ -1,3 +1,15 @@
+add_executable(test_ast_lifetime unittests/test_ast_lifetime.cpp)
+target_link_libraries(test_ast_lifetime PRIVATE triton)
+set_property(TARGET test_ast_lifetime PROPERTY CXX_STANDARD 17)
+if(WIN32)
+    set_property(TARGET test_ast_lifetime PROPERTY RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:triton>")
+endif()
+if(MSVC AND MSVC_STATIC)
+    set_property(TARGET test_ast_lifetime PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+add_test(NAME AstLifetime COMMAND test_ast_lifetime)
+add_dependencies(check test_ast_lifetime)
+
 # These following tests are used to test our semantics. It relies on Unicorn emulator.
 # Windows is included: unicorn and lief both publish win_amd64 wheels, none of
 # these scripts are platform specific, and running them there caught a real

--- a/src/testers/unittests/test_ast_lifetime.cpp
+++ b/src/testers/unittests/test_ast_lifetime.cpp
@@ -1,0 +1,218 @@
+/*
+** Copyright (C) - Triton
+** This program is under the terms of the Apache License 2.0.
+*/
+
+#include <cstdio>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include <triton/ast.hpp>
+#include <triton/astContext.hpp>
+#include <triton/context.hpp>
+#include <triton/symbolicExpression.hpp>
+
+namespace {
+
+  struct AllocationCounts {
+    unsigned allocated = 0;
+    unsigned deallocated = 0;
+    unsigned destroyed = 0;
+  };
+
+  template <typename T>
+  struct CountingAllocator {
+    using value_type = T;
+    AllocationCounts* counts;
+
+    explicit CountingAllocator(AllocationCounts& counts) : counts(&counts) {
+    }
+
+    template <typename U>
+    CountingAllocator(const CountingAllocator<U>& other) : counts(other.counts) {
+    }
+
+    T* allocate(std::size_t size) {
+      T* ptr = std::allocator<T>{}.allocate(size);
+      ++counts->allocated;
+      return ptr;
+    }
+
+    void deallocate(T* ptr, std::size_t size) {
+      ++counts->deallocated;
+      std::allocator<T>{}.deallocate(ptr, size);
+    }
+
+    template <typename U>
+    bool operator==(const CountingAllocator<U>& other) const {
+      return counts == other.counts;
+    }
+
+    template <typename U>
+    bool operator!=(const CountingAllocator<U>& other) const {
+      return !(*this == other);
+    }
+  };
+
+  template <typename Node>
+  struct TrackedNode : Node {
+    AllocationCounts& counts;
+
+    template <typename... Args>
+    TrackedNode(AllocationCounts& counts, Args&&... args)
+      : Node(std::forward<Args>(args)...), counts(counts) {
+    }
+
+    ~TrackedNode() override {
+      ++counts.destroyed;
+    }
+  };
+
+  template <typename Node, typename... Args>
+  std::shared_ptr<TrackedNode<Node>> tracked(AllocationCounts& counts, Args&&... args) {
+    using T = TrackedNode<Node>;
+    return std::allocate_shared<T>(CountingAllocator<T>(counts), counts,
+                                   std::forward<Args>(args)...);
+  }
+
+  void require(bool condition, const char* message) {
+    if (!condition) {
+      throw std::runtime_error(message);
+    }
+  }
+
+  void requireReleased(const AllocationCounts& counts) {
+    require(counts.allocated > 0, "allocate_shared did not use the tracking allocator");
+    require(counts.destroyed == 1, "AST node destructor did not run");
+    require(counts.deallocated == counts.allocated,
+            "destroyed AST node's allocation is retained while its child is alive");
+  }
+
+  void testParentRelease() {
+    AllocationCounts counts;
+    triton::Context ctx(triton::arch::ARCH_X86_64);
+    auto ast = ctx.getAstContext();
+    auto var = ast->variable(ctx.newSymbolicVariable(64));
+    {
+      auto node = tracked<triton::ast::BvxorNode>(counts, var, ast->bv(1, 64));
+      node->init();
+    }
+    // Do not call getParents(): it would hide delayed control-block reclamation.
+    requireReleased(counts);
+  }
+
+  void testRepeatedChildAndInit() {
+    AllocationCounts counts;
+    triton::Context ctx(triton::arch::ARCH_X86_64);
+    auto ast = ctx.getAstContext();
+    auto sym = ctx.newSymbolicVariable(64);
+    auto var = ast->variable(sym);
+    auto survivor = ast->bvxor(var, ast->bv(1, 64));
+    {
+      auto node = tracked<triton::ast::BvaddNode>(counts, var, var);
+      node->init();
+      node->init();
+      node->init();
+    }
+    requireReleased(counts);
+    ctx.setConcreteVariableValue(sym, 7);
+    require(survivor->evaluate() == 6, "surviving parent lost its variable dependency");
+  }
+
+  void testReplacingOneRepeatedChild() {
+    AllocationCounts counts;
+    triton::Context ctx(triton::arch::ARCH_X86_64);
+    auto ast = ctx.getAstContext();
+    auto sym = ctx.newSymbolicVariable(64);
+    auto var = ast->variable(sym);
+    auto replacement = ast->bv(3, 64);
+    {
+      auto node = tracked<triton::ast::BvaddNode>(counts, var, var);
+      node->init();
+      node->setChild(0, replacement);
+      ctx.setConcreteVariableValue(sym, 7);
+      require(node->evaluate() == 10, "replacing one child removed the remaining dependency");
+    }
+    requireReleased(counts);
+  }
+
+  void testSharedIntermediateChild() {
+    AllocationCounts counts;
+    triton::Context ctx(triton::arch::ARCH_X86_64);
+    auto ast = ctx.getAstContext();
+    auto var = ast->variable(ctx.newSymbolicVariable(64));
+    auto shared = ast->bvadd(var, ast->bv(2, 64));
+    {
+      auto node = tracked<triton::ast::BvxorNode>(counts, shared, shared);
+      node->init();
+    }
+    requireReleased(counts);
+    require(shared->evaluate() == 2, "shared child was invalidated");
+  }
+
+  void testInvalidChildDuringDestruction() {
+    AllocationCounts counts;
+    triton::Context ctx(triton::arch::ARCH_X86_64);
+    auto ast = ctx.getAstContext();
+    auto var = ast->variable(ctx.newSymbolicVariable(64));
+    {
+      auto node = tracked<triton::ast::BvaddNode>(counts, var, var);
+      node->init();
+      node->getChildren()[1].reset();
+    }
+    requireReleased(counts);
+  }
+
+  void testCopiesAndReferences() {
+    triton::Context ctx(triton::arch::ARCH_X86_64);
+    auto ast = ctx.getAstContext();
+    auto sym = ctx.newSymbolicVariable(64);
+    auto var = ast->variable(sym);
+    auto expression = ctx.newSymbolicExpression(ast->bvadd(var, ast->bv(2, 64)));
+    auto reference = ast->reference(expression);
+    auto original = ast->bvxor(reference, var);
+    auto duplicate = triton::ast::newInstance(expression->getAst().get());
+    auto unrolled = triton::ast::unroll(original);
+    for (unsigned i = 0; i < 100; ++i) {
+      auto temporary = triton::ast::unroll(original);
+    }
+    ctx.setConcreteVariableValue(sym, 7);
+    require(original->evaluate() == 14, "original AST no longer follows its variable");
+    require(duplicate->evaluate() == 9, "duplicate AST no longer follows its variable");
+    require(unrolled->evaluate() == 14, "unrolled AST no longer follows its variable");
+    expression->setAst(ast->bvadd(var, ast->bv(4, 64)));
+    require(original->evaluate() == 12, "reference no longer follows expression replacement");
+    require(duplicate->evaluate() == 9, "expression replacement modified the duplicate AST");
+    require(unrolled->evaluate() == 14, "expression replacement modified the unrolled AST");
+  }
+
+} // namespace
+
+int main() {
+  const struct {
+    const char* name;
+    void (*run)();
+  } tests[] = {
+    {"parent allocation release", testParentRelease},
+    {"repeated child and init", testRepeatedChildAndInit},
+    {"replace one repeated child", testReplacingOneRepeatedChild},
+    {"shared intermediate child", testSharedIntermediateChild},
+    {"null child during destruction", testInvalidChildDuringDestruction},
+    {"copies and references", testCopiesAndReferences},
+  };
+  unsigned failed = 0;
+  for (const auto& test : tests) {
+    try {
+      test.run();
+      std::printf("PASS: %s\n", test.name);
+    }
+    catch (const std::exception& error) {
+      ++failed;
+      std::printf("FAIL: %s: %s\n", test.name, error.what());
+    }
+  }
+  std::printf("%u/%zu tests passed\n", static_cast<unsigned>(sizeof(tests) / sizeof(tests[0])) - failed,
+              sizeof(tests) / sizeof(tests[0]));
+  return failed ? 1 : 0;
+}


### PR DESCRIPTION
Repeated `unroll()` calls leave expired weak references in children's parents maps, retaining memory after parent destruction

Remove the dying parent's entry from each child before clearing children

Add regression tests. All pass, and 10,000 repeated `unroll()` calls retain zero allocation blocks after the fix, compared with 20,000 before

Fixes #1431
